### PR TITLE
fix: update ImageSharp to avoid known vulnerability

### DIFF
--- a/Prowl.Editor/Prowl.Editor.csproj
+++ b/Prowl.Editor/Prowl.Editor.csproj
@@ -46,10 +46,10 @@
     <ItemGroup>
         <PackageReference Include="AssimpNet" Version="5.0.0-beta1" />
         <PackageReference Include="DirectXShaderCompiler.NET" Version="1.1.0" />
-        <PackageReference Include="NuGet.Protocol" Version="6.10.1" />
-        <PackageReference Include="NuGet.Resolver" Version="6.10.1" />
-        <PackageReference Include="NuGet.Versioning" Version="6.10.1" />
-        <PackageReference Include="SixLabors.ImageSharp" Version="2.1.3" />
+        <PackageReference Include="NuGet.Protocol" Version="6.11.0" />
+        <PackageReference Include="NuGet.Resolver" Version="6.11.0" />
+        <PackageReference Include="NuGet.Versioning" Version="6.11.0" />
+        <PackageReference Include="SixLabors.ImageSharp" Version="3.1.5" />
         <PackageReference Include="SixLabors.ImageSharp.Textures" Version="0.0.0-alpha.0.140" />
         <PackageReference Include="SPIRV-Cross.NET" Version="1.0.1" />
     </ItemGroup>

--- a/Prowl.Runtime/Prowl.Runtime.csproj
+++ b/Prowl.Runtime/Prowl.Runtime.csproj
@@ -66,7 +66,7 @@
         <!-- <PackageReference Include="Jitter2" Version="2.2.0" /> -->
         <PackageReference Include="BepuPhysics" Version="2.5.0-beta.23" />
         <PackageReference Include="Silk.NET.OpenAL" Version="2.21.0" />
-        <PackageReference Include="Silk.NET.OpenAL.Soft.Native" Version="1.21.1.2" />
+        <PackageReference Include="Silk.NET.OpenAL.Soft.Native" Version="1.23.1" />
         <PackageReference Include="StbTrueTypeSharp" Version="1.26.12" />
     </ItemGroup>
 


### PR DESCRIPTION
#146 

Updated to the latest version (which jumps from 2.1.3 to 3.1.5). Also, update:

    NuGet.Protocol.* to 6.11.0
    Silk.NET.OpenAL.Soft.Native to 1.23.1
