### PR TITLE
Fix Mesh.CreateCube incorrect indices

### DIFF
--- a/Prowl.Runtime/Resources/Mesh.cs
+++ b/Prowl.Runtime/Resources/Mesh.cs
@@ -467,12 +467,12 @@ namespace Prowl.Runtime
 
             uint[] indices =
             {
-                0, 1, 2, 0, 2, 3,       // Front face
-                4, 6, 5, 4, 7, 6,       // Back face
-                8, 9, 10, 8, 10, 11,    // Left face
-                12, 14, 13, 12, 15, 14, // Right face
-                16, 17, 18, 16, 18, 19, // Top face
-                20, 22, 21, 20, 23, 22  // Bottom face
+                1, 2, 0, 0, 2, 3,       // Front face
+                5, 4, 6, 6, 4, 7,       // Back face
+                9, 8, 10, 10, 8, 11,    // Left face
+                13, 12, 14, 14, 12, 15, // Right face
+                17, 18, 16, 16, 18, 19, // Top face
+                21, 22, 20, 20, 22, 23  // Bottom face
             };
 
             mesh.vertices = vertices;


### PR DESCRIPTION
Previously the left and bottom face of a cube created with `Mesh.CreateCube()` were inverted, since the indices were defined in a CCW winding order.