### PR TITLE
Fix/build warnings

### DIFF
--- a/Prowl.Editor/Assets/AssetDatabase.Core.cs
+++ b/Prowl.Editor/Assets/AssetDatabase.Core.cs
@@ -443,7 +443,7 @@ namespace Prowl.Editor.Assets
                     asset = (T)serialized.SubAssets[fileID - 1];
                 }
                 asset.AssetID = assetGuid;
-                asset.FileID = (ushort)fileID;
+                asset.FileID = fileID;
                 return asset;
             }
             catch (Exception e)

--- a/Prowl.Editor/Assets/AssetDatabase.Core.cs
+++ b/Prowl.Editor/Assets/AssetDatabase.Core.cs
@@ -34,8 +34,8 @@ namespace Prowl.Editor.Assets
         #region Private Fields
 
         static readonly List<(DirectoryInfo, AssetDirectoryCache)> rootFolders = [];
-        static double RefreshTimer = 0f;
-        static bool lastFocused = false;
+        static double RefreshTimer;
+        static bool lastFocused;
         static readonly Dictionary<string, MetaFile> assetPathToMeta = new(StringComparer.OrdinalIgnoreCase);
         static readonly Dictionary<Guid, MetaFile> assetGuidToMeta = [];
         static readonly Dictionary<Guid, SerializedAsset> guidToAssetData = [];

--- a/Prowl.Editor/Assets/AssetDatabase.Core.cs
+++ b/Prowl.Editor/Assets/AssetDatabase.Core.cs
@@ -79,7 +79,7 @@ namespace Prowl.Editor.Assets
         /// <param name="rootFolder">The path to the root folder.</param>
         public static void AddRootFolder(string rootFolder)
         {
-            ArgumentNullException.ThrowIfNullOrEmpty(rootFolder);
+            ArgumentException.ThrowIfNullOrEmpty(rootFolder);
 
             var rootPath = Path.Combine(Project.Active.ProjectPath, rootFolder);
             var info = new DirectoryInfo(rootPath);
@@ -212,7 +212,7 @@ namespace Prowl.Editor.Assets
         /// <returns>True if a reimport is needed</returns>
         static bool ProcessFile(string file, out bool metaOutdated)
         {
-            ArgumentNullException.ThrowIfNullOrEmpty(file);
+            ArgumentException.ThrowIfNullOrEmpty(file);
             var fileInfo = new FileInfo(file);
             metaOutdated = false;
 

--- a/Prowl.Editor/Assets/AssetDatabase.FileOperations.cs
+++ b/Prowl.Editor/Assets/AssetDatabase.FileOperations.cs
@@ -77,7 +77,7 @@ namespace Prowl.Editor.Assets
         public static bool Rename(FileInfo file, string newName)
         {
             ArgumentNullException.ThrowIfNull(file);
-            ArgumentNullException.ThrowIfNullOrEmpty(newName);
+            ArgumentException.ThrowIfNullOrEmpty(newName);
             if (!File.Exists(file.FullName)) return false;
 
             if (file.Extension.Equals(".meta", StringComparison.OrdinalIgnoreCase)) return false;
@@ -106,7 +106,7 @@ namespace Prowl.Editor.Assets
         public static bool Rename(DirectoryInfo source, string newName)
         {
             ArgumentNullException.ThrowIfNull(source);
-            ArgumentNullException.ThrowIfNullOrEmpty(newName);
+            ArgumentException.ThrowIfNullOrEmpty(newName);
             if (!Directory.Exists(source.FullName)) return false;
 
             var newFile = new FileInfo(Path.Combine(source.Parent!.FullName, newName));

--- a/Prowl.Editor/Assets/AssetDatabase.Packages.cs
+++ b/Prowl.Editor/Assets/AssetDatabase.Packages.cs
@@ -99,7 +99,7 @@ namespace Prowl.Editor.Assets
                 count++;
                 if (count % 10 == 0 || count >= maxCount - 5)
                 {
-                    float percentComplete = ((float)count / (float)maxCount) * 100f;
+                    float percentComplete = (count / (float)maxCount) * 100f;
                     Debug.Log($"Exporting Assets To Stream: {count}/{maxCount} - {percentComplete}%");
                 }
             }

--- a/Prowl.Editor/Assets/AssetDatabase.Packages.cs
+++ b/Prowl.Editor/Assets/AssetDatabase.Packages.cs
@@ -188,7 +188,7 @@ namespace Prowl.Editor.Assets
                     string[] nodes = line.Split('=');
                     if (nodes.Length != 2)
                     {
-                        Runtime.Debug.LogError($"Invalid Package: {line}");
+                        Debug.LogError($"Invalid Package: {line}");
                         continue;
                     }
 
@@ -199,14 +199,14 @@ namespace Prowl.Editor.Assets
             // Validate Packages
             foreach (var pair in DesiredPackages)
             {
-                var dependency = (await AssetDatabase.GetPackageMetadata(pair.Key, Project.Active.PackagesDirectory.FullName, PackageManagerPreferences.Instance.IncludePrerelease))
+                var dependency = (await GetPackageMetadata(pair.Key, Project.Active.PackagesDirectory.FullName, PackageManagerPreferences.Instance.IncludePrerelease))
                     .Where(x => x.Identity.Version.ToString() == pair.Value).FirstOrDefault();
                 if (dependency == null)
                 {
                     // The package is not installed, Lets try to install it
                     try
                     {
-                        await AssetDatabase.InstallPackage(pair.Key, pair.Value);
+                        await InstallPackage(pair.Key, pair.Value);
                     }
                     catch (Exception ex)
                     {

--- a/Prowl.Editor/Assets/AssetDatabase.Utilities.cs
+++ b/Prowl.Editor/Assets/AssetDatabase.Utilities.cs
@@ -224,7 +224,7 @@ namespace Prowl.Editor.Assets
                 var types = meta.assetTypes;
                 if (names.Length != types.Length)
                 {
-                    Runtime.Debug.LogWarning($"Meta file {meta.guid} has mismatched names and types at path {AssetDatabase.GetRelativePath(meta.AssetPath.FullName)}");
+                    Runtime.Debug.LogWarning($"Meta file {meta.guid} has mismatched names and types at path {GetRelativePath(meta.AssetPath.FullName)}");
                     continue;
                 }
                 for (ushort i = 0; i < types.Length; i++)

--- a/Prowl.Editor/Assets/AssetDatabase.Utilities.cs
+++ b/Prowl.Editor/Assets/AssetDatabase.Utilities.cs
@@ -163,7 +163,7 @@ namespace Prowl.Editor.Assets
 
         public static HashSet<Guid> AllThatDependOn(Guid dependsOn)
         {
-            HashSet<Guid> result = new();
+            HashSet<Guid> result = [];
             // Go over all stored meta files and return any that depend on the specified GUID
             foreach (var meta in assetGuidToMeta.Values)
             {
@@ -217,7 +217,7 @@ namespace Prowl.Editor.Assets
         public static List<(string name, Guid assetID, ushort fileID)> GetAllAssetsOfType(Type type)
         {
             // Go over all loaded meta files and check the Importers type
-            List<(string, Guid, ushort)> result = new();
+            List<(string, Guid, ushort)> result = [];
             foreach (var meta in assetGuidToMeta.Values)
             {
                 var names = meta.assetNames;
@@ -268,7 +268,7 @@ namespace Prowl.Editor.Assets
                 }
                 return result;
             }
-            return Array.Empty<SubAssetCache>();
+            return [];
         }
 
         #endregion

--- a/Prowl.Editor/Assets/AssetDirectoryCache.cs
+++ b/Prowl.Editor/Assets/AssetDirectoryCache.cs
@@ -56,23 +56,23 @@ namespace Prowl.Editor.Assets
                 if (string.IsNullOrEmpty(part))
                     continue;
 
-                DirNode nextNode = node.SubDirectories.Find(n => n.Directory.Name.Equals(part, StringComparison.OrdinalIgnoreCase));
+                DirNode nextNode = node.SubDirectories.Find(n =>
+                    n.Directory.Name.Equals(part, StringComparison.OrdinalIgnoreCase));
                 if (nextNode is null)
                     return false;
 
                 node = nextNode;
             }
+
             return true;
         }
 
         static bool IsPathInsideDirectory(string path, DirectoryInfo directoryInfo, out string relativePath)
         {
             relativePath = string.Empty;
-            if (string.IsNullOrEmpty(path))
-                throw new ArgumentNullException(nameof(path), "Path cannot be null or empty.");
+            ArgumentException.ThrowIfNullOrEmpty(path, "Path cannot be null or empty.");
 
-            if (directoryInfo == null)
-                throw new ArgumentNullException(nameof(directoryInfo), "DirectoryInfo cannot be null.");
+            ArgumentNullException.ThrowIfNull(nameof(directoryInfo), "DirectoryInfo cannot be null.");
 
             // Get the absolute paths
             string directoryFullPath = Path.GetFullPath(directoryInfo.FullName);

--- a/Prowl.Editor/Assets/AssetDirectoryCache.cs
+++ b/Prowl.Editor/Assets/AssetDirectoryCache.cs
@@ -40,7 +40,7 @@ namespace Prowl.Editor.Assets
 
 
         private DirNode _rootNode;
-        private DirectoryInfo _rootDir = root;
+        private readonly DirectoryInfo _rootDir = root;
 
         public bool PathToNode(string path, out DirNode node)
         {

--- a/Prowl.Editor/Assets/AssetDirectoryCache.cs
+++ b/Prowl.Editor/Assets/AssetDirectoryCache.cs
@@ -24,7 +24,7 @@ namespace Prowl.Editor.Assets
                 File = file;
 
                 AssetID = Guid.Empty;
-                SubAssets = Array.Empty<AssetDatabase.SubAssetCache>();
+                SubAssets = [];
                 if (AssetDatabase.TryGetGuid(file, out var guid))
                 {
                     AssetID = guid;

--- a/Prowl.Editor/Assets/ImporterAttribute.cs
+++ b/Prowl.Editor/Assets/ImporterAttribute.cs
@@ -11,7 +11,7 @@ namespace Prowl.Editor.Assets
     public class ImporterAttribute : Attribute
     {
         public string[] Extensions { get; private set; }
-        public string FileIcon { get; private set; } = "FileIcon.png";
+        public string FileIcon { get; private set; }
         public Type GeneralType { get; private set; }
         public ImporterAttribute(string fileIcon, Type generalType, params string[] extensions)
         {

--- a/Prowl.Editor/Assets/Importers/FontImporter.cs
+++ b/Prowl.Editor/Assets/Importers/FontImporter.cs
@@ -12,7 +12,7 @@ namespace Prowl.Editor.Assets
     [Importer("FileIcon.png", typeof(Font), ".ttf")]
     public class FontImporter : ScriptedImporter
     {
-        public List<Font.CharacterRange> characterRanges = new() { Font.CharacterRange.BasicLatin };
+        public List<Font.CharacterRange> characterRanges = [Font.CharacterRange.BasicLatin];
         public float fontSize = 20;
         public int width = 1024;
         public int height = 1024;

--- a/Prowl.Editor/Assets/Importers/FontImporter.cs
+++ b/Prowl.Editor/Assets/Importers/FontImporter.cs
@@ -28,7 +28,7 @@ namespace Prowl.Editor.Assets
     public class FontEditor : ScriptedEditor
     {
         static int start, end;
-        private int numberOfProperties = 0;
+        private readonly int numberOfProperties = 0;
         public void InputFloat(string name, ref float val)
         {
             double ItemSize = EditorStylePrefs.Instance.ItemSize;
@@ -71,7 +71,7 @@ namespace Prowl.Editor.Assets
             }
         }
 
-        public bool QuickButton(string label, LayoutNode popupHolder)
+        public bool QuickButton(string label, LayoutNode? popupHolder)
         {
             double ItemSize = EditorStylePrefs.Instance.ItemSize;
 

--- a/Prowl.Editor/Assets/Importers/ModelImporter.cs
+++ b/Prowl.Editor/Assets/Importers/ModelImporter.cs
@@ -634,10 +634,10 @@ namespace Prowl.Editor.Assets
 
         class MeshMaterialBinding
         {
-            private string meshName;
-            private AssetRef<Mesh> mesh;
-            private Assimp.Mesh aMesh;
-            private AssetRef<Material> material;
+            private readonly string meshName;
+            private readonly AssetRef<Mesh> mesh;
+            private readonly Assimp.Mesh aMesh;
+            private readonly AssetRef<Material> material;
 
             private MeshMaterialBinding() { }
             public MeshMaterialBinding(string meshName, Assimp.Mesh aMesh, AssetRef<Mesh> mesh, AssetRef<Material> material)

--- a/Prowl.Editor/Assets/Importers/ModelImporter.cs
+++ b/Prowl.Editor/Assets/Importers/ModelImporter.cs
@@ -21,7 +21,7 @@ namespace Prowl.Editor.Assets
     [Importer("ModelIcon.png", typeof(GameObject), ".obj", ".blend", ".dae", ".fbx", ".gltf", ".ply", ".pmx", ".stl")]
     public class ModelImporter : ScriptedImporter
     {
-        public static readonly string[] Supported = { ".obj", ".blend", ".dae", ".fbx", ".gltf", ".ply", ".pmx", ".stl" };
+        public static readonly string[] Supported = [".obj", ".blend", ".dae", ".fbx", ".gltf", ".ply", ".pmx", ".stl"];
 
         public bool GenerateColliders;
         public bool GenerateNormals = true;
@@ -133,7 +133,7 @@ namespace Prowl.Editor.Assets
                 //    }
                 //}
 
-                List<AssetRef<Material>> mats = new();
+                List<AssetRef<Material>> mats = [];
                 if (scene.HasMaterials)
                     LoadMaterials(ctx, scene, parentDir, mats);
 
@@ -142,7 +142,7 @@ namespace Prowl.Editor.Assets
                 if (scene.HasAnimations)
                     anims = LoadAnimations(ctx, scene, scale);
 
-                List<MeshMaterialBinding> meshMats = new List<MeshMaterialBinding>();
+                List<MeshMaterialBinding> meshMats = [];
                 if (scene.HasMeshes)
                     LoadMeshes(ctx, assetPath, scene, scale, mats, meshMats);
 

--- a/Prowl.Editor/Assets/Importers/ModelImporter.cs
+++ b/Prowl.Editor/Assets/Importers/ModelImporter.cs
@@ -484,14 +484,14 @@ namespace Prowl.Editor.Assets
 
                 foreach (var channel in anim.NodeAnimationChannels)
                 {
-                    Assimp.Node boneNode = scene.RootNode.FindNode(channel.NodeName);
+                    Node boneNode = scene.RootNode.FindNode(channel.NodeName);
 
                     var animBone = new AnimBone();
                     animBone.BoneName = boneNode.Name;
 
                     // construct full path from RootNode to this bone
                     // RootNode -> Parent -> Parent -> ... -> Parent -> Bone
-                    Assimp.Node target = boneNode;
+                    Node target = boneNode;
                     string path = target.Name;
                     //while (target.Parent != null)
                     //{
@@ -671,7 +671,7 @@ namespace Prowl.Editor.Assets
             var importer = (ModelImporter)(target as MetaFile).importer;
             var serialized = AssetDatabase.LoadAsset((target as MetaFile).AssetPath);
 
-            gui.CurrentNode.Layout(Runtime.GUI.LayoutType.Column);
+            gui.CurrentNode.Layout(LayoutType.Column);
             gui.CurrentNode.ScaleChildren();
 
             using (gui.Node("Tabs").Width(Size.Percentage(1f)).MaxHeight(ItemSize).Layout(LayoutType.Row).ScaleChildren().Enter())

--- a/Prowl.Editor/Assets/Importers/ModelImporter.cs
+++ b/Prowl.Editor/Assets/Importers/ModelImporter.cs
@@ -23,19 +23,19 @@ namespace Prowl.Editor.Assets
     {
         public static readonly string[] Supported = { ".obj", ".blend", ".dae", ".fbx", ".gltf", ".ply", ".pmx", ".stl" };
 
-        public bool GenerateColliders = false;
+        public bool GenerateColliders;
         public bool GenerateNormals = true;
-        public bool GenerateSmoothNormals = false;
+        public bool GenerateSmoothNormals;
         public bool CalculateTangentSpace = true;
         public bool MakeLeftHanded = true;
-        public bool FlipUVs = false;
-        public bool CullEmpty = false;
-        public bool OptimizeGraph = false;
-        public bool OptimizeMeshes = false;
-        public bool FlipWindingOrder = false;
-        public bool WeldVertices = false;
-        public bool InvertNormals = false;
-        public bool GlobalScale = false;
+        public bool FlipUVs;
+        public bool CullEmpty;
+        public bool OptimizeGraph;
+        public bool OptimizeMeshes;
+        public bool FlipWindingOrder;
+        public bool WeldVertices;
+        public bool InvertNormals;
+        public bool GlobalScale;
 
         public float UnitScale = 1.0f;
 
@@ -659,10 +659,10 @@ namespace Prowl.Editor.Assets
     public class ModelEditor : ScriptedEditor
     {
 
-        int selectedAnim = 0;
-        int selectedAnimBone = 0;
+        int selectedAnim;
+        int selectedAnimBone;
 
-        int selectedTab = 0;
+        int selectedTab;
 
         public override void OnInspectorGUI()
         {

--- a/Prowl.Editor/Assets/Importers/ShaderImporter.cs
+++ b/Prowl.Editor/Assets/Importers/ShaderImporter.cs
@@ -12,7 +12,7 @@ namespace Prowl.Editor.Assets
     {
         private static Shader s_internalError;
 
-        public static readonly string[] Supported = { ".shader" };
+        public static readonly string[] Supported = [".shader"];
 
         public override void Import(SerializedAsset ctx, FileInfo assetPath)
         {

--- a/Prowl.Editor/Assets/Importers/TextureImporter.cs
+++ b/Prowl.Editor/Assets/Importers/TextureImporter.cs
@@ -10,7 +10,8 @@ namespace Prowl.Editor.Assets
     [Importer("FileIcon.png", typeof(Texture2D), ".png", ".bmp", ".jpg", ".jpeg", ".tga", ".dds", ".pbm", ".webp", ".tif", ".tiff")]
     public class TextureImporter : ScriptedImporter
     {
-        public static readonly string[] Supported = { ".png", ".bmp", ".jpg", ".jpeg", ".tga", ".dds", ".pbm", ".webp", ".tif", ".tiff" };
+        public static readonly string[] Supported = [".png", ".bmp", ".jpg", ".jpeg", ".tga", ".dds", ".pbm", ".webp", ".tif", ".tiff"
+        ];
 
         public bool generateMipmaps = true;
 

--- a/Prowl.Editor/Assets/MetaFile.cs
+++ b/Prowl.Editor/Assets/MetaFile.cs
@@ -32,10 +32,10 @@ namespace Prowl.Editor.Assets
             if (importerType == null)
                 return;
 
-            this.AssetPath = assetFile;
-            this.guid = Guid.NewGuid();
-            this.lastModified = assetFile.LastWriteTimeUtc;
-            this.importer = Activator.CreateInstance(importerType) as ScriptedImporter;
+            AssetPath = assetFile;
+            guid = Guid.NewGuid();
+            lastModified = assetFile.LastWriteTimeUtc;
+            importer = Activator.CreateInstance(importerType) as ScriptedImporter;
         }
 
         /// <summary>Save the MetaFile to a specified file or default to the associated asset file with a ".meta" extension.</summary>

--- a/Prowl.Editor/Build/Desktop_Player.cs
+++ b/Prowl.Editor/Build/Desktop_Player.cs
@@ -64,7 +64,7 @@ namespace Prowl.Editor.Build
             }
             else
             {
-                HashSet<Guid> assets = new();
+                HashSet<Guid> assets = [];
                 foreach (var scene in scenes)
                     AssetDatabase.GetDependenciesDeep(scene.AssetID, ref assets);
 
@@ -102,7 +102,7 @@ namespace Prowl.Editor.Build
 
                         // Invoke the CopyTo method
                         string? test = BuildDataPath;
-                        copyTo.Invoke(null, new object[] { test });
+                        copyTo.Invoke(null, [test]);
                     }
 
 

--- a/Prowl.Editor/Build/Desktop_Player.cs
+++ b/Prowl.Editor/Build/Desktop_Player.cs
@@ -96,7 +96,7 @@ namespace Prowl.Editor.Build
                         MethodInfo copyTo = type.BaseType.GetMethod("CopyTo", BindingFlags.Static | BindingFlags.NonPublic);
                         if (copyTo is null)
                         {
-                            Runtime.Debug.LogError($"Failed to find CopyTo method for {type.Name}");
+                            Debug.LogError($"Failed to find CopyTo method for {type.Name}");
                             continue;
                         }
 
@@ -128,8 +128,8 @@ namespace Prowl.Editor.Build
             if (target != Target.Universal)
                 CleanupRuntimes(output);
 
-            Runtime.Debug.Log("**********************************************************************************************************************");
-            Runtime.Debug.Log($"Successfully built project!");
+            Debug.Log("**********************************************************************************************************************");
+            Debug.Log($"Successfully built project!");
 
             // Open the Build folder
             AssetDatabase.OpenPath(output);

--- a/Prowl.Editor/Build/ProjectBuilder.cs
+++ b/Prowl.Editor/Build/ProjectBuilder.cs
@@ -31,7 +31,7 @@ namespace Prowl.Editor.Build
             {
                 Build(scenes, output);
             }
-            catch (System.Exception e)
+            catch (Exception e)
             {
                 Debug.LogError($"Failed to build project: {e.Message}");
             }

--- a/Prowl.Editor/Editor/AssetSelectorWindow.cs
+++ b/Prowl.Editor/Editor/AssetSelectorWindow.cs
@@ -12,8 +12,8 @@ namespace Prowl.Editor
     public class AssetSelectorWindow : EditorWindow
     {
         private string _searchText = "";
-        private Type type;
-        private Action<Guid, ushort> _onAssetSelected;
+        private readonly Type type;
+        private readonly Action<Guid, ushort> _onAssetSelected;
 
         protected override bool Center { get; } = true;
         protected override double Width { get; } = 512;

--- a/Prowl.Editor/Editor/AssetsBrowserWindow.cs
+++ b/Prowl.Editor/Editor/AssetsBrowserWindow.cs
@@ -310,7 +310,7 @@ namespace Prowl.Editor
 
                 if (subAssets.Length > 1)
                 {
-                    expanded = gui.GetNodeStorage<bool>(gui.CurrentNode.Parent, entry.File.FullName, false);
+                    expanded = gui.GetNodeStorage(gui.CurrentNode.Parent, entry.File.FullName, false);
 
                     using (gui.Node("ExpandBtn").TopLeft(Offset.Percentage(1f, -(itemHeight * 0.5)), 2).Scale(itemHeight * 0.5).Enter())
                     {

--- a/Prowl.Editor/Editor/AssetsBrowserWindow.cs
+++ b/Prowl.Editor/Editor/AssetsBrowserWindow.cs
@@ -15,7 +15,7 @@ namespace Prowl.Editor
     public class AssetsBrowserWindow : EditorWindow
     {
         public AssetDirectoryCache.DirNode CurDirectoryNode;
-        public bool Locked = false;
+        public bool Locked;
 
         double itemHeight => EditorStylePrefs.Instance.ItemSize;
         double itemPadding => 4;
@@ -24,11 +24,11 @@ namespace Prowl.Editor
         private readonly List<FileInfo> _found = new();
         private readonly Dictionary<string, AssetRef<Texture2D>> _cachedThumbnails = new();
         private static (long, bool) _lastGenerated = (-1, false);
-        internal static string? RenamingEntry = null;
-        private static bool justStartedRename = false;
+        internal static string? RenamingEntry;
+        private static bool justStartedRename;
 
         private const float PingDuration = 3f;
-        private float _pingTimer = 0;
+        private float _pingTimer;
         private FileInfo _pingedFile;
 
         private float EntrySize => (1.0f + AssetPipelinePreferences.Instance.ThumbnailSize) * 90f;

--- a/Prowl.Editor/Editor/AssetsTreeWindow.cs
+++ b/Prowl.Editor/Editor/AssetsTreeWindow.cs
@@ -571,7 +571,7 @@ namespace Prowl.Editor
             if (entryNode.AssetID != Guid.Empty && interact.IsHovered() && Gui.ActiveGUI.IsPointerDoubleClick(MouseButton.Left))
             {
                 if (entry.Extension.Equals(".scene", StringComparison.OrdinalIgnoreCase))
-                    SceneManager.LoadScene(new AssetRef<Runtime.Scene>(entryNode.AssetID));
+                    SceneManager.LoadScene(new AssetRef<Scene>(entryNode.AssetID));
                 else
                     AssetDatabase.OpenPath(entry);
             }

--- a/Prowl.Editor/Editor/AssetsTreeWindow.cs
+++ b/Prowl.Editor/Editor/AssetsTreeWindow.cs
@@ -285,7 +285,7 @@ namespace Prowl.Editor
                         AssetDatabase.Move(dir, target);
                 }
 
-                expanded = gui.GetNodeStorage<bool>(root.RootDirectoryPath, defaultOpen);
+                expanded = gui.GetNodeStorage(root.RootDirectoryPath, defaultOpen);
                 using (gui.Node("ExpandBtn").TopLeft(5, 0).Scale(EditorStylePrefs.Instance.ItemSize).Enter())
                 {
                     if (gui.IsNodePressed())
@@ -362,7 +362,7 @@ namespace Prowl.Editor
                         }
                     }
 
-                    expanded = gui.GetNodeStorage<bool>(gui.CurrentNode.Parent, subDirectory.FullName, false);
+                    expanded = gui.GetNodeStorage(gui.CurrentNode.Parent, subDirectory.FullName, false);
                     using (gui.Node("ExpandBtn").TopLeft(5, 0).Scale(EditorStylePrefs.Instance.ItemSize).Enter())
                     {
                         if (gui.IsNodePressed())
@@ -442,7 +442,7 @@ namespace Prowl.Editor
 
                     if (subFileNode.SubAssets.Length > 1)
                     {
-                        expanded = gui.GetNodeStorage<bool>(gui.CurrentNode.Parent, subFile.FullName, false);
+                        expanded = gui.GetNodeStorage(gui.CurrentNode.Parent, subFile.FullName, false);
                         using (gui.Node("ExpandBtn").TopLeft(Offset.Percentage(1f, -EditorStylePrefs.Instance.ItemSize), 0).Scale(EditorStylePrefs.Instance.ItemSize).Enter())
                         {
                             if (gui.IsNodePressed())

--- a/Prowl.Editor/Editor/AssetsTreeWindow.cs
+++ b/Prowl.Editor/Editor/AssetsTreeWindow.cs
@@ -19,10 +19,10 @@ namespace Prowl.Editor
         private readonly List<FileInfo> _found = new();
 
         public readonly static SelectHandler<FileSystemInfo> SelectHandler = new((item) => !item.Exists, (a, b) => a.FullName.Equals(b.FullName, StringComparison.OrdinalIgnoreCase));
-        internal static string? RenamingEntry = null;
+        internal static string? RenamingEntry;
 
-        private int _treeCounter = 0;
-        private static bool justStartedRename = false;
+        private int _treeCounter;
+        private static bool justStartedRename;
 
         public AssetsTreeWindow() : base()
         {

--- a/Prowl.Editor/Editor/BuildWindow.cs
+++ b/Prowl.Editor/Editor/BuildWindow.cs
@@ -22,7 +22,7 @@ namespace Prowl.Editor
         protected override bool LockSize => true;
         protected override double Padding => 0;
 
-        private List<ProjectBuilder> builders = new List<ProjectBuilder>();
+        private readonly List<ProjectBuilder> builders = new List<ProjectBuilder>();
         private int selectedBuilder;
         private string buildName = "";
 

--- a/Prowl.Editor/Editor/BuildWindow.cs
+++ b/Prowl.Editor/Editor/BuildWindow.cs
@@ -23,7 +23,7 @@ namespace Prowl.Editor
         protected override double Padding => 0;
 
         private List<ProjectBuilder> builders = new List<ProjectBuilder>();
-        private int selectedBuilder = 0;
+        private int selectedBuilder;
         private string buildName = "";
 
         public BuildWindow() : base()

--- a/Prowl.Editor/Editor/ConsoleWindow.cs
+++ b/Prowl.Editor/Editor/ConsoleWindow.cs
@@ -1,14 +1,11 @@
 ﻿// This file is part of the Prowl Game Engine
 // Licensed under the MIT License. See the LICENSE file in the project root for details.
 
-using System.Diagnostics;
-
 using Prowl.Editor.Preferences;
 using Prowl.Icons;
 using Prowl.Runtime;
 using Prowl.Runtime.GUI;
 
-using Vector4F = System.Numerics.Vector4;
 using Debug = Prowl.Runtime.Debug;
 using Prowl.Editor.Assets;
 

--- a/Prowl.Editor/Editor/Docking/DockContainer.cs
+++ b/Prowl.Editor/Editor/Docking/DockContainer.cs
@@ -232,7 +232,7 @@ namespace Prowl.Editor.Docking
             return inside;
         }
 
-        public DockNode AttachWindow(EditorWindow window, DockNode leaf, DockZone zone, double splitDistance = 0.5f)
+        public DockNode? AttachWindow(EditorWindow window, DockNode leaf, DockZone zone, double splitDistance = 0.5f)
         {
             if (window == null)
                 return null;
@@ -303,7 +303,7 @@ namespace Prowl.Editor.Docking
             return DetachWindow(window.Leaf, index) != null;
         }
 
-        public EditorWindow DetachWindow(DockNode leaf, int index)
+        public EditorWindow? DetachWindow(DockNode leaf, int index)
         {
             // Expect leaf node
             if (leaf.Type != DockNode.NodeType.Leaf)
@@ -350,7 +350,7 @@ namespace Prowl.Editor.Docking
             return windowList;
         }
 
-        public DockNode FindParent(DockNode node)
+        public DockNode? FindParent(DockNode node)
         {
             if (node == Root)
                 return null;

--- a/Prowl.Editor/Editor/Docking/DockContainer.cs
+++ b/Prowl.Editor/Editor/Docking/DockContainer.cs
@@ -49,7 +49,7 @@ namespace Prowl.Editor.Docking
             Rect right = new Rect(cen + new Vector2(size.x + 5, 0), size);
             Rect top = new Rect(cen - new Vector2(0, size.y + 5), size);
             Rect bottom = new Rect(cen + new Vector2(0, size.y + 5), size);
-            possibleAreas = new List<Rect> { main, left, right, top, bottom };
+            possibleAreas = [main, left, right, top, bottom];
 
             DockPlacement placement = new DockPlacement();
             placement.Leaf = leaf;
@@ -345,7 +345,7 @@ namespace Prowl.Editor.Docking
 
         public List<EditorWindow> GetWindows()
         {
-            List<EditorWindow> windowList = new List<EditorWindow>();
+            List<EditorWindow> windowList = [];
             Root.GetWindows(windowList);
             return windowList;
         }

--- a/Prowl.Editor/Editor/Docking/DockNode.cs
+++ b/Prowl.Editor/Editor/Docking/DockNode.cs
@@ -43,7 +43,7 @@ namespace Prowl.Editor.Docking
         public Vector2 Maxs { get; set; }
         public double SplitDistance { get; set; } = 0.5f;
 
-        public DockNode TraceLeaf(double x, double y)
+        public DockNode? TraceLeaf(double x, double y)
         {
             if (Rect.CreateFromMinMax(Mins, Maxs).Contains(new Vector2(x, y)))
             {
@@ -61,7 +61,7 @@ namespace Prowl.Editor.Docking
             return null;
         }
 
-        public DockNode TraceSeparator(double x, double y)
+        public DockNode? TraceSeparator(double x, double y)
         {
             if (Type == NodeType.Leaf)
             {

--- a/Prowl.Editor/Editor/Docking/DockNode.cs
+++ b/Prowl.Editor/Editor/Docking/DockNode.cs
@@ -115,7 +115,7 @@ namespace Prowl.Editor.Docking
 
             if (Type == NodeType.SplitVertical)
             {
-                double d = (double)Math.Floor(SplitDistance * w);
+                double d = Math.Floor(SplitDistance * w);
 
                 // Left
                 Child[0].UpdateRecursive(x, y, d, h);
@@ -127,7 +127,7 @@ namespace Prowl.Editor.Docking
 
             if (Type == NodeType.SplitHorizontal)
             {
-                double d = (double)Math.Floor(SplitDistance * h);
+                double d = Math.Floor(SplitDistance * h);
 
                 // Top
                 Child[0].UpdateRecursive(x, y, w, d);

--- a/Prowl.Editor/Editor/DragnDrop.cs
+++ b/Prowl.Editor/Editor/DragnDrop.cs
@@ -33,7 +33,7 @@ namespace Prowl.Editor
         public static bool Peek(out object? payload, Type type, string tag = "")
         {
             if (Gui.ActiveGUI.PreviousInteractable == null)
-                throw new System.Exception("No Previous Interactable");
+                throw new Exception("No Previous Interactable");
 
             payload = default;
             if (draggedObject == null) return false;
@@ -67,7 +67,7 @@ namespace Prowl.Editor
         public static bool Drop(out object? payload, Type type, string tag = "")
         {
             if (Gui.ActiveGUI.PreviousInteractable == null)
-                throw new System.Exception("No Previous Interactable");
+                throw new Exception("No Previous Interactable");
 
             payload = default;
             if (draggedObject == null) return false;
@@ -109,7 +109,7 @@ namespace Prowl.Editor
         public static bool Drag(string tag = "", params object[] objs)
         {
             if (Gui.ActiveGUI.PreviousInteractable == null)
-                throw new System.Exception("No Previous Interactable");
+                throw new Exception("No Previous Interactable");
 
             if (OnBeginDrag(out var node))
             {
@@ -130,7 +130,7 @@ namespace Prowl.Editor
         public static bool OnBeginDrag(out LayoutNode? node)
         {
             if (Gui.ActiveGUI.PreviousInteractable == null)
-                throw new System.Exception("No Previous Interactable");
+                throw new Exception("No Previous Interactable");
 
             if (Gui.ActiveGUI.DragDrop_Source(out node))
                 return true;

--- a/Prowl.Editor/Editor/EditorGUI.cs
+++ b/Prowl.Editor/Editor/EditorGUI.cs
@@ -372,7 +372,7 @@ namespace Prowl.Editor
                         break;
 
                     case GuiAttribType.Separator:
-                        EditorGUI.Separator(1, id.GetHashCode());
+                        Separator(1, id.GetHashCode());
                         break;
 
                 }

--- a/Prowl.Editor/Editor/EditorWindow.cs
+++ b/Prowl.Editor/Editor/EditorWindow.cs
@@ -29,7 +29,7 @@ namespace Prowl.Editor
 
         private double _width, _height;
         public double _x, _y;
-        private bool _wasDragged = false;
+        private bool _wasDragged;
 
 
         public bool bAllowTabs = true;
@@ -260,7 +260,7 @@ namespace Prowl.Editor
             MaxZ = gui.GetCurrentInteractableZLayer();
         }
 
-        private bool _wasResizing = false;
+        private bool _wasResizing;
         private void HandleResize()
         {
             using (gui.Node("ResizeTab").TopLeft(Offset.Percentage(1f, -15)).Scale(15).IgnoreLayout().Enter())

--- a/Prowl.Editor/Editor/EditorWindow.cs
+++ b/Prowl.Editor/Editor/EditorWindow.cs
@@ -25,7 +25,7 @@ namespace Prowl.Editor
         protected virtual double Padding { get; } = 8;
 
         protected bool isOpened = true;
-        protected Runtime.GUI.Gui gui => Runtime.GUI.Gui.ActiveGUI;
+        protected Gui gui => Gui.ActiveGUI;
 
         private double _width, _height;
         public double _x, _y;
@@ -76,7 +76,7 @@ namespace Prowl.Editor
             }
             catch (Exception e)
             {
-                Runtime.Debug.LogError("Error in UpdateWindow: " + e.Message + "\n" + e.StackTrace);
+                Debug.LogError("Error in UpdateWindow: " + e.Message + "\n" + e.StackTrace);
             }
 
             try
@@ -254,7 +254,7 @@ namespace Prowl.Editor
             }
             catch (Exception e)
             {
-                Runtime.Debug.LogError("Error in EditorWindow: " + e.Message + "\n" + e.StackTrace);
+                Debug.LogError("Error in EditorWindow: " + e.Message + "\n" + e.StackTrace);
             }
 
             MaxZ = gui.GetCurrentInteractableZLayer();

--- a/Prowl.Editor/Editor/GameViewInputHandler.cs
+++ b/Prowl.Editor/Editor/GameViewInputHandler.cs
@@ -9,7 +9,7 @@ namespace Prowl.Runtime;
 
 public class GameViewInputHandler : DefaultInputHandler
 {
-    private GameWindow _window;
+    private readonly GameWindow _window;
     public bool HasFocus => GameWindow.LastFocused.Target == _window;
 
 

--- a/Prowl.Editor/Editor/GameWindow.cs
+++ b/Prowl.Editor/Editor/GameWindow.cs
@@ -35,7 +35,7 @@ public class GameWindow : EditorWindow
 
     RenderTexture RenderTarget;
     bool previouslyPlaying = false;
-    bool hasFrame = false;
+    bool hasFrame;
 
     public static WeakReference LastFocused;
     public static Vector2 FocusedPosition;

--- a/Prowl.Editor/Editor/GameWindow.cs
+++ b/Prowl.Editor/Editor/GameWindow.cs
@@ -90,7 +90,7 @@ public class GameWindow : EditorWindow
             bool changed = false;
 
             PropertyGridConfig config = PropertyGridConfig.NoLabel;
-            if (EditorGUI.DrawProperty(0, "Width", ref GeneralPreferences.Instance.CurrentWidth, config))
+            if (DrawProperty(0, "Width", ref GeneralPreferences.Instance.CurrentWidth, config))
             {
                 GeneralPreferences.Instance.CurrentWidth = Math.Clamp(GeneralPreferences.Instance.CurrentWidth, 1, 7680);
                 GeneralPreferences.Instance.Resolution = Resolutions.custom;
@@ -98,7 +98,7 @@ public class GameWindow : EditorWindow
                 RefreshRenderTexture();
             }
             gui.PreviousNode.Width(50);
-            if (EditorGUI.DrawProperty(1, "Height", ref GeneralPreferences.Instance.CurrentHeight, config))
+            if (DrawProperty(1, "Height", ref GeneralPreferences.Instance.CurrentHeight, config))
             {
                 GeneralPreferences.Instance.CurrentHeight = Math.Clamp(GeneralPreferences.Instance.CurrentHeight, 1, 4320);
                 GeneralPreferences.Instance.Resolution = Resolutions.custom;
@@ -107,7 +107,7 @@ public class GameWindow : EditorWindow
             }
             gui.PreviousNode.Width(50);
 
-            if (EditorGUI.DrawProperty(2, "Resolution", ref GeneralPreferences.Instance.Resolution, config))
+            if (DrawProperty(2, "Resolution", ref GeneralPreferences.Instance.Resolution, config))
             {
                 UpdateResolution(GeneralPreferences.Instance.Resolution);
                 changed = true;

--- a/Prowl.Editor/Editor/HierarchyWindow.cs
+++ b/Prowl.Editor/Editor/HierarchyWindow.cs
@@ -17,13 +17,13 @@ namespace Prowl.Editor
         const double entryPadding = 4;
 
         private string _searchText = "";
-        private GameObject? m_RenamingGO = null;
+        private GameObject? m_RenamingGO;
         public static SelectHandler<WeakReference> SelectHandler { get; private set; } = new((item) => !item.IsAlive || (item.Target is EngineObject eObj && eObj.IsDestroyed), (a, b) => ReferenceEquals(a.Target, b.Target));
 
         private const float PingDuration = 3f;
-        private static float pingTimer = 0;
+        private static float pingTimer;
         private static WeakReference pingedGO;
-        private bool justStartedRename = false;
+        private bool justStartedRename;
 
         public HierarchyWindow() : base()
         {

--- a/Prowl.Editor/Editor/InspectorWindow.cs
+++ b/Prowl.Editor/Editor/InspectorWindow.cs
@@ -57,10 +57,10 @@ namespace Prowl.Editor
         {
             double ItemSize = EditorStylePrefs.Instance.ItemSize;
 
-            gui.CurrentNode.Layout(Runtime.GUI.LayoutType.Column);
+            gui.CurrentNode.Layout(LayoutType.Column);
             gui.CurrentNode.ScaleChildren();
 
-            using (gui.Node("Header").ExpandWidth().MaxHeight(ItemSize).Layout(Runtime.GUI.LayoutType.Row).Padding(0, 10, 10, 10).Enter())
+            using (gui.Node("Header").ExpandWidth().MaxHeight(ItemSize).Layout(LayoutType.Row).Padding(0, 10, 10, 10).Enter())
             {
                 ForwardBackButtons();
 

--- a/Prowl.Editor/Editor/InspectorWindow.cs
+++ b/Prowl.Editor/Editor/InspectorWindow.cs
@@ -17,8 +17,8 @@ namespace Prowl.Editor
         private Stack<object> _BackStack = new();
         private Stack<object> _ForwardStack = new();
 
-        private object? Selected = null;
-        private bool lockSelection = false;
+        private object? Selected;
+        private bool lockSelection;
 
         (object, ScriptedEditor)? customEditor;
 

--- a/Prowl.Editor/Editor/InspectorWindow.cs
+++ b/Prowl.Editor/Editor/InspectorWindow.cs
@@ -14,8 +14,8 @@ namespace Prowl.Editor
     public class InspectorWindow : EditorWindow
     {
 
-        private Stack<object> _BackStack = new();
-        private Stack<object> _ForwardStack = new();
+        private readonly Stack<object> _BackStack = new();
+        private readonly Stack<object> _ForwardStack = new();
 
         private object? Selected;
         private bool lockSelection;

--- a/Prowl.Editor/Editor/NodeEditor/NodeEditor.cs
+++ b/Prowl.Editor/Editor/NodeEditor/NodeEditor.cs
@@ -147,7 +147,7 @@ namespace Prowl.Editor
                     using (g.Node("Fields").ExpandWidth().FitContentHeight().Layout(LayoutType.Column).Padding(5).Enter())
                     {
                         // Draw Fields
-                        List<MemberInfo> members = new();
+                        List<MemberInfo> members = [];
                         foreach (var field in node.GetSerializableFields())
                         {
                             if (field.GetCustomAttribute<InputAttribute>(true) != null) continue;
@@ -574,7 +574,7 @@ namespace Prowl.Editor
         private RenderTexture RenderTarget;
 
         internal NodePort? draggingPort;
-        internal List<Vector2> reroutePoints = new();
+        internal List<Vector2> reroutePoints = [];
 
         internal Vector2? dragSelectionStart;
         internal Rect dragSelection;
@@ -750,7 +750,7 @@ namespace Prowl.Editor
         {
             int index = 0;
             var safeNodes = graph.nodes.ToArray();
-            List<int> unusedKeys = new(customEditors.Keys);
+            List<int> unusedKeys = [..customEditors.Keys];
             foreach (var node in safeNodes)
             {
                 var key = node.GetHashCode();
@@ -1234,7 +1234,7 @@ namespace Prowl.Editor
             public string Name;
             public Type Type;
             public MethodInfo Method;
-            public List<NodeMenuItemInfo> Children = new();
+            public List<NodeMenuItemInfo> Children = [];
 
             public NodeMenuItemInfo() { }
 

--- a/Prowl.Editor/Editor/NodeEditor/NodeEditor.cs
+++ b/Prowl.Editor/Editor/NodeEditor/NodeEditor.cs
@@ -65,7 +65,7 @@ namespace Prowl.Editor
         protected NodeGraph nodegraph;
         protected SelectHandler<WeakReference> SelectHandler;
 
-        public void SetGraph(NodeGraph graph) => this.nodegraph = graph;
+        public void SetGraph(NodeGraph graph) => nodegraph = graph;
         public void SetEditor(NodeEditor editor) => this.editor = editor;
         public void SetSelectHandler(SelectHandler<WeakReference> handler) => SelectHandler = handler;
 

--- a/Prowl.Editor/Editor/NodeEditor/NodeEditor.cs
+++ b/Prowl.Editor/Editor/NodeEditor/NodeEditor.cs
@@ -904,7 +904,7 @@ namespace Prowl.Editor
                                 draw++;
                                 if (draw >= 2) draw = -2;
                                 if (draw < 0) continue;
-                                if (draw == 0) bezierPrevious = CalculateBezierPoint(point_a, tangent_a, tangent_b, point_b, (j - 1f) / (float)division);
+                                if (draw == 0) bezierPrevious = CalculateBezierPoint(point_a, tangent_a, tangent_b, point_b, (j - 1f) / division);
                             }
                             Vector2 bezierNext = CalculateBezierPoint(point_a, tangent_a, tangent_b, point_b, j / (float)division);
                             gui.Draw2D.DrawLine(bezierPrevious, bezierNext, color, thickness);

--- a/Prowl.Editor/Editor/NodeEditor/NodeEditor.cs
+++ b/Prowl.Editor/Editor/NodeEditor/NodeEditor.cs
@@ -478,8 +478,8 @@ namespace Prowl.Editor
     [NodeEditor(typeof(CommentNode))]
     public class CommentNodeEditor : DefaultNodeEditor
     {
-        private bool isRenamingHeader = false;
-        private bool isRenamingDesc = false;
+        private bool isRenamingHeader;
+        private bool isRenamingDesc;
 
         public override bool DrawNode(int index, Gui g, Node node)
         {
@@ -569,14 +569,14 @@ namespace Prowl.Editor
         private Vector2 topleft;
         private double zoom = 1.0f;
         private double targetzoom = 1.0f;
-        private bool hasChanged = false;
+        private bool hasChanged;
 
         private RenderTexture RenderTarget;
 
-        internal NodePort? draggingPort = null;
+        internal NodePort? draggingPort;
         internal List<Vector2> reroutePoints = new();
 
-        internal Vector2? dragSelectionStart = null;
+        internal Vector2? dragSelectionStart;
         internal Rect dragSelection;
 
         private string _searchText = string.Empty;

--- a/Prowl.Editor/Editor/NodeEditor/NodeEditor.cs
+++ b/Prowl.Editor/Editor/NodeEditor/NodeEditor.cs
@@ -562,9 +562,9 @@ namespace Prowl.Editor
         public bool IsDragging => draggingPort != null || dragSelectionStart != null;
         public bool IsDraggingPort => draggingPort != null;
 
-        private NodeGraph graph;
-        private NodeEditorInputHandler inputHandler;
-        private Gui gui;
+        private readonly NodeGraph graph;
+        private readonly NodeEditorInputHandler inputHandler;
+        private readonly Gui gui;
 
         private Vector2 topleft;
         private double zoom = 1.0f;
@@ -582,7 +582,7 @@ namespace Prowl.Editor
         private string _searchText = string.Empty;
         private static NodeMenuItemInfo rootMenuItem;
 
-        private SelectHandler<WeakReference> SelectHandler = new((item) => !item.IsAlive, (a, b) => ReferenceEquals(a.Target, b.Target));
+        private readonly SelectHandler<WeakReference> SelectHandler = new((item) => !item.IsAlive, (a, b) => ReferenceEquals(a.Target, b.Target));
 
         private readonly Dictionary<int, ScriptedNodeEditor> customEditors = [];
 
@@ -1233,8 +1233,8 @@ namespace Prowl.Editor
         {
             public string Name;
             public Type Type;
-            public MethodInfo Method;
-            public List<NodeMenuItemInfo> Children = [];
+            public readonly MethodInfo Method;
+            public readonly List<NodeMenuItemInfo> Children = [];
 
             public NodeMenuItemInfo() { }
 

--- a/Prowl.Editor/Editor/PackageManager.cs
+++ b/Prowl.Editor/Editor/PackageManager.cs
@@ -38,7 +38,7 @@ namespace Prowl.Editor
         List<(string, string)> package_Dependencies;
         IPackageSearchMetadata? _metadata;
 
-        List<(IPackageSearchMetadata, Texture2D?)> PackageEntries = [];
+        readonly List<(IPackageSearchMetadata, Texture2D?)> PackageEntries = [];
 
         string _searchText;
 

--- a/Prowl.Editor/Editor/PackageManager.cs
+++ b/Prowl.Editor/Editor/PackageManager.cs
@@ -26,13 +26,13 @@ namespace Prowl.Editor
         private (string, string) _currentSource;
 
         // Selected Package
-        bool _showProjectDetails = false;
+        bool _showProjectDetails;
         string[] _projectVersions = [];
-        int _selectedVersionIndex = 0;
+        int _selectedVersionIndex;
         List<IPackageSearchMetadata> _selectedPackageMetaData = [];
 
-        byte loadingPackageEntries = 0;
-        bool loadingDetails = false;
+        byte loadingPackageEntries;
+        bool loadingDetails;
         string package_Title, package_Authors, package_Description, package_Downloads, package_Version, package_PublishDate, package_ProjectURL, package_LicenseURL;
         Texture2D? package_Icon;
         List<(string, string)> package_Dependencies;

--- a/Prowl.Editor/Editor/PackageManager.cs
+++ b/Prowl.Editor/Editor/PackageManager.cs
@@ -324,7 +324,7 @@ namespace Prowl.Editor
                 MemoryStream ms = new MemoryStream(bytes);
                 return Texture2DLoader.FromStream(ms);
             }
-            catch (Exception e)
+            catch (Exception)
             {
                 return null;
             }

--- a/Prowl.Editor/Editor/Preferences/GeneralPreferences.cs
+++ b/Prowl.Editor/Editor/Preferences/GeneralPreferences.cs
@@ -107,7 +107,7 @@ namespace Prowl.Editor.Preferences
         public static Color RandomPastel(Type type, float alpha = 1f, float pastelStrength = 0.5f)
         {
             System.Random random = new System.Random(type.GetHashCode());
-            Color pastel = Color.FromHSV((float)random.Next(0, 360), pastelStrength, 0.75f, alpha);
+            Color pastel = Color.FromHSV(random.Next(0, 360), pastelStrength, 0.75f, alpha);
             return pastel;
             // var inverted = 1.0f - pastelStrength;
             // float r = (float)(random.NextDouble() * inverted + pastelStrength);

--- a/Prowl.Editor/Editor/Preferences/GeneralPreferences.cs
+++ b/Prowl.Editor/Editor/Preferences/GeneralPreferences.cs
@@ -109,11 +109,11 @@ namespace Prowl.Editor.Preferences
             System.Random random = new System.Random(type.GetHashCode());
             Color pastel = Color.FromHSV((float)random.Next(0, 360), pastelStrength, 0.75f, alpha);
             return pastel;
-            var inverted = 1.0f - pastelStrength;
-            float r = (float)(random.NextDouble() * inverted + pastelStrength);
-            float g = (float)(random.NextDouble() * inverted + pastelStrength);
-            float b = (float)(random.NextDouble() * inverted + pastelStrength);
-            return new Color(r, g, b, alpha);
+            // var inverted = 1.0f - pastelStrength;
+            // float r = (float)(random.NextDouble() * inverted + pastelStrength);
+            // float g = (float)(random.NextDouble() * inverted + pastelStrength);
+            // float b = (float)(random.NextDouble() * inverted + pastelStrength);
+            // return new Color(r, g, b, alpha);
         }
 
         public static Color RandomPastelColor(int seed, float alpha = 1f)

--- a/Prowl.Editor/Editor/ProjectSettingsWindow.cs
+++ b/Prowl.Editor/Editor/ProjectSettingsWindow.cs
@@ -77,7 +77,7 @@ public abstract class SingletonEditorWindow : EditorWindow
 
     public abstract void RenderSideView();
 
-    private int elementCounter = 0;
+    private int elementCounter;
     protected void RenderSideViewElement<T>(T elementInstance)
     {
         Type settingType = elementInstance.GetType();

--- a/Prowl.Editor/Editor/ProjectSettingsWindow.cs
+++ b/Prowl.Editor/Editor/ProjectSettingsWindow.cs
@@ -110,7 +110,7 @@ public abstract class SingletonEditorWindow : EditorWindow
         object setting = currentSingleton;
 
         string name = currentType.Name.Replace("Preferences", "");
-        if (PropertyGrid(name, ref setting, TargetFields.Serializable | EditorGUI.TargetFields.Properties, PropertyGridConfig.NoBorder | PropertyGridConfig.NoBackground))
+        if (PropertyGrid(name, ref setting, TargetFields.Serializable | TargetFields.Properties, PropertyGridConfig.NoBorder | PropertyGridConfig.NoBackground))
         {
             // Use reflection to find a method "protected void Save()" and OnValidate
             MethodInfo? validateMethod = setting.GetType().GetMethod("OnValidate", BindingFlags.Instance | BindingFlags.Public | BindingFlags.DeclaredOnly);

--- a/Prowl.Editor/Editor/ProjectsWindow.cs
+++ b/Prowl.Editor/Editor/ProjectsWindow.cs
@@ -10,15 +10,15 @@ namespace Prowl.Editor
 {
     public class ProjectsWindow : EditorWindow
     {
-        public Project? SelectedProject = null;
+        public Project? SelectedProject;
 
         private string _searchText = "";
 
         private string _createName = "";
 
         private (string, Action)[] _tabs;
-        private int _currentTab = 0;
-        private bool _createTabOpen = false;
+        private int _currentTab;
+        private bool _createTabOpen;
 
         private FileDialog _dialog;
         private FileDialogContext _dialogContext;

--- a/Prowl.Editor/Editor/ProjectsWindow.cs
+++ b/Prowl.Editor/Editor/ProjectsWindow.cs
@@ -16,7 +16,7 @@ namespace Prowl.Editor
 
         private string _createName = "";
 
-        private (string, Action)[] _tabs;
+        private readonly (string, Action)[] _tabs;
         private int _currentTab;
         private bool _createTabOpen;
 

--- a/Prowl.Editor/Editor/PropertyDrawer/Drawers/IAssetRef_PropertyDrawer.cs
+++ b/Prowl.Editor/Editor/PropertyDrawer/Drawers/IAssetRef_PropertyDrawer.cs
@@ -17,7 +17,7 @@ namespace Prowl.Editor.PropertyDrawers
         public override double MinWidth => 125;
         public static Guid assignedGUID;
         public static ushort assignedFileID;
-        public static ulong guidAssignedToID = 0;
+        public static ulong guidAssignedToID;
 
         public override bool OnValueGUI(Gui gui, string ID, Type targetType, ref object? targetValue)
         {

--- a/Prowl.Editor/Editor/PropertyDrawer/Drawers/PropertyDrawerEnumerable.cs
+++ b/Prowl.Editor/Editor/PropertyDrawer/Drawers/PropertyDrawerEnumerable.cs
@@ -67,7 +67,7 @@ namespace Prowl.Editor.PropertyDrawers
 
                 gui.TextNode("H_Text", RuntimeUtils.Prettify(label)).ExpandWidth().Height(EditorStylePrefs.Instance.ItemSize).IgnoreLayout();
 
-                bool enumexpanded = gui.GetNodeStorage<bool>("enumexpanded", false);
+                bool enumexpanded = gui.GetNodeStorage("enumexpanded", false);
                 using (gui.Node("EnumExpandBtn").TopLeft(5, 0).Scale(EditorStylePrefs.Instance.ItemSize).Enter())
                 {
                     if (gui.IsNodePressed())

--- a/Prowl.Editor/Editor/PropertyDrawer/Drawers/PropertyDrawerEnumerable.cs
+++ b/Prowl.Editor/Editor/PropertyDrawer/Drawers/PropertyDrawerEnumerable.cs
@@ -10,7 +10,7 @@ namespace Prowl.Editor.PropertyDrawers
 {
     public abstract class PropertyDrawerEnumerable<T> : PropertyDrawer where T : class
     {
-        public static ulong selectedDrawer = 0;
+        public static ulong selectedDrawer;
         public static int selectedElement = -1;
 
         private static int windowBG = 0;

--- a/Prowl.Editor/Editor/PropertyDrawer/PropertyDrawer.cs
+++ b/Prowl.Editor/Editor/PropertyDrawer/PropertyDrawer.cs
@@ -105,7 +105,7 @@ namespace Prowl.Editor.PropertyDrawers
 
                     gui.TextNode("H_Text", RuntimeUtils.Prettify(label)).ExpandWidth().Height(ItemSize).IgnoreLayout();
 
-                    bool enumexpanded = gui.GetNodeStorage<bool>("enumexpanded", false);
+                    bool enumexpanded = gui.GetNodeStorage("enumexpanded", false);
                     using (gui.Node("EnumExpandBtn").TopLeft(5, 0).Scale(ItemSize).Enter())
                     {
                         if (gui.IsNodePressed())

--- a/Prowl.Editor/Editor/PropertyDrawer/PropertyDrawer.cs
+++ b/Prowl.Editor/Editor/PropertyDrawer/PropertyDrawer.cs
@@ -17,9 +17,9 @@ namespace Prowl.Editor.PropertyDrawers
     {
         public Type TargetType { get; private set; } = type;
 
-        private static Dictionary<Type, PropertyDrawer> knownDrawers = [];
+        private static readonly Dictionary<Type, PropertyDrawer> knownDrawers = [];
 
-        private static Dictionary<Type, PropertyDrawer?> cachedDrawers = [];
+        private static readonly Dictionary<Type, PropertyDrawer?> cachedDrawers = [];
 
         private static List<Type> implementationTypes = [];
 

--- a/Prowl.Editor/Editor/SceneViewWindow.cs
+++ b/Prowl.Editor/Editor/SceneViewWindow.cs
@@ -16,7 +16,7 @@ public class SceneViewWindow : EditorWindow
     public static Camera LastFocusedCamera;
     private static bool LastFocusedCameraChanged;
 
-    Camera Cam;
+    readonly Camera Cam;
     Material gridMat;
     Mesh gridMesh;
     RenderTexture RenderTarget;
@@ -29,8 +29,8 @@ public class SceneViewWindow : EditorWindow
     bool hasStarted = false;
     double camX, camY;
 
-    TransformGizmo gizmo;
-    ViewManipulatorGizmo viewManipulator;
+    readonly TransformGizmo gizmo;
+    readonly ViewManipulatorGizmo viewManipulator;
 
     public enum GridType { None, XZ, XY, YZ }
 

--- a/Prowl.Editor/Editor/SceneViewWindow.cs
+++ b/Prowl.Editor/Editor/SceneViewWindow.cs
@@ -22,9 +22,9 @@ public class SceneViewWindow : EditorWindow
     RenderTexture RenderTarget;
     Vector2 WindowCenter;
     Vector2 mouseUV;
-    int frames = 0;
-    double fpsTimer = 0;
-    double fps = 0;
+    int frames;
+    double fpsTimer;
+    double fps;
     double moveSpeed = 1;
     bool hasStarted = false;
     double camX, camY;

--- a/Prowl.Editor/Editor/SceneViewWindow.cs
+++ b/Prowl.Editor/Editor/SceneViewWindow.cs
@@ -406,7 +406,7 @@ public class SceneViewWindow : EditorWindow
 
     private void HandleDragnDrop()
     {
-        if (DragnDrop.Drop<GameObject>(out GameObject? original))
+        if (DragnDrop.Drop(out GameObject? original))
         {
             if (original.AssetID == Guid.Empty) return;
 
@@ -422,7 +422,7 @@ public class SceneViewWindow : EditorWindow
             }
             HierarchyWindow.SelectHandler.SetSelection(new WeakReference(go));
         }
-        else if (DragnDrop.Drop<Prefab>(out Prefab? prefab))
+        else if (DragnDrop.Drop(out Prefab? prefab))
         {
             GameObject go = prefab.Instantiate();
             GameObject t = go;
@@ -438,11 +438,11 @@ public class SceneViewWindow : EditorWindow
 
             HierarchyWindow.SelectHandler.SetSelection(new WeakReference(go));
         }
-        else if (DragnDrop.Drop<Scene>(out Scene? scene))
+        else if (DragnDrop.Drop(out Scene? scene))
         {
             SceneManager.LoadScene(scene);
         }
-        else if (DragnDrop.Drop<Material>(out Material? material))
+        else if (DragnDrop.Drop(out Material? material))
         {
             SceneRaycaster.MeshHitInfo hit = SceneRaycaster.Raycast(Cam.ScreenPointToRay(mouseUV, new Vector2(RenderTarget.Width, RenderTarget.Height)));
 

--- a/Prowl.Editor/Editor/ScriptedEditors/GameObjectEditor.cs
+++ b/Prowl.Editor/Editor/ScriptedEditors/GameObjectEditor.cs
@@ -25,7 +25,7 @@ namespace Prowl.Editor.EditorWindows.CustomEditors
     {
         private string _searchText = string.Empty;
         private static MenuItemInfo rootMenuItem;
-        private Dictionary<int, ScriptedEditor> compEditors = new();
+        private readonly Dictionary<int, ScriptedEditor> compEditors = new();
 
         [OnAssemblyUnload]
         public static void ClearCache() => rootMenuItem = null;
@@ -523,7 +523,7 @@ namespace Prowl.Editor.EditorWindows.CustomEditors
         {
             public string Name;
             public Type Type;
-            public List<MenuItemInfo> Children = new();
+            public readonly List<MenuItemInfo> Children = new();
 
             public MenuItemInfo() { }
 

--- a/Prowl.Editor/Editor/ScriptedEditors/GameObjectEditor.cs
+++ b/Prowl.Editor/Editor/ScriptedEditors/GameObjectEditor.cs
@@ -45,18 +45,18 @@ namespace Prowl.Editor.EditorWindows.CustomEditors
                 gui.Draw2D.DrawText("This GameObject is not editable", gui.CurrentNode.LayoutData.InnerRect);
 
             bool isEnabled = go.enabled;
-            if (gui.Checkbox("IsEnabledChk", ref isEnabled, 0, 0, out _, EditorGUI.GetInputStyle()))
+            if (gui.Checkbox("IsEnabledChk", ref isEnabled, 0, 0, out _, GetInputStyle()))
                 go.enabled = isEnabled;
             gui.Tooltip("Is Enabled");
 
-            Gui.WidgetStyle style = EditorGUI.GetInputStyle();
+            WidgetStyle style = GetInputStyle();
             style.Roundness = 8f;
             style.BorderThickness = 1f;
             string name = go.Name;
             if (gui.InputField("NameInput", ref name, 32, InputFieldFlags.None, ItemSize, 0, Size.Percentage(1f, -(ItemSize * 3)), ItemSize, style))
                 go.Name = name.Trim();
 
-            var invisStyle = EditorGUI.GetInputStyle() with { BGColor = new Color(0, 0, 0, 0), BorderColor = new Color(0, 0, 0, 0) };
+            var invisStyle = GetInputStyle() with { BGColor = new Color(0, 0, 0, 0), BorderColor = new Color(0, 0, 0, 0) };
             int tagIndex = go.tagIndex;
             gui.Combo("#_TagID", "#_TagPopupID", ref tagIndex, TagLayerManager.Instance.tags.ToArray(), Offset.Percentage(1f, -(ItemSize * 2)), 0, ItemSize, ItemSize, invisStyle, FontAwesome6.Tag);
             go.tagIndex = (byte)tagIndex;
@@ -155,21 +155,21 @@ namespace Prowl.Editor.EditorWindows.CustomEditors
                         using (ActiveGUI.Node("PosParent", 0).ExpandWidth().Height(ItemSize).Layout(LayoutType.Row).ScaleChildren().Enter())
                         {
                             var tpos = t.localPosition;
-                            if (EditorGUI.DrawProperty(0, "Position", ref tpos))
+                            if (DrawProperty(0, "Position", ref tpos))
                                 t.localPosition = tpos;
                         }
 
                         using (ActiveGUI.Node("RotParent", 0).ExpandWidth().Height(ItemSize).Layout(LayoutType.Row).ScaleChildren().Enter())
                         {
                             var tpos = t.localEulerAngles;
-                            if (EditorGUI.DrawProperty(1, "Rotation", ref tpos))
+                            if (DrawProperty(1, "Rotation", ref tpos))
                                 t.localEulerAngles = tpos;
                         }
 
                         using (ActiveGUI.Node("ScaleParent", 0).ExpandWidth().Height(ItemSize).Layout(LayoutType.Row).ScaleChildren().Enter())
                         {
                             var tpos = t.localScale;
-                            if (EditorGUI.DrawProperty(2, "Scale", ref tpos))
+                            if (DrawProperty(2, "Scale", ref tpos))
                                 t.localScale = tpos;
                         }
                     }
@@ -216,7 +216,7 @@ namespace Prowl.Editor.EditorWindows.CustomEditors
                         gui.Draw2D.DrawText(cname, 23, gui.CurrentNode.LayoutData.GlobalContentPosition + new Vector2(28, centerY + 2));
 
                         isEnabled = comp.Enabled;
-                        if (gui.Checkbox("IsEnabledChk", ref isEnabled, Offset.Percentage(1f, -30), 0, out var chkNode, EditorGUI.GetInputStyle()))
+                        if (gui.Checkbox("IsEnabledChk", ref isEnabled, Offset.Percentage(1f, -30), 0, out var chkNode, GetInputStyle()))
                             comp.Enabled = isEnabled;
                         gui.Tooltip("Is Component Enabled?");
 
@@ -272,7 +272,7 @@ namespace Prowl.Editor.EditorWindows.CustomEditors
 
                             // No Editor, Fallback to default Inspector
                             object compRef = comp;
-                            if (EditorGUI.PropertyGrid("CompPropertyGrid", ref compRef, TargetFields.Serializable | EditorGUI.TargetFields.Properties, PropertyGridConfig.NoHeader | PropertyGridConfig.NoBorder | PropertyGridConfig.NoBackground))
+                            if (PropertyGrid("CompPropertyGrid", ref compRef, TargetFields.Serializable | TargetFields.Properties, PropertyGridConfig.NoHeader | PropertyGridConfig.NoBorder | PropertyGridConfig.NoBackground))
                                 comp.OnValidate();
 
                             // Draw any Buttons - these should be in PropertyGrid probably
@@ -309,7 +309,7 @@ namespace Prowl.Editor.EditorWindows.CustomEditors
                         {
                             gui.Search("##searchBox", ref _searchText, 0, 0, Size.Percentage(1f));
 
-                            EditorGUI.Separator();
+                            Separator();
 
                             rootMenuItem ??= GetAddComponentMenuItems();
                             DrawMenuItems(rootMenuItem, go);
@@ -354,7 +354,7 @@ namespace Prowl.Editor.EditorWindows.CustomEditors
         private static void HandleComponentContextMenu(GameObject? go, MonoBehaviour comp, LayoutNode popupHolder, ref List<MonoBehaviour> toDelete)
         {
             bool closePopup = false;
-            if (EditorGUI.StyledButton("Duplicate"))
+            if (StyledButton("Duplicate"))
             {
                 var serialized = Serializer.Serialize(comp);
                 var copy = Serializer.Deserialize<MonoBehaviour>(serialized);
@@ -363,14 +363,14 @@ namespace Prowl.Editor.EditorWindows.CustomEditors
                 closePopup = true;
             }
 
-            if (EditorGUI.StyledButton("Delete"))
+            if (StyledButton("Delete"))
             {
                 toDelete.Add(comp);
                 closePopup = true;
             }
 
             if (closePopup)
-                Gui.ActiveGUI.ClosePopup(popupHolder);
+                ActiveGUI.ClosePopup(popupHolder);
         }
 
         private void DrawMenuItems(MenuItemInfo menuItem, GameObject go)
@@ -390,27 +390,27 @@ namespace Prowl.Editor.EditorWindows.CustomEditors
                 if (item.Type != null)
                 {
 
-                    if (EditorGUI.StyledButton(item.Name))
+                    if (StyledButton(item.Name))
                         go.AddComponent(item.Type).OnValidate();
 
                 }
                 else
                 {
 
-                    if (EditorGUI.StyledButton(item.Name))
-                        Gui.ActiveGUI.OpenPopup(item.Name + "Popup", Gui.ActiveGUI.PreviousNode.LayoutData.Rect.TopRight);
+                    if (StyledButton(item.Name))
+                        ActiveGUI.OpenPopup(item.Name + "Popup", ActiveGUI.PreviousNode.LayoutData.Rect.TopRight);
 
                     // Enter the Button's Node
-                    using (Gui.ActiveGUI.PreviousNode.Enter())
+                    using (ActiveGUI.PreviousNode.Enter())
                     {
                         // Draw a > to indicate a popup
-                        Rect rect = Gui.ActiveGUI.CurrentNode.LayoutData.Rect;
+                        Rect rect = ActiveGUI.CurrentNode.LayoutData.Rect;
                         rect.x = rect.x + rect.width - 25;
                         rect.width = 20;
-                        Gui.ActiveGUI.Draw2D.DrawText(FontAwesome6.ChevronRight, rect, Color.white);
+                        ActiveGUI.Draw2D.DrawText(FontAwesome6.ChevronRight, rect, Color.white);
                     }
 
-                    if (Gui.ActiveGUI.BeginPopup(item.Name + "Popup", out var node))
+                    if (ActiveGUI.BeginPopup(item.Name + "Popup", out var node))
                     {
                         double largestWidth = 0;
                         foreach (var child in item.Children)
@@ -433,7 +433,7 @@ namespace Prowl.Editor.EditorWindows.CustomEditors
             // is first and found no component and were searching, lets create a new script
             if (hasSearch && !foundName && menuItem == rootMenuItem)
             {
-                if (EditorGUI.StyledButton("Create Script " + _searchText))
+                if (StyledButton("Create Script " + _searchText))
                 {
                     FileInfo file = new FileInfo(Path.Combine(Project.Active!.AssetDirectory.FullName, $"/{_searchText}.cs"));
                     if (File.Exists(file.FullName))

--- a/Prowl.Editor/Editor/ScriptedEditors/ScriptableObjectEditor.cs
+++ b/Prowl.Editor/Editor/ScriptedEditors/ScriptableObjectEditor.cs
@@ -12,7 +12,7 @@ namespace Prowl.Editor.ScriptedEditors
     [CustomEditor(typeof(ScriptableObjectImporter))]
     public class ScriptableObjectEditor : ScriptedEditor
     {
-        ScriptableObject? scriptObject = null;
+        ScriptableObject? scriptObject;
 
         public override void OnInspectorGUI()
         {

--- a/Prowl.Editor/Editor/ScriptedEditors/ScriptableObjectEditor.cs
+++ b/Prowl.Editor/Editor/ScriptedEditors/ScriptableObjectEditor.cs
@@ -25,7 +25,7 @@ namespace Prowl.Editor.ScriptedEditors
                 scriptObject ??= Serializer.Deserialize<ScriptableObject>(StringTagConverter.ReadFromFile((target as MetaFile).AssetPath));
 
                 object t = scriptObject;
-                changed |= PropertyGrid("CompPropertyGrid", ref t, TargetFields.Serializable | EditorGUI.TargetFields.Properties, PropertyGridConfig.NoHeader | PropertyGridConfig.NoBorder | PropertyGridConfig.NoBackground);
+                changed |= PropertyGrid("CompPropertyGrid", ref t, TargetFields.Serializable | TargetFields.Properties, PropertyGridConfig.NoHeader | PropertyGridConfig.NoBorder | PropertyGridConfig.NoBackground);
 
                 // Draw any Buttons
                 //changed |= EditorGui.HandleAttributeButtons(scriptObject);
@@ -37,7 +37,7 @@ namespace Prowl.Editor.ScriptedEditors
                     AssetDatabase.Reimport((target as MetaFile).AssetPath);
                 }
             }
-            catch (System.Exception e)
+            catch (Exception e)
             {
                 double ItemSize = EditorStylePrefs.Instance.ItemSize;
                 gui.Node("DummyForText").ExpandWidth().Height(ItemSize * 10);

--- a/Prowl.Editor/Editor/Widgets/FileDialog.cs
+++ b/Prowl.Editor/Editor/Widgets/FileDialog.cs
@@ -61,7 +61,7 @@ namespace Prowl.Editor
 
         private FileDialogSortBy _sortBy = FileDialogSortBy.None;
 
-        private bool _sortDown = false;
+        private bool _sortDown;
         private Stack<DirectoryInfo> _backStack = new();
 
         protected override bool Center { get; } = true;
@@ -73,7 +73,7 @@ namespace Prowl.Editor
         protected override bool TitleBar => false;
 
         private string _path = "";
-        private bool _pastFirstFrame = false;
+        private bool _pastFirstFrame;
 
 
         public FileDialog(FileDialogContext dialogInfo) : base()

--- a/Prowl.Editor/Editor/Widgets/FileDialog.cs
+++ b/Prowl.Editor/Editor/Widgets/FileDialog.cs
@@ -62,7 +62,7 @@ namespace Prowl.Editor
         private FileDialogSortBy _sortBy = FileDialogSortBy.None;
 
         private bool _sortDown;
-        private Stack<DirectoryInfo> _backStack = new();
+        private readonly Stack<DirectoryInfo> _backStack = new();
 
         protected override bool Center { get; } = true;
         protected override double Width { get; } = 512 + (512 / 2);

--- a/Prowl.Editor/EditorGuiManager.cs
+++ b/Prowl.Editor/EditorGuiManager.cs
@@ -18,7 +18,7 @@ public static class EditorGuiManager
 {
     public static System.Numerics.Vector4 SelectedColor => new System.Numerics.Vector4(0.06f, 0.53f, 0.98f, 1.00f);
 
-    public static Runtime.GUI.Gui Gui;
+    public static Gui Gui;
     public static DockContainer Container;
     public static EditorWindow DraggingWindow;
     public static DockNode DragSplitter;

--- a/Prowl.Editor/EditorGuiManager.cs
+++ b/Prowl.Editor/EditorGuiManager.cs
@@ -19,13 +19,13 @@ public static class EditorGuiManager
     public static System.Numerics.Vector4 SelectedColor => new System.Numerics.Vector4(0.06f, 0.53f, 0.98f, 1.00f);
 
     public static Gui Gui;
-    public static DockContainer Container;
+    public static DockContainer? Container;
     public static EditorWindow DraggingWindow;
     public static DockNode DragSplitter;
     private static Vector2 m_DragPos;
     private static double m_StartSplitPos;
 
-    public static WeakReference FocusedWindow;
+    public static WeakReference? FocusedWindow;
 
     public static List<EditorWindow> Windows = [];
 
@@ -59,7 +59,7 @@ public static class EditorGuiManager
             WindowsToRemove.Add(editorWindow);
     }
 
-    public static DockNode DockWindowTo(EditorWindow window, DockNode? node, DockZone zone, double split = 0.5f)
+    public static DockNode? DockWindowTo(EditorWindow window, DockNode? node, DockZone zone, double split = 0.5f)
     {
         if (node != null)
             return Container.AttachWindow(window, node, zone, split);
@@ -77,7 +77,7 @@ public static class EditorGuiManager
 
         Rect screenRect = new Rect(0, 0, Graphics.TargetResolution.x, Graphics.TargetResolution.y);
 
-        Vector2 framebufferAndInputScale = new((float)Graphics.TargetResolution.x / Screen.Size.x, (float)Graphics.TargetResolution.y / (float)Screen.Size.y);
+        Vector2 framebufferAndInputScale = new((float)Graphics.TargetResolution.x / Screen.Size.x, Graphics.TargetResolution.y / (float)Screen.Size.y);
 
         Gui.PointerWheel = Input.MouseWheelDelta;
         double scale = EditorStylePrefs.Instance.Scale;
@@ -239,7 +239,7 @@ public static class EditorGuiManager
                         double w = DragSplitter.Maxs.x - DragSplitter.Mins.x;
                         double split = m_StartSplitPos + dragDelta.x;
                         split -= DragSplitter.Mins.x;
-                        split = (double)Math.Floor(split);
+                        split = Math.Floor(split);
                         split = Math.Clamp(split, minSize, w - minSize);
                         split /= w;
 
@@ -250,7 +250,7 @@ public static class EditorGuiManager
                         double h = DragSplitter.Maxs.y - DragSplitter.Mins.y;
                         double split = m_StartSplitPos + dragDelta.y;
                         split -= DragSplitter.Mins.y;
-                        split = (double)Math.Floor(split);
+                        split = Math.Floor(split);
                         split = Math.Clamp(split, minSize, h - minSize);
                         split /= h;
 

--- a/Prowl.Editor/EditorGuiManager.cs
+++ b/Prowl.Editor/EditorGuiManager.cs
@@ -29,7 +29,7 @@ public static class EditorGuiManager
 
     public static List<EditorWindow> Windows = [];
 
-    static List<EditorWindow> WindowsToRemove = [];
+    static readonly List<EditorWindow> WindowsToRemove = [];
 
     public static void Initialize()
     {

--- a/Prowl.Editor/Program.cs
+++ b/Prowl.Editor/Program.cs
@@ -17,7 +17,7 @@ public static class Program
     public static bool IsReloadingExternalAssemblies { get; private set; }
     public static void RegisterReloadOfExternalAssemblies() => IsReloadingExternalAssemblies = true;
 
-    private static bool CreatedDefaultWindows = false;
+    private static bool CreatedDefaultWindows;
     public static int Main(string[] args)
     {
         // set global Culture to invariant

--- a/Prowl.Editor/SelectHandler.cs
+++ b/Prowl.Editor/SelectHandler.cs
@@ -21,7 +21,7 @@ public static class GlobalSelectHandler
 /// <typeparam name="T">The Type you want to select, Must be of type 'Class'</typeparam>
 public class SelectHandler<T> where T : class
 {
-    bool selectedThisFrame = false;
+    bool selectedThisFrame;
     List<T> selected = new();
     SortedList<int, T> previousFrameSelectables;
     SortedList<int, T> selectables = new();

--- a/Prowl.Editor/SelectHandler.cs
+++ b/Prowl.Editor/SelectHandler.cs
@@ -22,7 +22,7 @@ public static class GlobalSelectHandler
 public class SelectHandler<T> where T : class
 {
     bool selectedThisFrame;
-    List<T> selected = new();
+    readonly List<T> selected = new();
     SortedList<int, T> previousFrameSelectables;
     SortedList<int, T> selectables = new();
     int lastSelectedIndex = -1;
@@ -34,8 +34,8 @@ public class SelectHandler<T> where T : class
     public event Action<T>? OnSelectObject;
     public event Action<T>? OnDeselectObject;
 
-    private Func<T, bool> CheckIsDestroyed;
-    private Func<T, T, bool> Equals;
+    private readonly Func<T, bool> CheckIsDestroyed;
+    private readonly Func<T, T, bool> Equals;
 
     public SelectHandler(Func<T, bool> checkIsDestroyed, Func<T, T, bool> equals)
     {

--- a/Prowl.Editor/Utilities/ShaderCompiler/FileIncluder.cs
+++ b/Prowl.Editor/Utilities/ShaderCompiler/FileIncluder.cs
@@ -10,10 +10,10 @@ public class FileIncluder
     public string SourceFile;
     public string SourceFilePath => Path.Join(_searchDirectories[0].FullName, SourceFile);
 
-    private string _relativeDirectory;
-    private int _qualifiedPrefixLength;
+    private readonly string _relativeDirectory;
+    private readonly int _qualifiedPrefixLength;
 
-    private DirectoryInfo[] _searchDirectories;
+    private readonly DirectoryInfo[] _searchDirectories;
 
 
     public FileIncluder(string sourceFile, DirectoryInfo[] searchDirectories)

--- a/Prowl.Editor/Utilities/ShaderCompiler/ShaderCompiler.cs
+++ b/Prowl.Editor/Utilities/ShaderCompiler/ShaderCompiler.cs
@@ -115,8 +115,8 @@ namespace Prowl.Editor.Utilities
 
         public static ShaderVariant[] GenerateVariants(ShaderCreationArgs args, FileIncluder includer, List<CompilationMessage> messages)
         {
-            List<KeyValuePair<string, HashSet<string>>> combinations = new(args.combinations);
-            List<ShaderVariant> variantList = new();
+            List<KeyValuePair<string, HashSet<string>>> combinations = [..args.combinations];
+            List<ShaderVariant> variantList = [];
             List<KeyValuePair<string, string>> combination = new(combinations.Count);
 
             using Context ctx = new Context();

--- a/Prowl.Editor/Utilities/ShaderCompiler/ShaderParser.cs
+++ b/Prowl.Editor/Utilities/ShaderCompiler/ShaderParser.cs
@@ -1,7 +1,6 @@
 ﻿// This file is part of the Prowl Game Engine
 // Licensed under the MIT License. See the LICENSE file in the project root for details.
 
-using System.Diagnostics;
 using System.Text;
 using System.Text.RegularExpressions;
 

--- a/Prowl.Editor/Utilities/ShaderCompiler/ShaderParser.cs
+++ b/Prowl.Editor/Utilities/ShaderCompiler/ShaderParser.cs
@@ -799,7 +799,7 @@ namespace Prowl.Editor.Utilities
         public ShaderPassDescription Description;
 
         public int ProgramStartLine;
-        public string? Program = null;
+        public string? Program;
     }
 
     public struct EntryPoint(ShaderStages stages, string name)

--- a/Prowl.Editor/Utilities/ShaderCompiler/ShaderParser.cs
+++ b/Prowl.Editor/Utilities/ShaderCompiler/ShaderParser.cs
@@ -74,7 +74,7 @@ namespace Prowl.Editor.Utilities
 
             List<ShaderProperty> properties = [];
             ParsedPass? globalDefaults = null;
-            List<ParsedPass> parsedPasses = new();
+            List<ParsedPass> parsedPasses = [];
 
             string? fallback = null;
 
@@ -168,7 +168,7 @@ namespace Prowl.Editor.Utilities
                 args.shaderModel = shaderModel ?? (6, 0);
                 args.sourceCode = sourceCode;
 
-                List<CompilationMessage> compilerMessages = new();
+                List<CompilationMessage> compilerMessages = [];
 
                 ShaderVariant[] variants = ShaderCompiler.GenerateVariants(args, includer, compilerMessages);
 
@@ -236,7 +236,7 @@ namespace Prowl.Editor.Utilities
 
         private static List<ShaderProperty> ParseProperties(Tokenizer<ShaderToken> tokenizer)
         {
-            List<ShaderProperty> properties = new();
+            List<ShaderProperty> properties = [];
 
             ExpectToken(tokenizer, ShaderToken.OpenCurlBrace);
 
@@ -613,7 +613,7 @@ namespace Prowl.Editor.Utilities
             {
                 string name = tokenizer.Token.ToString();
 
-                HashSet<string> values = new();
+                HashSet<string> values = [];
 
                 ExpectToken(tokenizer, ShaderToken.OpenSquareBrace);
 
@@ -629,7 +629,7 @@ namespace Prowl.Editor.Utilities
 
         private static bool ParseProgramInfo(string program, out EntryPoint[]? entrypoints, out (int, int)? shaderModel, out CompilationMessage? message)
         {
-            List<EntryPoint> entrypointsList = new();
+            List<EntryPoint> entrypointsList = [];
             entrypoints = null;
             shaderModel = null;
             message = null;
@@ -763,7 +763,7 @@ namespace Prowl.Editor.Utilities
             if (Enum.TryParse(text, true, out T value))
                 return value;
 
-            List<string> values = new(Enum.GetNames<T>());
+            List<string> values = [..Enum.GetNames<T>()];
             values.AddRange(extraValues);
 
             throw new ParseException($"Error parsing {fieldName}. Possible values: [{string.Join(", ", values)}]");

--- a/Prowl.Editor/Utilities/Texture2DLoader.cs
+++ b/Prowl.Editor/Utilities/Texture2DLoader.cs
@@ -53,8 +53,7 @@ namespace Prowl.Editor
         /// <typeparam name="TPixel">The pixel format to use.</typeparam>
         public static Texture2D FromImage<TPixel>(Image<TPixel> image, bool generateMipmaps = false) where TPixel : unmanaged, IPixel<TPixel>
         {
-            if (image == null)
-                throw new ArgumentNullException(nameof(image));
+            ArgumentNullException.ThrowIfNull(image);
 
             image.Mutate(x => x.Flip(FlipMode.Vertical));
 

--- a/Prowl.Editor/Utilities/Texture2DLoader.cs
+++ b/Prowl.Editor/Utilities/Texture2DLoader.cs
@@ -16,7 +16,7 @@ namespace Prowl.Editor
         #region ImageMagick integration
 
 
-        private static Dictionary<Type, PixelFormat> formatLookup = new()
+        private static readonly Dictionary<Type, PixelFormat> formatLookup = new()
         {
             { typeof(A8),               PixelFormat.R8_UNorm                },
             { typeof(Bgra32),           PixelFormat.B8_G8_R8_A8_UNorm       },

--- a/Prowl.Players/Prowl.Desktop/Program.cs
+++ b/Prowl.Players/Prowl.Desktop/Program.cs
@@ -34,10 +34,7 @@ internal class Program
             }
         };
 
-        Application.Update += () =>
-        {
-            SceneManager.Update();
-        };
+        Application.Update += SceneManager.Update;
 
         Application.Render += () =>
         {

--- a/Prowl.Players/Prowl.Desktop/StandaloneAssetProvider.cs
+++ b/Prowl.Players/Prowl.Desktop/StandaloneAssetProvider.cs
@@ -17,7 +17,7 @@ public class StandaloneAssetProvider : IAssetProvider
             assetBundles.Add(new AssetBundle(firstPackage.OpenRead(), ZipArchiveMode.Read));
             firstPackage = new FileInfo(Path.Combine(Program.Data.FullName, $"Data{packageIndex++}.prowl"));
         }
-        this.packages = assetBundles.ToArray();
+        packages = assetBundles.ToArray();
     }
 
     readonly Dictionary<Guid, SerializedAsset> _loaded = [];

--- a/Prowl.Players/Prowl.Desktop/StandaloneAssetProvider.cs
+++ b/Prowl.Players/Prowl.Desktop/StandaloneAssetProvider.cs
@@ -5,22 +5,22 @@ using Prowl.Runtime.Utils;
 
 public class StandaloneAssetProvider : IAssetProvider
 {
-    AssetBundle[] packages;
+    readonly AssetBundle[] packages;
 
     public StandaloneAssetProvider()
     {
         int packageIndex = 0;
         FileInfo firstPackage = new FileInfo(Path.Combine(Program.Data.FullName, $"Data{packageIndex++}.prowl"));
-        List<AssetBundle> packages = new();
+        List<AssetBundle> assetBundles = [];
         while (File.Exists(firstPackage.FullName))
         {
-            packages.Add(new AssetBundle(firstPackage.OpenRead(), ZipArchiveMode.Read));
+            assetBundles.Add(new AssetBundle(firstPackage.OpenRead(), ZipArchiveMode.Read));
             firstPackage = new FileInfo(Path.Combine(Program.Data.FullName, $"Data{packageIndex++}.prowl"));
         }
-        this.packages = packages.ToArray();
+        this.packages = assetBundles.ToArray();
     }
 
-    Dictionary<Guid, SerializedAsset> _loaded = [];
+    readonly Dictionary<Guid, SerializedAsset> _loaded = [];
 
     public bool HasAsset(Guid assetID) => _loaded.ContainsKey(assetID);
 

--- a/Prowl.Runtime/AnimationCurve.cs
+++ b/Prowl.Runtime/AnimationCurve.cs
@@ -449,8 +449,7 @@ namespace Prowl.Runtime
             get { return _keys[index]; }
             set
             {
-                if (value == null)
-                    throw new ArgumentNullException();
+                ArgumentNullException.ThrowIfNull(value);
 
                 if (index >= _keys.Count)
                     throw new IndexOutOfRangeException();
@@ -488,8 +487,7 @@ namespace Prowl.Runtime
         /// <remarks>The new key would be added respectively to a position of that key and the position of other keys.</remarks>
         public void Add(KeyFrame item)
         {
-            if (item == null)
-                throw new ArgumentNullException(nameof(item));
+            ArgumentNullException.ThrowIfNull(item);
 
             if (_keys.Count == 0)
             {

--- a/Prowl.Runtime/AnimationCurve.cs
+++ b/Prowl.Runtime/AnimationCurve.cs
@@ -59,7 +59,7 @@ namespace Prowl.Runtime
         /// </summary>
         public AnimationCurve()
         {
-            this.Keys =
+            Keys =
             [
                 new KeyFrame(0, 0),
                 new KeyFrame(1, 1)
@@ -94,7 +94,7 @@ namespace Prowl.Runtime
 
             if (position < first.Position)
             {
-                switch (this.PreLoop)
+                switch (PreLoop)
                 {
                     case CurveLoopType.Constant:
                         //constant
@@ -130,7 +130,7 @@ namespace Prowl.Runtime
             else if (position > last.Position)
             {
                 int cycle;
-                switch (this.PostLoop)
+                switch (PostLoop)
                 {
                     case CurveLoopType.Constant:
                         //constant
@@ -278,11 +278,11 @@ namespace Prowl.Runtime
         private double GetCurvePosition(double position)
         {
             //only for position in curve
-            KeyFrame prev = this.Keys[0];
+            KeyFrame prev = Keys[0];
             KeyFrame next;
-            for (int i = 1; i < this.Keys.Count; ++i)
+            for (int i = 1; i < Keys.Count; ++i)
             {
-                next = this.Keys[i];
+                next = Keys[i];
                 if (next.Position >= position)
                 {
                     if (prev.Continuity == CurveContinuity.Step)
@@ -311,11 +311,11 @@ namespace Prowl.Runtime
         public SerializedProperty Serialize(Serializer.SerializationContext ctx)
         {
             var value = SerializedProperty.NewCompound();
-            value.Add("PreLoop", new SerializedProperty((int)this.PreLoop));
-            value.Add("PostLoop", new SerializedProperty((int)this.PostLoop));
+            value.Add("PreLoop", new SerializedProperty((int)PreLoop));
+            value.Add("PostLoop", new SerializedProperty((int)PostLoop));
 
             var keyList = SerializedProperty.NewList();
-            foreach (var key in this.Keys)
+            foreach (var key in Keys)
             {
                 var keyProp = SerializedProperty.NewCompound();
                 keyProp.Add("Position", new SerializedProperty(key.Position));
@@ -332,15 +332,15 @@ namespace Prowl.Runtime
 
         public void Deserialize(SerializedProperty value, Serializer.SerializationContext ctx)
         {
-            this.PreLoop = (CurveLoopType)value.Get("PreLoop").IntValue;
-            this.PostLoop = (CurveLoopType)value.Get("PostLoop").IntValue;
+            PreLoop = (CurveLoopType)value.Get("PreLoop").IntValue;
+            PostLoop = (CurveLoopType)value.Get("PostLoop").IntValue;
 
             var keyList = value.Get("Keys").List;
             foreach (var key in keyList)
             {
                 var position = key.Get("Position").DoubleValue;
                 var curveKey = new KeyFrame(position, key.Get("Value").DoubleValue, key.Get("TangentIn").DoubleValue, key.Get("TangentOut").DoubleValue, (CurveContinuity)key.Get("Continuity").IntValue);
-                this.Keys.Add(curveKey);
+                Keys.Add(curveKey);
             }
         }
 
@@ -390,11 +390,11 @@ namespace Prowl.Runtime
         /// <summary> Creates a new instance of <see cref="KeyFrame"/> class. </summary>
         public KeyFrame(double position, double value, double tangentIn = 0, double tangentOut = 0, CurveContinuity continuity = CurveContinuity.Smooth)
         {
-            this.Position = position;
-            this.Value = value;
-            this.TangentIn = tangentIn;
-            this.TangentOut = tangentOut;
-            this.Continuity = continuity;
+            Position = position;
+            Value = value;
+            TangentIn = tangentIn;
+            TangentOut = tangentOut;
+            Continuity = continuity;
         }
 
         #endregion
@@ -406,11 +406,11 @@ namespace Prowl.Runtime
 
         public static bool operator ==(KeyFrame value1, KeyFrame value2)
         {
-            if (object.Equals(value1, null))
-                return object.Equals(value2, null);
+            if (Equals(value1, null))
+                return Equals(value2, null);
 
-            if (object.Equals(value2, null))
-                return object.Equals(value1, null);
+            if (Equals(value2, null))
+                return Equals(value1, null);
 
             return (value1.Position == value2.Position)
                 && (value1.Value == value2.Value)
@@ -421,12 +421,12 @@ namespace Prowl.Runtime
 
         #region Inherited Methods
 
-        public int CompareTo(KeyFrame other) => this.Position.CompareTo(other.Position);
+        public int CompareTo(KeyFrame other) => Position.CompareTo(other.Position);
         public bool Equals(KeyFrame other) => (this == other);
         public override bool Equals(object obj) => (obj as KeyFrame) != null && Equals((KeyFrame)obj);
         public override int GetHashCode() =>
-                this.Position.GetHashCode() ^ this.Value.GetHashCode() ^ this.TangentIn.GetHashCode() ^
-                this.TangentOut.GetHashCode() ^ this.Continuity.GetHashCode();
+                Position.GetHashCode() ^ Value.GetHashCode() ^ TangentIn.GetHashCode() ^
+                TangentOut.GetHashCode() ^ Continuity.GetHashCode();
 
         #endregion
     }
@@ -493,20 +493,20 @@ namespace Prowl.Runtime
 
             if (_keys.Count == 0)
             {
-                this._keys.Add(item);
+                _keys.Add(item);
                 return;
             }
 
-            for (int i = 0; i < this._keys.Count; i++)
+            for (int i = 0; i < _keys.Count; i++)
             {
-                if (item.Position < this._keys[i].Position)
+                if (item.Position < _keys[i].Position)
                 {
-                    this._keys.Insert(i, item);
+                    _keys.Insert(i, item);
                     return;
                 }
             }
 
-            this._keys.Add(item);
+            _keys.Add(item);
         }
 
         /// <summary> Removes all keys from this collection. </summary>

--- a/Prowl.Runtime/AnimationCurve.cs
+++ b/Prowl.Runtime/AnimationCurve.cs
@@ -489,7 +489,7 @@ namespace Prowl.Runtime
         public void Add(KeyFrame item)
         {
             if (item == null)
-                throw new ArgumentNullException("item");
+                throw new ArgumentNullException(nameof(item));
 
             if (_keys.Count == 0)
             {

--- a/Prowl.Runtime/AnimationCurve.cs
+++ b/Prowl.Runtime/AnimationCurve.cs
@@ -59,10 +59,12 @@ namespace Prowl.Runtime
         /// </summary>
         public AnimationCurve()
         {
-            this.Keys = [];
+            this.Keys =
+            [
+                new KeyFrame(0, 0),
+                new KeyFrame(1, 1)
+            ];
             // Add Default keys
-            this.Keys.Add(new KeyFrame(0, 0));
-            this.Keys.Add(new KeyFrame(1, 1));
             SmoothTangents(CurveTangent.Smooth);
         }
 
@@ -474,7 +476,7 @@ namespace Prowl.Runtime
         #region Constructors
 
         /// <summary> Creates a new instance of <see cref="CurveKeyCollection"/> class. </summary>
-        public CurveKeyCollection() => _keys = new List<KeyFrame>();
+        public CurveKeyCollection() => _keys = [];
 
         #endregion
 

--- a/Prowl.Runtime/Application.cs
+++ b/Prowl.Runtime/Application.cs
@@ -25,9 +25,9 @@ public static class Application
     public static event Action Render;
     public static event Action Quitting;
 
-    private static TimeData AppTime = new();
+    private static readonly TimeData AppTime = new();
 
-    private static GraphicsBackend[] preferredWindowsBackends = // Covers Windows/UWP
+    private static readonly GraphicsBackend[] preferredWindowsBackends = // Covers Windows/UWP
     [
         GraphicsBackend.Vulkan,
         GraphicsBackend.OpenGL,
@@ -35,14 +35,14 @@ public static class Application
         GraphicsBackend.OpenGLES,
     ];
 
-    private static GraphicsBackend[] preferredUnixBackends = // Cover Unix-like (Linux, FreeBSD, OpenBSD)
+    private static readonly GraphicsBackend[] preferredUnixBackends = // Cover Unix-like (Linux, FreeBSD, OpenBSD)
     [
         GraphicsBackend.Vulkan,
         GraphicsBackend.OpenGL,
         GraphicsBackend.OpenGLES,
     ];
 
-    private static GraphicsBackend[] preferredMacBackends = // Covers MacOS/Apple
+    private static readonly GraphicsBackend[] preferredMacBackends = // Covers MacOS/Apple
     [
         GraphicsBackend.Metal,
         GraphicsBackend.OpenGL,

--- a/Prowl.Runtime/Audio/OpenAL/OpenALEngine.cs
+++ b/Prowl.Runtime/Audio/OpenAL/OpenALEngine.cs
@@ -7,7 +7,7 @@ using Silk.NET.OpenAL;
 
 namespace Prowl.Runtime.Audio.OpenAL
 {
-    public class OpenALEngine : AudioEngine, System.IDisposable
+    public class OpenALEngine : AudioEngine, IDisposable
     {
         public static ALContext alContext { get; private set; }
         public static AL al { get; private set; }

--- a/Prowl.Runtime/Color.cs
+++ b/Prowl.Runtime/Color.cs
@@ -75,7 +75,7 @@ namespace Prowl.Runtime
             this.r = r;
             this.g = g;
             this.b = b;
-            this.a = 1f;
+            a = 1f;
         }
 
         public Color(byte r, byte g, byte b, byte a)
@@ -91,7 +91,7 @@ namespace Prowl.Runtime
             this.r = r / 255f;
             this.g = g / 255f;
             this.b = b / 255f;
-            this.a = 1f;
+            a = 1f;
         }
 
         public uint GetUInt() => ((Color32)this).GetUInt();

--- a/Prowl.Runtime/Color32.cs
+++ b/Prowl.Runtime/Color32.cs
@@ -30,7 +30,7 @@ namespace Prowl.Runtime
         internal uint GetUInt()
         {
             uint @out;
-            @out = (uint)r;
+            @out = r;
             @out |= (uint)g << 8;
             @out |= (uint)b << 16;
             @out |= (uint)a << 24;
@@ -44,7 +44,7 @@ namespace Prowl.Runtime
 
         public static implicit operator Color(Color32 v)
         {
-            return new Color((float)v.r / 255f, (float)v.g / 255f, (float)v.b / 255f, (float)v.a / 255f);
+            return new Color(v.r / 255f, v.g / 255f, v.b / 255f, v.a / 255f);
         }
 
         public override readonly string ToString() => string.Format("RGBA({0}, {1}, {2}, {3})", new object[] { r, g, b, a });

--- a/Prowl.Runtime/Components/Animation.cs
+++ b/Prowl.Runtime/Components/Animation.cs
@@ -187,7 +187,7 @@ namespace Prowl.Runtime
             // Find all bone names used by the clip
             foreach (var bone in clip.Bones)
             {
-                var t = this.GameObject.Transform.DeepFind(bone.BoneName);
+                var t = GameObject.Transform.DeepFind(bone.BoneName);
                 if (t == null)
                     continue;
                 if (!transforms.Contains(t))

--- a/Prowl.Runtime/Components/Animation.cs
+++ b/Prowl.Runtime/Components/Animation.cs
@@ -17,10 +17,10 @@ namespace Prowl.Runtime
         public bool PlayAutomatically = true;
         public double Speed = 1.0;
 
-        private List<AnimationState> _states = new List<AnimationState>();
-        private Dictionary<string, AnimationState> _stateDictionary = new Dictionary<string, AnimationState>();
+        private readonly List<AnimationState> _states = new List<AnimationState>();
+        private readonly Dictionary<string, AnimationState> _stateDictionary = new Dictionary<string, AnimationState>();
 
-        private List<Transform> transforms = [];
+        private readonly List<Transform> transforms = [];
 
         public override void OnEnable()
         {

--- a/Prowl.Runtime/Components/Audio/AudioListener.cs
+++ b/Prowl.Runtime/Components/Audio/AudioListener.cs
@@ -14,17 +14,17 @@ namespace Prowl.Runtime
 
         public override void OnEnable()
         {
-            lastPos = this.GameObject.Transform.position;
+            lastPos = GameObject.Transform.position;
             AudioSystem.RegisterListener(this);
         }
         public override void OnDisable() => AudioSystem.UnregisterListener(this);
         public override void Update()
         {
-            if (_lastVersion != this.GameObject.Transform.version)
+            if (_lastVersion != GameObject.Transform.version)
             {
-                AudioSystem.ListenerTransformChanged(this.GameObject.Transform, lastPos);
-                lastPos = this.GameObject.Transform.position;
-                _lastVersion = this.GameObject.Transform.version;
+                AudioSystem.ListenerTransformChanged(GameObject.Transform, lastPos);
+                lastPos = GameObject.Transform.position;
+                _lastVersion = GameObject.Transform.version;
             }
         }
     }

--- a/Prowl.Runtime/Components/Camera.cs
+++ b/Prowl.Runtime/Components/Camera.cs
@@ -1,8 +1,6 @@
 ﻿// This file is part of the Prowl Game Engine
 // Licensed under the MIT License. See the LICENSE file in the project root for details.
 
-using System.Collections.Generic;
-
 using Prowl.Icons;
 using Prowl.Runtime.RenderPipelines;
 

--- a/Prowl.Runtime/Components/Lights/Light.cs
+++ b/Prowl.Runtime/Components/Lights/Light.cs
@@ -1,9 +1,6 @@
 ﻿// This file is part of the Prowl Game Engine
 // Licensed under the MIT License. See the LICENSE file in the project root for details.
 
-using System.Collections.Generic;
-using System.Runtime.InteropServices;
-
 namespace Prowl.Runtime;
 
 public abstract class Light : MonoBehaviour, IRenderableLight

--- a/Prowl.Runtime/Components/MeshRenderer.cs
+++ b/Prowl.Runtime/Components/MeshRenderer.cs
@@ -3,9 +3,6 @@
 
 using Prowl.Icons;
 
-using Material = Prowl.Runtime.Material;
-using Mesh = Prowl.Runtime.Mesh;
-
 namespace Prowl.Runtime;
 
 [ExecuteAlways]

--- a/Prowl.Runtime/Components/Navmesh/NavMeshAgent.cs
+++ b/Prowl.Runtime/Components/Navmesh/NavMeshAgent.cs
@@ -120,7 +120,7 @@ public class NavMeshAgent : MonoBehaviour
         {
             // calculate position
             Vector3 pos = surface.Transform.TransformPoint(new(InternalAgent.npos.X, InternalAgent.npos.Y, InternalAgent.npos.Z));
-            this.Transform.position = pos;
+            Transform.position = pos;
         }
 
     }

--- a/Prowl.Runtime/Components/Navmesh/NavMeshSurface.cs
+++ b/Prowl.Runtime/Components/Navmesh/NavMeshSurface.cs
@@ -126,7 +126,7 @@ namespace Prowl.Runtime
                     var transform = input.transformsOut[i];
                     for (int l = 0; l < shape.Vertices.Length; l++)
                     {
-                        verts.Add(this.Transform.InverseTransformPoint(transform.TransformPoint(shape.Vertices[l])));
+                        verts.Add(Transform.InverseTransformPoint(transform.TransformPoint(shape.Vertices[l])));
                     }
                 }
 
@@ -229,7 +229,7 @@ namespace Prowl.Runtime
             if (useStaticGeometry)
             {
                 staticGeometry.Clear();
-                foreach (var sBody in EngineObject.FindObjectsOfType<Staticbody>())
+                foreach (var sBody in FindObjectsOfType<Staticbody>())
                 {
                     if (SceneManagement.SceneManager.Has(sBody.GameObject))
                         staticGeometry.Add(sBody);
@@ -238,7 +238,7 @@ namespace Prowl.Runtime
             else
             {
                 meshGeometry.Clear();
-                foreach (var mRend in EngineObject.FindObjectsOfType<MeshRenderer>())
+                foreach (var mRend in FindObjectsOfType<MeshRenderer>())
                 {
                     if (SceneManagement.SceneManager.Has(mRend.GameObject))
                         meshGeometry.Add(mRend);
@@ -511,7 +511,7 @@ namespace Prowl.Runtime
                     agentMaxSpeed = agentMaxSpeed,
                     minRegionSize = minRegionSize,
                     mergedRegionSize = mergedRegionSize,
-                    partitioning = DotRecast.Recast.RcPartitionType.WATERSHED.Value,
+                    partitioning = RcPartitionType.WATERSHED.Value,
                     filterLowHangingObstacles = filterLowHangingObstacles,
                     filterLedgeSpans = filterLedgeSpans,
                     filterWalkableLowHeightSpans = filterWalkableLowHeightSpans,

--- a/Prowl.Runtime/Components/Navmesh/NavMeshSurface.cs
+++ b/Prowl.Runtime/Components/Navmesh/NavMeshSurface.cs
@@ -416,8 +416,8 @@ namespace Prowl.Runtime
                 public List<int> indices;
             }
 
-            public List<Mesh> shapeData = new();
-            public List<Transform> transformsOut = new();
+            public readonly List<Mesh> shapeData = new();
+            public readonly List<Transform> transformsOut = new();
 
             public void Append(Collider collider)
             {

--- a/Prowl.Runtime/Components/Navmesh/NavMeshSurface.cs
+++ b/Prowl.Runtime/Components/Navmesh/NavMeshSurface.cs
@@ -118,9 +118,9 @@ namespace Prowl.Runtime
 
                     for (int j = 0; j < shape.Indices16.Length; j += 3)
                     {
-                        indices.Add(verts.Count + (int)shape.Indices16[j + 0]);
-                        indices.Add(verts.Count + (int)shape.Indices16[j + 1]);
-                        indices.Add(verts.Count + (int)shape.Indices16[j + 2]);
+                        indices.Add(verts.Count + shape.Indices16[j + 0]);
+                        indices.Add(verts.Count + shape.Indices16[j + 1]);
+                        indices.Add(verts.Count + shape.Indices16[j + 2]);
                     }
 
                     var transform = input.transformsOut[i];

--- a/Prowl.Runtime/Components/Physics/CharacterController.cs
+++ b/Prowl.Runtime/Components/Physics/CharacterController.cs
@@ -33,7 +33,7 @@ public sealed class CharacterController : Rigidbody
 
     protected override void RigidbodyAttached()
     {
-        ref var character = ref Physics.Characters.AllocateCharacter(base.BodyReference.Value.Handle);
+        ref var character = ref Physics.Characters.AllocateCharacter(BodyReference.Value.Handle);
         character.LocalUp = new Vector3(0, 1, 0);
         character.JumpVelocity = jumpVelocity;
         character.MaximumVerticalForce = maxVerticalForce;
@@ -44,36 +44,36 @@ public sealed class CharacterController : Rigidbody
 
         character.TargetVelocity = TargetVelocity;
 
-        base.BodyReference.Value.SetLocalInertia(new BodyInertia { InverseMass = 1f / base.Mass });
+        BodyReference.Value.SetLocalInertia(new BodyInertia { InverseMass = 1f / Mass });
     }
 
     protected override void RigidbodyDetached()
     {
-        Physics.Characters.RemoveCharacterByBodyHandle(base.BodyReference.Value.Handle);
+        Physics.Characters.RemoveCharacterByBodyHandle(BodyReference.Value.Handle);
     }
 
     public override void Update()
     {
-        ref var character = ref Physics.Characters.GetCharacterByBodyHandle(base.BodyReference.Value.Handle);
+        ref var character = ref Physics.Characters.GetCharacterByBodyHandle(BodyReference.Value.Handle);
 
         character.CosMaximumSlope = MathF.Cos(maxSlope.ToRad());
         character.JumpVelocity = jumpVelocity;
 
-        if (!base.BodyReference.Value.Awake &&
+        if (!BodyReference.Value.Awake &&
             ((character.TryJump && character.Supported) ||
             TargetVelocity.ToFloat() != character.TargetVelocity ||
-            (TargetVelocity != Vector2.zero && character.ViewDirection != this.Transform.forward.ToFloat())))
+            (TargetVelocity != Vector2.zero && character.ViewDirection != Transform.forward.ToFloat())))
         {
             Physics.Sim.Awakener.AwakenBody(character.BodyHandle);
         }
 
-        character.ViewDirection = this.Transform.forward;
+        character.ViewDirection = Transform.forward;
         character.TargetVelocity = TargetVelocity;
         IsGrounded = character.Supported;
 
         if (!base.Kinematic)
-            base.BodyReference.Value.LocalInertia = new BodyInertia { InverseMass = 1f / base.Mass };
+            BodyReference.Value.LocalInertia = new BodyInertia { InverseMass = 1f / Mass };
     }
 
-    public void TryJump() => Physics.Characters.GetCharacterByBodyHandle(base.BodyReference.Value.Handle).TryJump = true;
+    public void TryJump() => Physics.Characters.GetCharacterByBodyHandle(BodyReference.Value.Handle).TryJump = true;
 }

--- a/Prowl.Runtime/Components/Physics/Colliders/BoxCollider.cs
+++ b/Prowl.Runtime/Components/Physics/Colliders/BoxCollider.cs
@@ -30,7 +30,7 @@ public sealed class BoxCollider : Collider
     {
         get
         {
-            return _size * this.Transform.lossyScale;
+            return _size * Transform.lossyScale;
         }
     }
 

--- a/Prowl.Runtime/Components/Physics/Colliders/CapsuleCollider.cs
+++ b/Prowl.Runtime/Components/Physics/Colliders/CapsuleCollider.cs
@@ -43,14 +43,14 @@ public sealed class CapsuleCollider : Collider
     {
         get
         {
-            var scale = this.Transform.lossyScale;
+            var scale = Transform.lossyScale;
             return _length * (float)MathD.Max(scale.x, scale.z);
         }
     }
 
     public float WorldLength
     {
-        get => _length * (float)this.Transform.lossyScale.y;
+        get => _length * (float)Transform.lossyScale.y;
     }
 
     internal override void AddToCompoundBuilder(BufferPool pool, ref CompoundBuilder builder, NRigidPose localPose)

--- a/Prowl.Runtime/Components/Physics/Colliders/Collider.cs
+++ b/Prowl.Runtime/Components/Physics/Colliders/Collider.cs
@@ -30,16 +30,16 @@ public abstract class Collider : MonoBehaviour
     public override void OnEnable()
     {
         base.OnEnable();
-        _transformVersion = this.Transform.version;
+        _transformVersion = Transform.version;
     }
 
     public override void LateUpdate()
     {
-        if (this.Transform.version != _transformVersion)
+        if (Transform.version != _transformVersion)
         {
-            if (Container.Transform != this.Transform)
+            if (Container.Transform != Transform)
                 Container?.ReAttach();
-            _transformVersion = this.Transform.version;
+            _transformVersion = Transform.version;
         }
     }
 

--- a/Prowl.Runtime/Components/Physics/Colliders/CylinderCollider.cs
+++ b/Prowl.Runtime/Components/Physics/Colliders/CylinderCollider.cs
@@ -43,14 +43,14 @@ public sealed class CylinderCollider : Collider
     {
         get
         {
-            var scale = this.Transform.lossyScale;
+            var scale = Transform.lossyScale;
             return _length * (float)MathD.Max(scale.x, scale.z);
         }
     }
 
     public float WorldLength
     {
-        get => _length * (float)this.Transform.lossyScale.y;
+        get => _length * (float)Transform.lossyScale.y;
     }
 
     internal override void AddToCompoundBuilder(BufferPool pool, ref CompoundBuilder builder, NRigidPose localPose)

--- a/Prowl.Runtime/Components/Physics/Colliders/SphereCollider.cs
+++ b/Prowl.Runtime/Components/Physics/Colliders/SphereCollider.cs
@@ -31,7 +31,7 @@ public sealed class SphereCollider : Collider
     {
         get
         {
-            var worldScale = this.Transform.lossyScale;
+            var worldScale = Transform.lossyScale;
             return _radius * (float)MathD.Max(worldScale.x, worldScale.y, worldScale.z);
         }
     }

--- a/Prowl.Runtime/Components/Physics/Colliders/TriangleCollider.cs
+++ b/Prowl.Runtime/Components/Physics/Colliders/TriangleCollider.cs
@@ -53,9 +53,9 @@ public sealed class TriangleCollider : Collider
 
     internal override void AddToCompoundBuilder(BufferPool pool, ref CompoundBuilder builder, NRigidPose localPose)
     {
-        var localA = A * this.Transform.lossyScale;
-        var localB = B * this.Transform.lossyScale;
-        var localC = C * this.Transform.lossyScale;
+        var localA = A * Transform.lossyScale;
+        var localB = B * Transform.lossyScale;
+        var localC = C * Transform.lossyScale;
         builder.Add(new Triangle(localA, localB, localC), localPose, Mass);
     }
 }

--- a/Prowl.Runtime/Components/Physics/Constraints/AngularAxisGearMotorConstraintComponent.cs
+++ b/Prowl.Runtime/Components/Physics/Constraints/AngularAxisGearMotorConstraintComponent.cs
@@ -5,7 +5,7 @@ using BepuPhysics.Constraints;
 
 namespace Prowl.Runtime;
 
-[AddComponentMenu($"{Prowl.Icons.FontAwesome6.HillRockslide}  Physics/{Prowl.Icons.FontAwesome6.Joint}  Constraints/{Prowl.Icons.FontAwesome6.Rotate}  Angular Axis Gear Motor Constraint")]
+[AddComponentMenu($"{Icons.FontAwesome6.HillRockslide}  Physics/{Icons.FontAwesome6.Joint}  Constraints/{Icons.FontAwesome6.Rotate}  Angular Axis Gear Motor Constraint")]
 public sealed class AngularAxisGearMotorConstraintComponent : TwoBodyConstraintComponent<AngularAxisGearMotor>
 {
     [SerializeField, HideInInspector] private Vector3 _localAxisA;

--- a/Prowl.Runtime/Components/Physics/Constraints/AngularAxisMotorConstraintComponent.cs
+++ b/Prowl.Runtime/Components/Physics/Constraints/AngularAxisMotorConstraintComponent.cs
@@ -5,7 +5,7 @@ using BepuPhysics.Constraints;
 
 namespace Prowl.Runtime;
 
-[AddComponentMenu($"{Prowl.Icons.FontAwesome6.HillRockslide}  Physics/{Prowl.Icons.FontAwesome6.Joint}  Constraints/{Prowl.Icons.FontAwesome6.Rotate}  Angular Axis Motor Constraint")]
+[AddComponentMenu($"{Icons.FontAwesome6.HillRockslide}  Physics/{Icons.FontAwesome6.Joint}  Constraints/{Icons.FontAwesome6.Rotate}  Angular Axis Motor Constraint")]
 public sealed class AngularAxisMotorConstraintComponent : TwoBodyConstraintComponent<AngularAxisMotor>
 {
     [SerializeField, HideInInspector] private Vector3 _localAxisA;

--- a/Prowl.Runtime/Components/Physics/Constraints/AngularHingeConstraintComponent.cs
+++ b/Prowl.Runtime/Components/Physics/Constraints/AngularHingeConstraintComponent.cs
@@ -5,7 +5,7 @@ using BepuPhysics.Constraints;
 
 namespace Prowl.Runtime;
 
-[AddComponentMenu($"{Prowl.Icons.FontAwesome6.HillRockslide}  Physics/{Prowl.Icons.FontAwesome6.Joint}  Constraints/{Prowl.Icons.FontAwesome6.Rotate}  Angular Hinge Constraint")]
+[AddComponentMenu($"{Icons.FontAwesome6.HillRockslide}  Physics/{Icons.FontAwesome6.Joint}  Constraints/{Icons.FontAwesome6.Rotate}  Angular Hinge Constraint")]
 public sealed class AngularHingeConstraintComponent : TwoBodyConstraintComponent<AngularHinge>
 {
     [SerializeField, HideInInspector] private Vector3 _localHingeAxisA;

--- a/Prowl.Runtime/Components/Physics/Constraints/AngularServoConstraintComponent.cs
+++ b/Prowl.Runtime/Components/Physics/Constraints/AngularServoConstraintComponent.cs
@@ -6,7 +6,7 @@ using BepuPhysics.Constraints;
 namespace Prowl.Runtime;
 
 
-[AddComponentMenu($"{Prowl.Icons.FontAwesome6.HillRockslide}  Physics/{Prowl.Icons.FontAwesome6.Joint}  Constraints/{Prowl.Icons.FontAwesome6.ClockRotateLeft}  Angular Servo")]
+[AddComponentMenu($"{Icons.FontAwesome6.HillRockslide}  Physics/{Icons.FontAwesome6.Joint}  Constraints/{Icons.FontAwesome6.ClockRotateLeft}  Angular Servo")]
 public sealed class AngularServoConstraintComponent : TwoBodyConstraintComponent<AngularServo>
 {
 

--- a/Prowl.Runtime/Components/Physics/Constraints/AngularSwivelHingeConstraintComponent.cs
+++ b/Prowl.Runtime/Components/Physics/Constraints/AngularSwivelHingeConstraintComponent.cs
@@ -6,7 +6,7 @@ using BepuPhysics.Constraints;
 namespace Prowl.Runtime;
 
 
-[AddComponentMenu($"{Prowl.Icons.FontAwesome6.HillRockslide}  Physics/{Prowl.Icons.FontAwesome6.Joint}  Constraints/{Prowl.Icons.FontAwesome6.ClockRotateLeft}  Angular Swivel Hinge")]
+[AddComponentMenu($"{Icons.FontAwesome6.HillRockslide}  Physics/{Icons.FontAwesome6.Joint}  Constraints/{Icons.FontAwesome6.ClockRotateLeft}  Angular Swivel Hinge")]
 public sealed class AngularSwivelHingeConstraintComponent : TwoBodyConstraintComponent<AngularSwivelHinge>
 {
     [SerializeField, HideInInspector] private Vector3 _localSwivelAxisA;

--- a/Prowl.Runtime/Components/Physics/Constraints/AreaConstraintComponent.cs
+++ b/Prowl.Runtime/Components/Physics/Constraints/AreaConstraintComponent.cs
@@ -6,7 +6,7 @@ using BepuPhysics.Constraints;
 namespace Prowl.Runtime;
 
 
-[AddComponentMenu($"{Prowl.Icons.FontAwesome6.HillRockslide}  Physics/{Prowl.Icons.FontAwesome6.Joint}  Constraints/{Prowl.Icons.FontAwesome6.Square}  Area Constraint")]
+[AddComponentMenu($"{Icons.FontAwesome6.HillRockslide}  Physics/{Icons.FontAwesome6.Joint}  Constraints/{Icons.FontAwesome6.Square}  Area Constraint")]
 public sealed class AreaConstraintComponent : ThreeBodyConstraintComponent<AreaConstraint>
 {
     [SerializeField, HideInInspector] private float _targetScaledArea;

--- a/Prowl.Runtime/Components/Physics/Constraints/BallSocketConstraintComponent.cs
+++ b/Prowl.Runtime/Components/Physics/Constraints/BallSocketConstraintComponent.cs
@@ -6,7 +6,7 @@ using BepuPhysics.Constraints;
 namespace Prowl.Runtime;
 
 
-[AddComponentMenu($"{Prowl.Icons.FontAwesome6.HillRockslide}  Physics/{Prowl.Icons.FontAwesome6.Joint}  Constraints/{Prowl.Icons.FontAwesome6.Circle}  Ball Socket")]
+[AddComponentMenu($"{Icons.FontAwesome6.HillRockslide}  Physics/{Icons.FontAwesome6.Joint}  Constraints/{Icons.FontAwesome6.Circle}  Ball Socket")]
 public sealed class BallSocketConstraintComponent : TwoBodyConstraintComponent<BallSocket>
 {
     [SerializeField, HideInInspector] private Vector3 _localOffsetA;

--- a/Prowl.Runtime/Components/Physics/Constraints/BallSocketMotorConstraintComponent.cs
+++ b/Prowl.Runtime/Components/Physics/Constraints/BallSocketMotorConstraintComponent.cs
@@ -6,7 +6,7 @@ using BepuPhysics.Constraints;
 namespace Prowl.Runtime;
 
 
-[AddComponentMenu($"{Prowl.Icons.FontAwesome6.HillRockslide}  Physics/{Prowl.Icons.FontAwesome6.Joint}  Constraints/{Prowl.Icons.FontAwesome6.Circle}  Ball Socket Motor")]
+[AddComponentMenu($"{Icons.FontAwesome6.HillRockslide}  Physics/{Icons.FontAwesome6.Joint}  Constraints/{Icons.FontAwesome6.Circle}  Ball Socket Motor")]
 public sealed class BallSocketMotorConstraintComponent : TwoBodyConstraintComponent<BallSocketMotor>
 {
     [SerializeField, HideInInspector] private Vector3 _localOffsetB;

--- a/Prowl.Runtime/Components/Physics/Constraints/BallSocketServoConstraintComponent.cs
+++ b/Prowl.Runtime/Components/Physics/Constraints/BallSocketServoConstraintComponent.cs
@@ -6,7 +6,7 @@ using BepuPhysics.Constraints;
 namespace Prowl.Runtime;
 
 
-[AddComponentMenu($"{Prowl.Icons.FontAwesome6.HillRockslide}  Physics/{Prowl.Icons.FontAwesome6.Joint}  Constraints/{Prowl.Icons.FontAwesome6.Circle}  Ball Socket Servo")]
+[AddComponentMenu($"{Icons.FontAwesome6.HillRockslide}  Physics/{Icons.FontAwesome6.Joint}  Constraints/{Icons.FontAwesome6.Circle}  Ball Socket Servo")]
 public sealed class BallSocketServoConstraintComponent : TwoBodyConstraintComponent<BallSocketServo>
 {
     [SerializeField, HideInInspector] private Vector3 _localOffsetA;

--- a/Prowl.Runtime/Components/Physics/Constraints/CenterDistanceConstraintComponent.cs
+++ b/Prowl.Runtime/Components/Physics/Constraints/CenterDistanceConstraintComponent.cs
@@ -6,7 +6,7 @@ using BepuPhysics.Constraints;
 namespace Prowl.Runtime;
 
 
-[AddComponentMenu($"{Prowl.Icons.FontAwesome6.HillRockslide}  Physics/{Prowl.Icons.FontAwesome6.Joint}  Constraints/{Prowl.Icons.FontAwesome6.ArrowsToDot}  Center Distance Constraint")]
+[AddComponentMenu($"{Icons.FontAwesome6.HillRockslide}  Physics/{Icons.FontAwesome6.Joint}  Constraints/{Icons.FontAwesome6.ArrowsToDot}  Center Distance Constraint")]
 public sealed class CenterDistanceConstraintComponent : TwoBodyConstraintComponent<CenterDistanceConstraint>
 {
     [SerializeField, HideInInspector] private float _targetDistance = 0;

--- a/Prowl.Runtime/Components/Physics/Constraints/CenterDistanceLimitConstraintComponent.cs
+++ b/Prowl.Runtime/Components/Physics/Constraints/CenterDistanceLimitConstraintComponent.cs
@@ -6,7 +6,7 @@ using BepuPhysics.Constraints;
 namespace Prowl.Runtime;
 
 
-[AddComponentMenu($"{Prowl.Icons.FontAwesome6.HillRockslide}  Physics/{Prowl.Icons.FontAwesome6.Joint}  Constraints/{Prowl.Icons.FontAwesome6.ArrowsToDot}  Center Distance Limit")]
+[AddComponentMenu($"{Icons.FontAwesome6.HillRockslide}  Physics/{Icons.FontAwesome6.Joint}  Constraints/{Icons.FontAwesome6.ArrowsToDot}  Center Distance Limit")]
 public sealed class CenterDistanceLimitConstraintComponent : TwoBodyConstraintComponent<CenterDistanceLimit>
 {
     [SerializeField, HideInInspector] private float _minimumDistance = 0;

--- a/Prowl.Runtime/Components/Physics/Constraints/DistanceLimitConstraintComponent.cs
+++ b/Prowl.Runtime/Components/Physics/Constraints/DistanceLimitConstraintComponent.cs
@@ -6,7 +6,7 @@ using BepuPhysics.Constraints;
 namespace Prowl.Runtime;
 
 
-[AddComponentMenu($"{Prowl.Icons.FontAwesome6.HillRockslide}  Physics/{Prowl.Icons.FontAwesome6.Joint}  Constraints/{Prowl.Icons.FontAwesome6.Ruler}  Distance Limit")]
+[AddComponentMenu($"{Icons.FontAwesome6.HillRockslide}  Physics/{Icons.FontAwesome6.Joint}  Constraints/{Icons.FontAwesome6.Ruler}  Distance Limit")]
 public sealed class DistanceLimitConstraintComponent : TwoBodyConstraintComponent<DistanceLimit>
 {
     [SerializeField, HideInInspector] private Vector3 _localOffsetA;

--- a/Prowl.Runtime/Components/Physics/Constraints/DistanceServoConstraintComponent.cs
+++ b/Prowl.Runtime/Components/Physics/Constraints/DistanceServoConstraintComponent.cs
@@ -6,7 +6,7 @@ using BepuPhysics.Constraints;
 namespace Prowl.Runtime;
 
 
-[AddComponentMenu($"{Prowl.Icons.FontAwesome6.HillRockslide}  Physics/{Prowl.Icons.FontAwesome6.Joint}  Constraints/{Prowl.Icons.FontAwesome6.Ruler}  Distance Servo")]
+[AddComponentMenu($"{Icons.FontAwesome6.HillRockslide}  Physics/{Icons.FontAwesome6.Joint}  Constraints/{Icons.FontAwesome6.Ruler}  Distance Servo")]
 public sealed class DistanceServoConstraintComponent : TwoBodyConstraintComponent<DistanceServo>
 {
     [SerializeField, HideInInspector] private Vector3 _localOffsetA;

--- a/Prowl.Runtime/Components/Physics/Constraints/HingeConstraintComponent.cs
+++ b/Prowl.Runtime/Components/Physics/Constraints/HingeConstraintComponent.cs
@@ -5,7 +5,7 @@ using BepuPhysics.Constraints;
 
 namespace Prowl.Runtime;
 
-[AddComponentMenu($"{Prowl.Icons.FontAwesome6.HillRockslide}  Physics/{Prowl.Icons.FontAwesome6.Joint}  Constraints/{Prowl.Icons.FontAwesome6.Rotate}  Hinge Constraint")]
+[AddComponentMenu($"{Icons.FontAwesome6.HillRockslide}  Physics/{Icons.FontAwesome6.Joint}  Constraints/{Icons.FontAwesome6.Rotate}  Hinge Constraint")]
 public sealed class HingeConstraintComponent : TwoBodyConstraintComponent<Hinge>
 {
 

--- a/Prowl.Runtime/Components/Physics/Constraints/LinearAxisLimitConstraintComponent.cs
+++ b/Prowl.Runtime/Components/Physics/Constraints/LinearAxisLimitConstraintComponent.cs
@@ -6,7 +6,7 @@ using BepuPhysics.Constraints;
 namespace Prowl.Runtime;
 
 
-[AddComponentMenu($"{Prowl.Icons.FontAwesome6.HillRockslide}  Physics/{Prowl.Icons.FontAwesome6.Joint}  Constraints/{Prowl.Icons.FontAwesome6.LinesLeaning}  Linear Axis Limit Constraint")]
+[AddComponentMenu($"{Icons.FontAwesome6.HillRockslide}  Physics/{Icons.FontAwesome6.Joint}  Constraints/{Icons.FontAwesome6.LinesLeaning}  Linear Axis Limit Constraint")]
 public sealed class LinearAxisLimitConstraintComponent : TwoBodyConstraintComponent<LinearAxisLimit>
 {
     [SerializeField, HideInInspector] private Vector3 _localOffsetA;

--- a/Prowl.Runtime/Components/Physics/Constraints/LinearAxisMotorConstraintComponent.cs
+++ b/Prowl.Runtime/Components/Physics/Constraints/LinearAxisMotorConstraintComponent.cs
@@ -6,7 +6,7 @@ using BepuPhysics.Constraints;
 namespace Prowl.Runtime;
 
 
-[AddComponentMenu($"{Prowl.Icons.FontAwesome6.HillRockslide}  Physics/{Prowl.Icons.FontAwesome6.Joint}  Constraints/{Prowl.Icons.FontAwesome6.LinesLeaning}  Linear Axis Motor")]
+[AddComponentMenu($"{Icons.FontAwesome6.HillRockslide}  Physics/{Icons.FontAwesome6.Joint}  Constraints/{Icons.FontAwesome6.LinesLeaning}  Linear Axis Motor")]
 public sealed class LinearAxisMotorConstraintComponent : TwoBodyConstraintComponent<LinearAxisMotor>
 {
     [SerializeField, HideInInspector] private Vector3 _localOffsetA;

--- a/Prowl.Runtime/Components/Physics/Constraints/LinearAxisServoConstraintComponent.cs
+++ b/Prowl.Runtime/Components/Physics/Constraints/LinearAxisServoConstraintComponent.cs
@@ -6,7 +6,7 @@ using BepuPhysics.Constraints;
 namespace Prowl.Runtime;
 
 
-[AddComponentMenu($"{Prowl.Icons.FontAwesome6.HillRockslide}  Physics/{Prowl.Icons.FontAwesome6.Joint}  Constraints/{Prowl.Icons.FontAwesome6.LinesLeaning}  Linear Axis Servo")]
+[AddComponentMenu($"{Icons.FontAwesome6.HillRockslide}  Physics/{Icons.FontAwesome6.Joint}  Constraints/{Icons.FontAwesome6.LinesLeaning}  Linear Axis Servo")]
 public sealed class LinearAxisServoConstraintComponent : TwoBodyConstraintComponent<LinearAxisServo>
 {
     [SerializeField, HideInInspector] private Vector3 _localOffsetA;

--- a/Prowl.Runtime/Components/Physics/Constraints/OneBodyAngularMotorConstraintComponent.cs
+++ b/Prowl.Runtime/Components/Physics/Constraints/OneBodyAngularMotorConstraintComponent.cs
@@ -6,7 +6,7 @@ using BepuPhysics.Constraints;
 namespace Prowl.Runtime;
 
 
-[AddComponentMenu($"{Prowl.Icons.FontAwesome6.HillRockslide}  Physics/{Prowl.Icons.FontAwesome6.Joint}  Constraints/{Prowl.Icons.FontAwesome6.ArrowsSpin}  One Body Angular Motor")]
+[AddComponentMenu($"{Icons.FontAwesome6.HillRockslide}  Physics/{Icons.FontAwesome6.Joint}  Constraints/{Icons.FontAwesome6.ArrowsSpin}  One Body Angular Motor")]
 public sealed class OneBodyAngularMotorConstraintComponent : OneBodyConstraintComponent<OneBodyAngularMotor>
 {
     [SerializeField, HideInInspector] private Vector3 _targetVelocity;

--- a/Prowl.Runtime/Components/Physics/Constraints/OneBodyAngularServoConstraintComponent.cs
+++ b/Prowl.Runtime/Components/Physics/Constraints/OneBodyAngularServoConstraintComponent.cs
@@ -6,7 +6,7 @@ using BepuPhysics.Constraints;
 namespace Prowl.Runtime;
 
 
-[AddComponentMenu($"{Prowl.Icons.FontAwesome6.HillRockslide}  Physics/{Prowl.Icons.FontAwesome6.Joint}  Constraints/{Prowl.Icons.FontAwesome6.LinesLeaning}  One Body Angular Servo")]
+[AddComponentMenu($"{Icons.FontAwesome6.HillRockslide}  Physics/{Icons.FontAwesome6.Joint}  Constraints/{Icons.FontAwesome6.LinesLeaning}  One Body Angular Servo")]
 public sealed class OneBodyAngularServoConstraintComponent : OneBodyConstraintComponent<OneBodyAngularServo>
 {
     [SerializeField, HideInInspector] private Quaternion _targetOrientation = Quaternion.identity;

--- a/Prowl.Runtime/Components/Physics/Constraints/OneBodyLinearMotorConstraintComponent.cs
+++ b/Prowl.Runtime/Components/Physics/Constraints/OneBodyLinearMotorConstraintComponent.cs
@@ -6,7 +6,7 @@ using BepuPhysics.Constraints;
 namespace Prowl.Runtime;
 
 
-[AddComponentMenu($"{Prowl.Icons.FontAwesome6.HillRockslide}  Physics/{Prowl.Icons.FontAwesome6.Joint}  Constraints/{Prowl.Icons.FontAwesome6.LinesLeaning}  One Body Linear Motor")]
+[AddComponentMenu($"{Icons.FontAwesome6.HillRockslide}  Physics/{Icons.FontAwesome6.Joint}  Constraints/{Icons.FontAwesome6.LinesLeaning}  One Body Linear Motor")]
 public sealed class OneBodyLinearMotorConstraintComponent : OneBodyConstraintComponent<OneBodyLinearMotor>
 {
     [SerializeField, HideInInspector] private Vector3 _localOffset;

--- a/Prowl.Runtime/Components/Physics/Constraints/OneBodyLinearServoConstraintComponent.cs
+++ b/Prowl.Runtime/Components/Physics/Constraints/OneBodyLinearServoConstraintComponent.cs
@@ -6,7 +6,7 @@ using BepuPhysics.Constraints;
 namespace Prowl.Runtime;
 
 
-[AddComponentMenu($"{Prowl.Icons.FontAwesome6.HillRockslide}  Physics/{Prowl.Icons.FontAwesome6.Joint}  Constraints/{Prowl.Icons.FontAwesome6.LinesLeaning}  One Body Linear Servo")]
+[AddComponentMenu($"{Icons.FontAwesome6.HillRockslide}  Physics/{Icons.FontAwesome6.Joint}  Constraints/{Icons.FontAwesome6.LinesLeaning}  One Body Linear Servo")]
 public sealed class OneBodyLinearServoConstraintComponent : OneBodyConstraintComponent<OneBodyLinearServo>
 {
     [SerializeField, HideInInspector] private Vector3 _localOffset;

--- a/Prowl.Runtime/Components/Physics/Constraints/PointOnLineServoConstraintComponent.cs
+++ b/Prowl.Runtime/Components/Physics/Constraints/PointOnLineServoConstraintComponent.cs
@@ -6,7 +6,7 @@ using BepuPhysics.Constraints;
 namespace Prowl.Runtime;
 
 
-[AddComponentMenu($"{Prowl.Icons.FontAwesome6.HillRockslide}  Physics/{Prowl.Icons.FontAwesome6.Joint}  Constraints/{Prowl.Icons.FontAwesome6.LinesLeaning}  Point On Line Servo")]
+[AddComponentMenu($"{Icons.FontAwesome6.HillRockslide}  Physics/{Icons.FontAwesome6.Joint}  Constraints/{Icons.FontAwesome6.LinesLeaning}  Point On Line Servo")]
 public sealed class PointOnLineServoConstraintComponent : TwoBodyConstraintComponent<PointOnLineServo>
 {
 

--- a/Prowl.Runtime/Components/Physics/Constraints/SwingLimitConstraintComponent.cs
+++ b/Prowl.Runtime/Components/Physics/Constraints/SwingLimitConstraintComponent.cs
@@ -6,7 +6,7 @@ using BepuPhysics.Constraints;
 namespace Prowl.Runtime;
 
 
-[AddComponentMenu($"{Prowl.Icons.FontAwesome6.HillRockslide}  Physics/{Prowl.Icons.FontAwesome6.Joint}  Constraints/{Prowl.Icons.FontAwesome6.U}  Swing Limit")]
+[AddComponentMenu($"{Icons.FontAwesome6.HillRockslide}  Physics/{Icons.FontAwesome6.Joint}  Constraints/{Icons.FontAwesome6.U}  Swing Limit")]
 public sealed class SwingLimitConstraintComponent : TwoBodyConstraintComponent<SwingLimit>
 {
     [SerializeField, HideInInspector] private Vector3 _axisLocalA;

--- a/Prowl.Runtime/Components/Physics/Constraints/SwivelHingeConstraintComponent.cs
+++ b/Prowl.Runtime/Components/Physics/Constraints/SwivelHingeConstraintComponent.cs
@@ -6,7 +6,7 @@ using BepuPhysics.Constraints;
 namespace Prowl.Runtime;
 
 
-[AddComponentMenu($"{Prowl.Icons.FontAwesome6.HillRockslide}  Physics/{Prowl.Icons.FontAwesome6.Joint}  Constraints/{Prowl.Icons.FontAwesome6.U}  Swing Hinge")]
+[AddComponentMenu($"{Icons.FontAwesome6.HillRockslide}  Physics/{Icons.FontAwesome6.Joint}  Constraints/{Icons.FontAwesome6.U}  Swing Hinge")]
 public sealed class SwivelHingeConstraintComponent : TwoBodyConstraintComponent<SwivelHinge>
 {
     [SerializeField, HideInInspector] private Vector3 _localOffsetA;

--- a/Prowl.Runtime/Components/Physics/Constraints/TwistLimitConstraintComponent.cs
+++ b/Prowl.Runtime/Components/Physics/Constraints/TwistLimitConstraintComponent.cs
@@ -6,7 +6,7 @@ using BepuPhysics.Constraints;
 namespace Prowl.Runtime;
 
 
-[AddComponentMenu($"{Prowl.Icons.FontAwesome6.HillRockslide}  Physics/{Prowl.Icons.FontAwesome6.Joint}  Constraints/{Prowl.Icons.FontAwesome6.GroupArrowsRotate}  Twist Limit")]
+[AddComponentMenu($"{Icons.FontAwesome6.HillRockslide}  Physics/{Icons.FontAwesome6.Joint}  Constraints/{Icons.FontAwesome6.GroupArrowsRotate}  Twist Limit")]
 public sealed class TwistLimitConstraintComponent : TwoBodyConstraintComponent<TwistLimit>
 {
     [SerializeField, HideInInspector] private Quaternion _localBasisA;

--- a/Prowl.Runtime/Components/Physics/Constraints/TwistMotorConstraintComponent.cs
+++ b/Prowl.Runtime/Components/Physics/Constraints/TwistMotorConstraintComponent.cs
@@ -6,7 +6,7 @@ using BepuPhysics.Constraints;
 namespace Prowl.Runtime;
 
 
-[AddComponentMenu($"{Prowl.Icons.FontAwesome6.HillRockslide}  Physics/{Prowl.Icons.FontAwesome6.Joint}  Constraints/{Prowl.Icons.FontAwesome6.GroupArrowsRotate}  Twist Motor")]
+[AddComponentMenu($"{Icons.FontAwesome6.HillRockslide}  Physics/{Icons.FontAwesome6.Joint}  Constraints/{Icons.FontAwesome6.GroupArrowsRotate}  Twist Motor")]
 public sealed class TwistMotorConstraintComponent : TwoBodyConstraintComponent<TwistMotor>
 {
     [SerializeField, HideInInspector] private Vector3 _localOffsetA;

--- a/Prowl.Runtime/Components/Physics/Constraints/TwistServoConstraintComponent.cs
+++ b/Prowl.Runtime/Components/Physics/Constraints/TwistServoConstraintComponent.cs
@@ -6,7 +6,7 @@ using BepuPhysics.Constraints;
 namespace Prowl.Runtime;
 
 
-[AddComponentMenu($"{Prowl.Icons.FontAwesome6.HillRockslide}  Physics/{Prowl.Icons.FontAwesome6.Joint}  Constraints/{Prowl.Icons.FontAwesome6.GroupArrowsRotate}  Twist Servo")]
+[AddComponentMenu($"{Icons.FontAwesome6.HillRockslide}  Physics/{Icons.FontAwesome6.Joint}  Constraints/{Icons.FontAwesome6.GroupArrowsRotate}  Twist Servo")]
 public sealed class TwistServoConstraintComponent : TwoBodyConstraintComponent<TwistServo>
 {
     [SerializeField, HideInInspector] private Quaternion _localBasisA;

--- a/Prowl.Runtime/Components/Physics/Constraints/VolumeConstraintComponent.cs
+++ b/Prowl.Runtime/Components/Physics/Constraints/VolumeConstraintComponent.cs
@@ -6,7 +6,7 @@ using BepuPhysics.Constraints;
 namespace Prowl.Runtime;
 
 
-[AddComponentMenu($"{Prowl.Icons.FontAwesome6.HillRockslide}  Physics/{Prowl.Icons.FontAwesome6.Joint}  Constraints/{Prowl.Icons.FontAwesome6.Square}  Volume Constraint")]
+[AddComponentMenu($"{Icons.FontAwesome6.HillRockslide}  Physics/{Icons.FontAwesome6.Joint}  Constraints/{Icons.FontAwesome6.Square}  Volume Constraint")]
 public sealed class VolumeConstraintComponent : FourBodyConstraintComponent<VolumeConstraint>
 {
     [SerializeField, HideInInspector] private float _targetScaledVolume = 35;

--- a/Prowl.Runtime/Components/Physics/Constraints/WeldConstraintComponent.cs
+++ b/Prowl.Runtime/Components/Physics/Constraints/WeldConstraintComponent.cs
@@ -5,7 +5,7 @@ using BepuPhysics.Constraints;
 
 namespace Prowl.Runtime;
 
-[AddComponentMenu($"{Prowl.Icons.FontAwesome6.HillRockslide}  Physics/{Prowl.Icons.FontAwesome6.Joint}  Constraints/{Prowl.Icons.FontAwesome6.LocationPin}  Weld Constraint")]
+[AddComponentMenu($"{Icons.FontAwesome6.HillRockslide}  Physics/{Icons.FontAwesome6.Joint}  Constraints/{Icons.FontAwesome6.LocationPin}  Weld Constraint")]
 public sealed class WeldConstraintComponent : TwoBodyConstraintComponent<Weld>
 {
     [SerializeField, HideInInspector] private Vector3 _localOffset;

--- a/Prowl.Runtime/Components/Physics/Constraints/_ConstraintComponentBase.cs
+++ b/Prowl.Runtime/Components/Physics/Constraints/_ConstraintComponentBase.cs
@@ -10,7 +10,7 @@ namespace Prowl.Runtime;
 
 public abstract class ConstraintComponentBase : MonoBehaviour
 {
-    [SerializeField, HideInInspector] private Rigidbody?[] _bodies;
+    [SerializeField, HideInInspector] private readonly Rigidbody?[] _bodies;
 
     public ReadOnlySpan<Rigidbody?> Bodies => _bodies;
 

--- a/Prowl.Runtime/Components/Physics/PhysicsBody.cs
+++ b/Prowl.Runtime/Components/Physics/PhysicsBody.cs
@@ -140,7 +140,7 @@ namespace Prowl.Runtime
 
         bool TryGetShape(out TypedIndex index, out Vector3 centerOfMass, out BodyInertia inertia)
         {
-            List<Collider> colliders = this.GetComponentsInChildren<Collider>().ToList();
+            List<Collider> colliders = GetComponentsInChildren<Collider>().ToList();
 
             if (colliders.Count == 0)
             {
@@ -163,7 +163,7 @@ namespace Prowl.Runtime
 
                     Vector3 localTranslation = Vector3.zero;
                     Quaternion localRotation = Quaternion.identity;
-                    if (collider.Transform != this.Transform)
+                    if (collider.Transform != Transform)
                     {
                         localTranslation = collider.Transform.localPosition;
                         localRotation = collider.Transform.localRotation;

--- a/Prowl.Runtime/Components/Physics/Rigidbody.cs
+++ b/Prowl.Runtime/Components/Physics/Rigidbody.cs
@@ -192,7 +192,7 @@ namespace Prowl.Runtime
         public override void OnEnable()
         {
             base.OnEnable();
-            _transformVersion = this.Transform.version;
+            _transformVersion = Transform.version;
         }
 
         public void ApplyImpulse(Vector3 impulse, Vector3 impulseOffset)
@@ -271,14 +271,14 @@ namespace Prowl.Runtime
 
         public void SyncTransform()
         {
-            if (this.Transform.version != _transformVersion)
+            if (Transform.version != _transformVersion)
             {
-                Position = this.Transform.position;
-                Orientation = this.Transform.rotation;
+                Position = Transform.position;
+                Orientation = Transform.rotation;
                 LinearVelocity = Vector3.zero;
                 AngularVelocity = Vector3.zero;
                 Awake = true;
-                _transformVersion = this.Transform.version;
+                _transformVersion = Transform.version;
             }
         }
 

--- a/Prowl.Runtime/Components/Physics/Staticbody.cs
+++ b/Prowl.Runtime/Components/Physics/Staticbody.cs
@@ -54,7 +54,7 @@ namespace Prowl.Runtime
         public override void OnEnable()
         {
             base.OnEnable();
-            _transformVersion = this.Transform.version;
+            _transformVersion = Transform.version;
         }
 
         protected override ref PhysicsMaterial MaterialProperties => ref Physics.CollidableMaterials[StaticReference!.Value.Handle];
@@ -97,11 +97,11 @@ namespace Prowl.Runtime
 
         public void SyncTransform()
         {
-            if (this.Transform.version != _transformVersion)
+            if (Transform.version != _transformVersion)
             {
-                Position = this.Transform.position;
-                Orientation = this.Transform.rotation;
-                _transformVersion = this.Transform.version;
+                Position = Transform.position;
+                Orientation = Transform.rotation;
+                _transformVersion = Transform.version;
             }
         }
 

--- a/Prowl.Runtime/Components/Physics/Types/Contacts/ContactEventsManager.cs
+++ b/Prowl.Runtime/Components/Physics/Types/Contacts/ContactEventsManager.cs
@@ -38,7 +38,7 @@ internal class ContactEventsManager : IDisposable
         public int FeatureId3;
     }
 
-    IThreadDispatcher? threadDispatcher;
+    readonly IThreadDispatcher? threadDispatcher;
     BufferPool? pool;
 
     //We'll use a handle->index mapping in a CollidableProperty to point at our contiguously stored listeners (in the later listeners array).

--- a/Prowl.Runtime/Components/SkinnedMeshRenderer.cs
+++ b/Prowl.Runtime/Components/SkinnedMeshRenderer.cs
@@ -30,7 +30,7 @@ public class SkinnedMeshRenderer : MonoBehaviour, ISerializable
             }
             else
             {
-                boneTransforms[i] = (t.localToWorldMatrix * this.GameObject.Transform.worldToLocalMatrix).ToFloat();
+                boneTransforms[i] = (t.localToWorldMatrix * GameObject.Transform.worldToLocalMatrix).ToFloat();
             }
         }
     }

--- a/Prowl.Runtime/Debug.cs
+++ b/Prowl.Runtime/Debug.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License. See the LICENSE file in the project root for details.
 
 using System;
-using System.Collections.Generic;
 using System.Diagnostics;
 using System.Reflection;
 using System.Text;

--- a/Prowl.Runtime/GUI/Graphics/UIDrawList.cs
+++ b/Prowl.Runtime/GUI/Graphics/UIDrawList.cs
@@ -73,12 +73,12 @@ namespace Prowl.Runtime.GUI.Graphics
         private uint _currentVertexIndex; // == _vertices.Count
         private int _vertexWritePos; // point within _vertices after each add command (to avoid using the ImVector<> operators too much)
         private int _indexWritePos; // point within _indices after each add command (to avoid using the ImVector<> operators too much)
-        private List<Vector4> _clipRectStack;
-        private List<Texture2D> _textureStack;
-        private List<Vector2> _buildingPath; // current path building
-        private int _currentChannel; // current channel number (0)
-        private int _activeChannels; // number of active channels (1+)
-        private List<UIDrawChannel> _channels; // draw channels for columns API (not resized down so _channelsCount may be smaller than _channels.Count)
+        private readonly List<Vector4> _clipRectStack;
+        private readonly List<Texture2D> _textureStack;
+        private readonly List<Vector2> _buildingPath;   // current path building
+        private int _currentChannel;                    // current channel number (0)
+        private int _activeChannels;                    // number of active channels (1+)
+        private readonly List<UIDrawChannel> _channels; // draw channels for columns API (not resized down so _channelsCount may be smaller than _channels.Count)
         private int _primitiveCount = -10000;
 
         private bool _antiAliasing;

--- a/Prowl.Runtime/GUI/Graphics/UIDrawList.cs
+++ b/Prowl.Runtime/GUI/Graphics/UIDrawList.cs
@@ -104,7 +104,7 @@ namespace Prowl.Runtime.GUI.Graphics
 
         public void AntiAliasing(bool antiAliasing)
         {
-            this._antiAliasing = antiAliasing;
+            _antiAliasing = antiAliasing;
         }
 
 

--- a/Prowl.Runtime/GUI/Graphics/UIDrawList.cs
+++ b/Prowl.Runtime/GUI/Graphics/UIDrawList.cs
@@ -374,7 +374,7 @@ namespace Prowl.Runtime.GUI.Graphics
         {
             Vector2 uv0 = _uv0 ?? new Vector2(0, 0);
             Vector2 uv1 = _uv1 ?? new Vector2(1, 1);
-            Color32 col = _col ?? (Color32)Color.white;
+            Color32 col = _col ?? Color.white;
 
             // FIXME-OPT: This is wasting draw calls.
             bool push_texture_id = _textureStack.Count == 0 || user_texture_id != GetCurrentTexture();
@@ -465,10 +465,10 @@ namespace Prowl.Runtime.GUI.Graphics
 
                         // Add indexes
 
-                        _indices[_indexWritePos++] = (uint)(idx2 + 0); _indices[_indexWritePos++] = (uint)(idx1 + 0); _indices[_indexWritePos++] = (uint)(idx1 + 2);
-                        _indices[_indexWritePos++] = (uint)(idx1 + 2); _indices[_indexWritePos++] = (uint)(idx2 + 2); _indices[_indexWritePos++] = (uint)(idx2 + 0);
-                        _indices[_indexWritePos++] = (uint)(idx2 + 1); _indices[_indexWritePos++] = (uint)(idx1 + 1); _indices[_indexWritePos++] = (uint)(idx1 + 0);
-                        _indices[_indexWritePos++] = (uint)(idx1 + 0); _indices[_indexWritePos++] = (uint)(idx2 + 0); _indices[_indexWritePos++] = (uint)(idx2 + 1);
+                        _indices[_indexWritePos++] = idx2 + 0; _indices[_indexWritePos++] = idx1 + 0; _indices[_indexWritePos++] = idx1 + 2;
+                        _indices[_indexWritePos++] = idx1 + 2; _indices[_indexWritePos++] = idx2 + 2; _indices[_indexWritePos++] = idx2 + 0;
+                        _indices[_indexWritePos++] = idx2 + 1; _indices[_indexWritePos++] = idx1 + 1; _indices[_indexWritePos++] = idx1 + 0;
+                        _indices[_indexWritePos++] = idx1 + 0; _indices[_indexWritePos++] = idx2 + 0; _indices[_indexWritePos++] = idx2 + 1;
                         //_IdxWritePtr += 12;
 
                         idx1 = idx2;
@@ -571,8 +571,8 @@ namespace Prowl.Runtime.GUI.Graphics
                     _vertices[_vertexWritePos++] = new UIVertex(new Vector3(p1.x - dy, p1.y + dx, _primitiveCount), uv, col);
                     //_VtxWritePtr += 4;
 
-                    _indices[_indexWritePos++] = (uint)_currentVertexIndex; _indices[_indexWritePos++] = (uint)(_currentVertexIndex + 1); _indices[_indexWritePos++] = (uint)(_currentVertexIndex + 2);
-                    _indices[_indexWritePos++] = (uint)_currentVertexIndex; _indices[_indexWritePos++] = (uint)(_currentVertexIndex + 2); _indices[_indexWritePos++] = (uint)(_currentVertexIndex + 3);
+                    _indices[_indexWritePos++] = _currentVertexIndex; _indices[_indexWritePos++] = _currentVertexIndex + 1; _indices[_indexWritePos++] = _currentVertexIndex + 2;
+                    _indices[_indexWritePos++] = _currentVertexIndex; _indices[_indexWritePos++] = _currentVertexIndex + 2; _indices[_indexWritePos++] = _currentVertexIndex + 3;
                     //_IdxWritePtr += 6;
                     _currentVertexIndex += 4;
                 }
@@ -604,7 +604,7 @@ namespace Prowl.Runtime.GUI.Graphics
                 uint vtx_outer_idx = _currentVertexIndex + 1;
                 for (int i = 2; i < points_count; i++)
                 {
-                    _indices[_indexWritePos++] = (uint)vtx_inner_idx;
+                    _indices[_indexWritePos++] = vtx_inner_idx;
                     _indices[_indexWritePos++] = (uint)(vtx_inner_idx + (i - 1 << 1));
                     _indices[_indexWritePos++] = (uint)(vtx_inner_idx + (i << 1));
                 }
@@ -662,7 +662,7 @@ namespace Prowl.Runtime.GUI.Graphics
 
                 for (uint i = 2u; i < points_count; i++)
                 {
-                    _indices[_indexWritePos++] = (uint)_currentVertexIndex; _indices[_indexWritePos++] = (uint)(_currentVertexIndex + i - 1u); _indices[_indexWritePos++] = (uint)(_currentVertexIndex + i);
+                    _indices[_indexWritePos++] = _currentVertexIndex; _indices[_indexWritePos++] = _currentVertexIndex + i - 1u; _indices[_indexWritePos++] = _currentVertexIndex + i;
                 }
                 _currentVertexIndex += (uint)vtx_count;
             }
@@ -996,7 +996,7 @@ namespace Prowl.Runtime.GUI.Graphics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private void AddVerts(UIVertex a, UIVertex b, UIVertex c, UIVertex d)
         {
-            uint idx = (uint)_currentVertexIndex;
+            uint idx = _currentVertexIndex;
             _indices[_indexWritePos + 0] = idx; _indices[_indexWritePos + 1] = idx + 1; _indices[_indexWritePos + 2] = idx + 2;
             _indices[_indexWritePos + 3] = idx; _indices[_indexWritePos + 4] = idx + 2; _indices[_indexWritePos + 5] = idx + 3;
 

--- a/Prowl.Runtime/GUI/Graphics/UIDrawListRenderer.cs
+++ b/Prowl.Runtime/GUI/Graphics/UIDrawListRenderer.cs
@@ -105,7 +105,7 @@ namespace Prowl.Runtime.GUI.Graphics
                 new ResourceLayoutElementDescription("MainTexture", ResourceKind.TextureReadOnly, ShaderStages.Fragment)));
             s_textureLayout.Name = "UI Texture Layout";
 
-            Veldrid.GraphicsPipelineDescription pd = new Veldrid.GraphicsPipelineDescription(
+            GraphicsPipelineDescription pd = new GraphicsPipelineDescription(
                 BlendStateDescription.SingleAlphaBlend,
 
                 new DepthStencilStateDescription(false, false, ComparisonKind.Always),

--- a/Prowl.Runtime/GUI/Gui.Animation.cs
+++ b/Prowl.Runtime/GUI/Gui.Animation.cs
@@ -44,7 +44,7 @@ namespace Prowl.Runtime.GUI
 
     public partial class Gui
     {
-        private Dictionary<ulong, BoolAnimation> _boolAnimations = [];
+        private readonly Dictionary<ulong, BoolAnimation> _boolAnimations = [];
 
         /// <inheritdoc cref="AnimateBool(ulong, bool, float, EaseType)"/>
         public float AnimateBool(bool state, float durationIn, float durationOut, EaseType easeIn, EaseType easeOut)

--- a/Prowl.Runtime/GUI/Gui.Core.cs
+++ b/Prowl.Runtime/GUI/Gui.Core.cs
@@ -30,10 +30,10 @@ namespace Prowl.Runtime.GUI
         internal ulong frameCount = 0;
         internal readonly List<LayoutNode> ScollableNodes = new();
 
-        private Dictionary<ulong, LayoutNode.PostLayoutData> _previousLayoutData;
+        private readonly Dictionary<ulong, LayoutNode.PostLayoutData> _previousLayoutData;
         private LayoutNode rootNode;
         private Dictionary<ulong, ulong> _computedNodeHashes;
-        private HashSet<ulong> _createdNodes;
+        private readonly HashSet<ulong> _createdNodes;
         private double uiScale = 1;
         private double lastUIScale = -1;
 
@@ -154,7 +154,7 @@ namespace Prowl.Runtime.GUI
 
         public LayoutNode Node(string stringID, [CallerLineNumber] int intID = 0) => Node(CurrentNode, stringID, intID);
 
-        private Dictionary<ulong, uint> nodeCountPerLine = [];
+        private readonly Dictionary<ulong, uint> nodeCountPerLine = [];
         public LayoutNode Node(LayoutNode parent, string stringID, [CallerLineNumber] int intID = 0)
         {
             ulong storageHash = (ulong)HashCode.Combine(parent.ID, IDStack.Peek(), stringID, intID);

--- a/Prowl.Runtime/GUI/Gui.Interaction.cs
+++ b/Prowl.Runtime/GUI/Gui.Interaction.cs
@@ -125,7 +125,7 @@ namespace Prowl.Runtime.GUI
         {
             if (zIndex == -1)
             {
-                if (!_zInteractableCounter.TryGetValue((int)CurrentZIndex, out int count))
+                if (!_zInteractableCounter.TryGetValue(CurrentZIndex, out int count))
                     count = 0;
 
                 // ZIndex.count - supports up to 1k interactables per Z Index

--- a/Prowl.Runtime/GUI/Gui.Interaction.cs
+++ b/Prowl.Runtime/GUI/Gui.Interaction.cs
@@ -18,9 +18,9 @@ namespace Prowl.Runtime.GUI
 
         private Dictionary<ulong, Interactable> _oldinteractables = [];
         private List<(double, Rect)> _oldblockers = [];
-        private Dictionary<ulong, Interactable> _interactables = [];
-        private List<(double, Rect)> _blockers = [];
-        private Dictionary<int, int> _zInteractableCounter = [];
+        private readonly Dictionary<ulong, Interactable> _interactables = [];
+        private readonly List<(double, Rect)> _blockers = [];
+        private readonly Dictionary<int, int> _zInteractableCounter = [];
 
 
         private void StartInteractionFrame()
@@ -266,7 +266,7 @@ namespace Prowl.Runtime.GUI
         public Rect Rect => _rect;
         public double ZIndex => zIndex;
 
-        private Gui _gui;
+        private readonly Gui _gui;
         internal ulong _id;
         internal Rect _rect;
         internal double zIndex;

--- a/Prowl.Runtime/GUI/Gui.Interaction.cs
+++ b/Prowl.Runtime/GUI/Gui.Interaction.cs
@@ -44,7 +44,7 @@ namespace Prowl.Runtime.GUI
             _oldinteractables.Clear();
             _oldblockers.Clear();
             _oldinteractables = new(_interactables);
-            _oldblockers = new(_blockers);
+            _oldblockers = [.._blockers];
             _interactables.Clear();
             _blockers.Clear();
             _zInteractableCounter.Clear();

--- a/Prowl.Runtime/GUI/Gui.State.cs
+++ b/Prowl.Runtime/GUI/Gui.State.cs
@@ -12,7 +12,7 @@ namespace Prowl.Runtime.GUI
     {
         public int CurrentZIndex => CurrentNode.ZIndex;
 
-        private static Dictionary<ulong, Hashtable> _storage = [];
+        private static readonly Dictionary<ulong, Hashtable> _storage = [];
 
         /// <summary>
         /// Set the ZIndex for the current node

--- a/Prowl.Runtime/GUI/Gui.State.cs
+++ b/Prowl.Runtime/GUI/Gui.State.cs
@@ -32,7 +32,7 @@ namespace Prowl.Runtime.GUI
         public void SetGlobalStorage<T>(string key, T value) where T : unmanaged => SetNodeStorage(rootNode, key, value);
 
         /// <summary> Get a value from the current node's storage </summary>
-        public T GetNodeStorage<T>(string key, T defaultValue = default) where T : unmanaged => GetNodeStorage<T>(CurrentNode, key, defaultValue);
+        public T GetNodeStorage<T>(string key, T defaultValue = default) where T : unmanaged => GetNodeStorage(CurrentNode, key, defaultValue);
 
         /// <summary> Get a value from the current node's storage </summary>
         public T GetNodeStorage<T>(LayoutNode node, string key, T defaultValue = default) where T : unmanaged

--- a/Prowl.Runtime/GUI/GuiDraw2D.cs
+++ b/Prowl.Runtime/GUI/GuiDraw2D.cs
@@ -16,9 +16,9 @@ namespace Prowl.Runtime.GUI
 
         private int currentZIndex => _gui.CurrentZIndex;
 
-        private Gui _gui;
+        private readonly Gui _gui;
         private bool _AntiAliasing;
-        List<UIDrawList> drawListsOrdered = new();
+        readonly List<UIDrawList> drawListsOrdered = new();
 
         public GuiDraw2D(Gui gui, bool antiAliasing)
         {

--- a/Prowl.Runtime/GUI/GuiDraw3D.cs
+++ b/Prowl.Runtime/GUI/GuiDraw3D.cs
@@ -109,10 +109,12 @@ namespace Prowl.Runtime.GUI
                 Vector2 direction = (arrowEnd - arrowStart).normalized;
                 Vector2 cross = new Vector2(-direction.y, direction.x) * stroke.Thickness / 2.0f;
 
-                List<Vector2> points = new List<Vector2>();
-                points.Add(arrowStart - cross);
-                points.Add(arrowStart + cross);
-                points.Add(arrowEnd);
+                List<Vector2> points =
+                [
+                    arrowStart - cross,
+                    arrowStart + cross,
+                    arrowEnd
+                ];
 
                 _gui.Draw2D.DrawList.AddConvexPolyFilled(points, 3, stroke.Color);
             }
@@ -243,8 +245,9 @@ namespace Prowl.Runtime.GUI
         }
 
         // Define the eight corners of the cube
-        static readonly Vector3[] cubeCorners = {
-                new Vector3(-0.5, -0.5, -0.5), // Bottom-back-left
+        static readonly Vector3[] cubeCorners =
+        [
+            new Vector3(-0.5, -0.5, -0.5), // Bottom-back-left
                 new Vector3(0.5,  -0.5, -0.5),  // Bottom-back-right
                 new Vector3(0.5,  -0.5, 0.5),   // Bottom-front-right
                 new Vector3(-0.5, -0.5, 0.5),  // Bottom-front-left
@@ -252,14 +255,15 @@ namespace Prowl.Runtime.GUI
                 new Vector3(0.5,  0.5,  -0.5),   // Top-back-right
                 new Vector3(0.5,  0.5,  0.5),    // Top-front-right
                 new Vector3(-0.5, 0.5,  0.5)    // Top-front-left
-            };
+        ];
 
         // Define the cube edges
-        int[] cubeEdges = {
-                0, 1, 1, 2, 2, 3, 3, 0, // Bottom face
+        int[] cubeEdges =
+        [
+            0, 1, 1, 2, 2, 3, 3, 0, // Bottom face
                 4, 5, 5, 6, 6, 7, 7, 4, // Top face
                 0, 4, 1, 5, 2, 6, 3, 7  // Vertical edges
-            };
+        ];
 
         public void Cube(double size, Stroke3D stroke)
         {
@@ -339,13 +343,13 @@ namespace Prowl.Runtime.GUI
             double halfSize = size / 2.0;
 
             // Define the four corners of the quad
-            Vector3[] quadCorners = new Vector3[]
-            {
+            Vector3[] quadCorners =
+            [
                 new Vector3((float)-halfSize, 0.0f, (float)-halfSize), // Bottom-left
                 new Vector3((float)halfSize, 0.0f, (float)-halfSize),  // Bottom-right
                 new Vector3((float)halfSize, 0.0f, (float)halfSize),   // Top-right
                 new Vector3((float)-halfSize, 0.0f, (float)halfSize)   // Top-left
-            };
+            ];
 
             // Convert to screen coordinates and add to the points buffer
             foreach (var corner in quadCorners)

--- a/Prowl.Runtime/GUI/GuiDraw3D.cs
+++ b/Prowl.Runtime/GUI/GuiDraw3D.cs
@@ -31,10 +31,10 @@ namespace Prowl.Runtime.GUI
 
         private readonly Gui _gui = gui;
 
-        private Stack<Rect> _viewports = new Stack<Rect>();
+        private readonly Stack<Rect> _viewports = new Stack<Rect>();
         private Rect _viewport => _viewports.Peek();
 
-        private Stack<Matrix4x4> _mvps = new Stack<Matrix4x4>();
+        private readonly Stack<Matrix4x4> _mvps = new Stack<Matrix4x4>();
         private Matrix4x4 _mvp => _mvps.Peek();
 
         private bool hasViewport => _viewports.Count > 0;
@@ -258,7 +258,7 @@ namespace Prowl.Runtime.GUI
         ];
 
         // Define the cube edges
-        int[] cubeEdges =
+        readonly int[] cubeEdges =
         [
             0, 1, 1, 2, 2, 3, 3, 0, // Bottom face
                 4, 5, 5, 6, 6, 7, 7, 4, // Top face

--- a/Prowl.Runtime/GUI/Layout/LayoutNode.Core.cs
+++ b/Prowl.Runtime/GUI/Layout/LayoutNode.Core.cs
@@ -338,7 +338,7 @@ namespace Prowl.Runtime.GUI.Layout
                             Gui.layoutDirty = true;
                         }
                     }
-                    else if (interact.IsHovered()) Gui.Draw2D.DrawRectFilled(barRect, style.HoveredColor, (float)style.Roundness);
+                    else if (interact.IsHovered()) Gui.Draw2D.DrawRectFilled(barRect, style.HoveredColor, style.Roundness);
                     else Gui.Draw2D.DrawRectFilled(barRect, style.BGColor * 1.8f, style.Roundness);
 
                     if (Gui.IsPointerHovering(LayoutData.InnerRect) && Gui.PointerWheel != 0)
@@ -383,7 +383,7 @@ namespace Prowl.Runtime.GUI.Layout
                             Gui.layoutDirty = true;
                         }
                     }
-                    else if (interact.IsHovered()) Gui.Draw2D.DrawRectFilled(barRect, style.HoveredColor, (float)style.Roundness);
+                    else if (interact.IsHovered()) Gui.Draw2D.DrawRectFilled(barRect, style.HoveredColor, style.Roundness);
                     else Gui.Draw2D.DrawRectFilled(barRect, style.BGColor * 1.8f, style.Roundness);
 
                     //if (Gui.IsPointerHovering(LayoutData.InnerRect) && Gui.PointerWheel != 0)
@@ -547,20 +547,20 @@ namespace Prowl.Runtime.GUI.Layout
         {
             ulong hash = 17;
             hash = hash * 23 + ID;
-            hash = hash * 23 + (ulong)_positionX.GetHashCode64();
-            hash = hash * 23 + (ulong)_positionY.GetHashCode64();
-            hash = hash * 23 + (ulong)_width.GetHashCode64();
-            hash = hash * 23 + (ulong)_height.GetHashCode64();
-            hash = hash * 23 + (ulong)_maxWidth.GetHashCode64();
-            hash = hash * 23 + (ulong)_maxHeight.GetHashCode64();
-            hash = hash * 23 + (ulong)_marginLeft.GetHashCode64();
-            hash = hash * 23 + (ulong)_marginRight.GetHashCode64();
-            hash = hash * 23 + (ulong)_marginTop.GetHashCode64();
-            hash = hash * 23 + (ulong)_marginBottom.GetHashCode64();
-            hash = hash * 23 + (ulong)_paddingLeft.GetHashCode64();
-            hash = hash * 23 + (ulong)_paddingRight.GetHashCode64();
-            hash = hash * 23 + (ulong)_paddingTop.GetHashCode64();
-            hash = hash * 23 + (ulong)_paddingBottom.GetHashCode64();
+            hash = hash * 23 + _positionX.GetHashCode64();
+            hash = hash * 23 + _positionY.GetHashCode64();
+            hash = hash * 23 + _width.GetHashCode64();
+            hash = hash * 23 + _height.GetHashCode64();
+            hash = hash * 23 + _maxWidth.GetHashCode64();
+            hash = hash * 23 + _maxHeight.GetHashCode64();
+            hash = hash * 23 + _marginLeft.GetHashCode64();
+            hash = hash * 23 + _marginRight.GetHashCode64();
+            hash = hash * 23 + _marginTop.GetHashCode64();
+            hash = hash * 23 + _marginBottom.GetHashCode64();
+            hash = hash * 23 + _paddingLeft.GetHashCode64();
+            hash = hash * 23 + _paddingRight.GetHashCode64();
+            hash = hash * 23 + _paddingTop.GetHashCode64();
+            hash = hash * 23 + _paddingBottom.GetHashCode64();
             hash = hash * 23 + (ulong)_ignore.GetHashCode();
             hash = hash * 23 + (ulong)_fitContentX.GetHashCode();
             hash = hash * 23 + (ulong)_fitContentXPerc.GetHashCode();

--- a/Prowl.Runtime/GUI/TextEdit/StbTextEdit.cs
+++ b/Prowl.Runtime/GUI/TextEdit/StbTextEdit.cs
@@ -894,7 +894,7 @@ namespace Prowl.Runtime.GUI.TextEdit
                         num = 999 - redo_char_point;
 
                         Array.Copy(undo_char, redo_char_point - n, undo_char, redo_char_point, num);
-                        for (i = (int)redo_point; i < k; ++i)
+                        for (i = redo_point; i < k; ++i)
                             if (undo_rec[i].char_storage >= 0)
                                 undo_rec[i].char_storage += n;
                     }

--- a/Prowl.Runtime/GUI/Widgets/Gizmo/GizmoUtils.cs
+++ b/Prowl.Runtime/GUI/Widgets/Gizmo/GizmoUtils.cs
@@ -259,12 +259,12 @@ namespace Prowl.Runtime.GUI
 
             using (_gizmo._gui.Draw3D.Matrix(transform * _gizmo.ViewProjection))
             {
-                var color3 = GizmoUtils.GizmoColor(_gizmo, focused, direction);
+                var color3 = GizmoColor(_gizmo, focused, direction);
 
-                var scale = GizmoUtils.PlaneSize(_gizmo) * 0.5f;
-                var bitangent = GizmoUtils.PlaneBitangent(direction) * scale;
-                var tangent = GizmoUtils.PlaneTangent(direction) * scale;
-                var origin3 = GizmoUtils.PlaneLocalOrigin(_gizmo, direction);
+                var scale = PlaneSize(_gizmo) * 0.5f;
+                var bitangent = PlaneBitangent(direction) * scale;
+                var tangent = PlaneTangent(direction) * scale;
+                var origin3 = PlaneLocalOrigin(_gizmo, direction);
 
                 var v1 = origin3 - bitangent - tangent;
                 var v2 = origin3 + bitangent - tangent;
@@ -297,8 +297,8 @@ namespace Prowl.Runtime.GUI
 
             using (_gizmo._gui.Draw3D.Matrix(transform * _gizmo.ViewProjection))
             {
-                var color2 = GizmoUtils.GizmoColor(_gizmo, focused, GizmoDirection.View);
-                _gizmo._gui.Draw3D.Circle(GizmoUtils.InnerCircleRadius(_gizmo), new Stroke3D { Color = color2, Thickness = _gizmo.StrokeWidth });
+                var color2 = GizmoColor(_gizmo, focused, GizmoDirection.View);
+                _gizmo._gui.Draw3D.Circle(InnerCircleRadius(_gizmo), new Stroke3D { Color = color2, Thickness = _gizmo.StrokeWidth });
                 return transform;
             }
         }
@@ -322,8 +322,8 @@ namespace Prowl.Runtime.GUI
 
             using (_gizmo._gui.Draw3D.Matrix(transform * _gizmo.ViewProjection))
             {
-                var color2 = GizmoUtils.GizmoColor(_gizmo, focused, GizmoDirection.View);
-                _gizmo._gui.Draw3D.Quad(GizmoUtils.InnerCircleRadius(_gizmo), new Stroke3D { Color = color2, Thickness = _gizmo.StrokeWidth });
+                var color2 = GizmoColor(_gizmo, focused, GizmoDirection.View);
+                _gizmo._gui.Draw3D.Quad(InnerCircleRadius(_gizmo), new Stroke3D { Color = color2, Thickness = _gizmo.StrokeWidth });
                 return transform;
             }
         }
@@ -335,8 +335,8 @@ namespace Prowl.Runtime.GUI
 
             using (_gizmo._gui.Draw3D.Matrix(transform * _gizmo.ViewProjection))
             {
-                var color = GizmoUtils.GizmoColor(_gizmo, focused, direction);
-                var normal = GizmoUtils.GizmoLocalNormal(_gizmo, direction);
+                var color = GizmoColor(_gizmo, focused, direction);
+                var normal = GizmoLocalNormal(_gizmo, direction);
 
                 (Vector3 start, Vector3 end, double length) = ArrowParams(_gizmo, normal, mode);
 
@@ -376,7 +376,7 @@ namespace Prowl.Runtime.GUI
             double length;
             if (isTranslate && overlapping)
             {
-                start = direction * (width * 0.5f + GizmoUtils.InnerCircleRadius(_gizmo));
+                start = direction * (width * 0.5f + InnerCircleRadius(_gizmo));
                 length = gizmoSize - start.magnitude;
                 length -= width * 2.0;
                 //if config.modes.len() > 1 {

--- a/Prowl.Runtime/GUI/Widgets/Gizmo/TransformGizmo.cs
+++ b/Prowl.Runtime/GUI/Widgets/Gizmo/TransformGizmo.cs
@@ -110,7 +110,7 @@ namespace Prowl.Runtime.GUI
         internal Matrix4x4 ModelViewProjection;
         internal Matrix4x4 InverseModelViewProjection;
 
-        private List<ISubGizmo> _subGizmos = [];
+        private readonly List<ISubGizmo> _subGizmos = [];
         internal Gui _gui;
         internal TransformGizmoMode mode;
 

--- a/Prowl.Runtime/GUI/Widgets/Gizmo/TranslationSubGizmo.cs
+++ b/Prowl.Runtime/GUI/Widgets/Gizmo/TranslationSubGizmo.cs
@@ -19,9 +19,9 @@ namespace Prowl.Runtime.GUI
             public double StartAxisAngle, StartRotationAngle, LastRotationAngle, CurrentDelta;
         }
 
-        private RotationParams _params;
+        private readonly RotationParams _params;
         private RotationState _state;
-        private TransformGizmo _gizmo;
+        private readonly TransformGizmo _gizmo;
         internal bool focused;
 
         public RotationSubGizmo(TransformGizmo gizmo, RotationParams parameters)
@@ -323,9 +323,9 @@ namespace Prowl.Runtime.GUI
             public Vector3 ScaleDelta;
         }
 
-        private ScaleParams _params;
+        private readonly ScaleParams _params;
         private ScaleState _state;
-        private TransformGizmo _gizmo;
+        private readonly TransformGizmo _gizmo;
         internal bool focused;
 
         public ScaleSubGizmo(TransformGizmo gizmo, ScaleParams parameters)
@@ -473,9 +473,9 @@ namespace Prowl.Runtime.GUI
             public Vector3 StartPoint, LastPoint, CurrentDelta;
         }
 
-        private TranslationParams _params;
+        private readonly TranslationParams _params;
         private TranslationState _state;
-        private TransformGizmo _gizmo;
+        private readonly TransformGizmo _gizmo;
         internal bool focused;
 
         public TranslationSubGizmo(TransformGizmo gizmo, TranslationParams parameters)

--- a/Prowl.Runtime/GUI/Widgets/Gizmo/TranslationSubGizmo.cs
+++ b/Prowl.Runtime/GUI/Widgets/Gizmo/TranslationSubGizmo.cs
@@ -152,12 +152,11 @@ namespace Prowl.Runtime.GUI
                         (startAngle2, endAngle2) = (endAngle2, startAngle2);
                     }
 
-                    _gizmo._gui.Draw3D.Polyline(new[]
-                    {
-                    new Vector3(Math.Cos(startAngle) * radius, 0, Math.Sin(startAngle) * radius),
+                    _gizmo._gui.Draw3D.Polyline([
+                        new Vector3(Math.Cos(startAngle) * radius, 0, Math.Sin(startAngle) * radius),
                     Vector3.zero,
                     new Vector3(Math.Cos(endAngle) * radius, 0, Math.Sin(endAngle) * radius)
-                }, stroke);
+                    ], stroke);
 
                     var w = stroke;
                     if (fullCircles > 0)

--- a/Prowl.Runtime/GUI/Widgets/Gizmo/TranslationSubGizmo.cs
+++ b/Prowl.Runtime/GUI/Widgets/Gizmo/TranslationSubGizmo.cs
@@ -556,7 +556,7 @@ namespace Prowl.Runtime.GUI
             var translationDelta = newPoint - _state.LastPoint;
             var totalTranslation = newPoint - _state.StartPoint;
 
-            if (_gizmo.Orientation == TransformGizmo.GizmoOrientation.Local)
+            if (_gizmo.Orientation == GizmoOrientation.Local)
             {
                 //var inverseRotation = Quaternion.Inverse(_gizmo.Rotation);
                 //translationDelta = Vector4.Transform(new Vector4(translationDelta, 0), inverseRotation).xyz;

--- a/Prowl.Runtime/GUI/Widgets/Gizmo/ViewManipulatorGizmo.cs
+++ b/Prowl.Runtime/GUI/Widgets/Gizmo/ViewManipulatorGizmo.cs
@@ -8,7 +8,7 @@ namespace Prowl.Runtime.GUI.Widgets.Gizmo
     public class ViewManipulatorGizmo
     {
 
-        private Gui _gui;
+        private readonly Gui _gui;
         private Rect _gizmoRect;
 
         private Matrix4x4 _view;

--- a/Prowl.Runtime/GUI/Widgets/Gizmo/ViewManipulatorGizmo.cs
+++ b/Prowl.Runtime/GUI/Widgets/Gizmo/ViewManipulatorGizmo.cs
@@ -181,7 +181,7 @@ namespace Prowl.Runtime.GUI.Widgets.Gizmo
                         {
                             var hovCol = Color.white;
                             hovCol.a = 0.25f;
-                            _gui.Draw2D.DrawList.AddConvexPolyFilled(screenPoints, screenPoints.Count, (Color32)hovCol);
+                            _gui.Draw2D.DrawList.AddConvexPolyFilled(screenPoints, screenPoints.Count, hovCol);
                             //_gui.DrawList.AddPolyline(screenPoints, screenPoints.Count, hovCol, true, 1, true);
                             hovering = true;
                             axis = faceNormal;

--- a/Prowl.Runtime/GUI/Widgets/Gui.InputField.cs
+++ b/Prowl.Runtime/GUI/Widgets/Gui.InputField.cs
@@ -190,7 +190,7 @@ namespace Prowl.Runtime.GUI
                 searches_input_ptr[0] = text_begin + stb.CursorIndex;
                 searches_input_ptr[1] = -1;
                 int searches_remaining = 1;
-                int[] searches_result_line_number = { -1, -999 };
+                int[] searches_result_line_number = [-1, -999];
                 if (stb.SelectStart != stb.SelectEnd)
                 {
                     searches_input_ptr[1] = text_begin + MathD.Min(stb.SelectStart, stb.SelectEnd);

--- a/Prowl.Runtime/GUI/Widgets/Gui.InputField.cs
+++ b/Prowl.Runtime/GUI/Widgets/Gui.InputField.cs
@@ -102,7 +102,7 @@ namespace Prowl.Runtime.GUI
                         render_pos.y -= g.CurrentNode.VScroll;
 
                     Color32 colb = style.TextColor;
-                    g.Draw2D.DrawList.AddText(font, (float)fontsize, render_pos, colb, value, 0, value.Length, 0.0f, null);
+                    g.Draw2D.DrawList.AddText(font, fontsize, render_pos, colb, value, 0, value.Length, 0.0f, null);
                 }
                 g.Draw2D.PopClip();
 
@@ -265,7 +265,7 @@ namespace Prowl.Runtime.GUI
             if ((Flags & InputFieldFlags.OnlyDisplay) == InputFieldFlags.OnlyDisplay)
             {
                 Color32 colb = style.TextColor;
-                g.Draw2D.DrawList.AddText(font, (float)fontsize, render_pos - render_scroll, colb, stb.Text, 0, stb.Text.Length, 0.0f, (is_multiline ? null : (Vector4?)clip_rect));
+                g.Draw2D.DrawList.AddText(font, fontsize, render_pos - render_scroll, colb, stb.Text, 0, stb.Text.Length, 0.0f, (is_multiline ? null : (Vector4?)clip_rect));
                 return false;
             }
 
@@ -307,7 +307,7 @@ namespace Prowl.Runtime.GUI
 
 
             Color32 col = style.TextColor;
-            g.Draw2D.DrawList.AddText(font, (float)fontsize, render_pos - render_scroll, col, stb.Text, 0, stb.Text.Length, 0.0f, (is_multiline ? null : (Vector4?)clip_rect));
+            g.Draw2D.DrawList.AddText(font, fontsize, render_pos - render_scroll, col, stb.Text, 0, stb.Text.Length, 0.0f, (is_multiline ? null : (Vector4?)clip_rect));
             //g.DrawText(font, fontsize, Text, render_pos - render_scroll, Color.black, 0, stb.CurLenA, 0.0f, (is_multiline ? null : (ImVec4?)clip_rect));
 
             // Draw blinking cursor

--- a/Prowl.Runtime/GUI/Widgets/Gui.InputField.cs
+++ b/Prowl.Runtime/GUI/Widgets/Gui.InputField.cs
@@ -58,7 +58,7 @@ namespace Prowl.Runtime.GUI
         public bool InputField(string ID, ref string value, uint maxLength, InputFieldFlags flags, Offset x, Offset y, Size width, Size? height = null, WidgetStyle? inputstyle = null, bool invisible = false)
         {
             var style = inputstyle ?? new WidgetStyle(30);
-            var g = Gui.ActiveGUI;
+            var g = ActiveGUI;
             bool multiline = ((flags & InputFieldFlags.Multiline) == InputFieldFlags.Multiline);
             Size h = (multiline ? style.FontSize * 8 : style.ItemSize);
             if (height != null) h = height.Value;
@@ -132,7 +132,7 @@ namespace Prowl.Runtime.GUI
 
         internal static bool OnProcess(WidgetStyle style, Interactable interact, ref string Text, uint MaxLength, InputFieldFlags Flags)
         {
-            var g = Gui.ActiveGUI;
+            var g = ActiveGUI;
             var font = style.Font.IsAvailable ? style.Font.Res : Font.DefaultFont;
             var fontsize = style.FontSize;
             var render_pos = new Vector2(g.CurrentNode.LayoutData.InnerRect.x, g.CurrentNode.LayoutData.InnerRect.y);
@@ -340,7 +340,7 @@ namespace Prowl.Runtime.GUI
 
         private static void HandleKeyEvent(StbTextEditState stb, uint MaxLength, InputFieldFlags Flags)
         {
-            var g = Gui.ActiveGUI;
+            var g = ActiveGUI;
             var KeyCode = g.KeyCode;
             if (KeyCode == Key.Unknown)
             {
@@ -554,7 +554,7 @@ namespace Prowl.Runtime.GUI
 
         private static void HandleMouseEvent(StbTextEditState stb)
         {
-            var g = Gui.ActiveGUI;
+            var g = ActiveGUI;
             var Pos = g.PointerPos - g.CurrentNode.LayoutData.InnerRect.Position;
             Pos.x -= 5; // Account for padding in text rendering
             Pos.x += stb.ScrollX;

--- a/Prowl.Runtime/GUI/Widgets/Gui.SimpleWidgets.cs
+++ b/Prowl.Runtime/GUI/Widgets/Gui.SimpleWidgets.cs
@@ -24,7 +24,7 @@ namespace Prowl.Runtime.GUI
             ItemIndex = Math.Clamp(ItemIndex, 0, Items.Length - 1);
 
             var style = inputstyle ?? new(30);
-            var g = Gui.ActiveGUI;
+            var g = ActiveGUI;
             using (g.Node(ID).Left(x).Top(y).Width(width).Height(height).Padding(2).Enter())
             {
                 Interactable interact = g.GetInteractable();

--- a/Prowl.Runtime/GameObject/GameObject.cs
+++ b/Prowl.Runtime/GameObject/GameObject.cs
@@ -27,7 +27,7 @@ public class GameObject : EngineObject, ISerializable
 
     private List<MonoBehaviour> _components = new();
 
-    private MultiValueDictionary<Type, MonoBehaviour> _componentCache = new();
+    private readonly MultiValueDictionary<Type, MonoBehaviour> _componentCache = new();
 
     private bool _enabled = true;
     private bool _enabledInHierarchy = true;

--- a/Prowl.Runtime/GameObject/GameObject.cs
+++ b/Prowl.Runtime/GameObject/GameObject.cs
@@ -127,7 +127,7 @@ public class GameObject : EngineObject, ISerializable
 
     public bool IsChildOf(GameObject parent)
     {
-        if (this.InstanceID == parent.InstanceID) return false; // Not a child their the same object
+        if (InstanceID == parent.InstanceID) return false; // Not a child their the same object
 
         GameObject child = this;
         while (child != null)
@@ -155,9 +155,9 @@ public class GameObject : EngineObject, ISerializable
 
         if (worldPositionStays)
         {
-            worldPosition = this.Transform.position;
-            worldRotation = this.Transform.rotation;
-            worldScale = this.Transform.GetWorldRotationAndScale();
+            worldPosition = Transform.position;
+            worldRotation = Transform.rotation;
+            worldScale = Transform.GetWorldRotationAndScale();
         }
 
         if (NewParent != _parent)
@@ -176,18 +176,18 @@ public class GameObject : EngineObject, ISerializable
         {
             if (_parent != null)
             {
-                this.Transform.localPosition = _parent.Transform.InverseTransformPoint(worldPosition);
-                this.Transform.localRotation = Quaternion.NormalizeSafe(Quaternion.Inverse(_parent.Transform.rotation) * worldRotation);
+                Transform.localPosition = _parent.Transform.InverseTransformPoint(worldPosition);
+                Transform.localRotation = Quaternion.NormalizeSafe(Quaternion.Inverse(_parent.Transform.rotation) * worldRotation);
             }
             else
             {
-                this.Transform.localPosition = worldPosition;
-                this.Transform.localRotation = Quaternion.NormalizeSafe(worldRotation);
+                Transform.localPosition = worldPosition;
+                Transform.localRotation = Quaternion.NormalizeSafe(worldRotation);
             }
 
-            this.Transform.localScale = Vector3.one;
-            Matrix4x4 inverseRS = this.Transform.GetWorldRotationAndScale().Invert() * worldScale;
-            this.Transform.localScale = new Vector3(inverseRS[0, 0], inverseRS[1, 1], inverseRS[2, 2]);
+            Transform.localScale = Vector3.one;
+            Matrix4x4 inverseRS = Transform.GetWorldRotationAndScale().Invert() * worldScale;
+            Transform.localScale = new Vector3(inverseRS[0, 0], inverseRS[1, 1], inverseRS[2, 2]);
         }
 
         HierarchyStateChanged();
@@ -233,7 +233,7 @@ public class GameObject : EngineObject, ISerializable
     /// <summary> Recursive function to check if this GameObject is a parent of another GameObject </summary>
     public bool IsParentOf(GameObject go)
     {
-        if (go.parent?.InstanceID == this.InstanceID)
+        if (go.parent?.InstanceID == InstanceID)
             return true;
 
         foreach (var child in children)

--- a/Prowl.Runtime/GameObject/MonoBehaviour.cs
+++ b/Prowl.Runtime/GameObject/MonoBehaviour.cs
@@ -104,7 +104,7 @@ public abstract class MonoBehaviour : EngineObject
 #warning "Need to apply this to Component Deletion in Inspector, to make sure not to delete dependant Components"
         if (_go.IsComponentRequired(this, out Type dependentType))
         {
-            Debug.LogError("Can't remove " + this.GetType().Name + " because " + dependentType.Name + " depends on it");
+            Debug.LogError("Can't remove " + GetType().Name + " because " + dependentType.Name + " depends on it");
             return false;
         }
         return true;

--- a/Prowl.Runtime/GameObject/MonoBehaviour.cs
+++ b/Prowl.Runtime/GameObject/MonoBehaviour.cs
@@ -140,7 +140,7 @@ public abstract class MonoBehaviour : EngineObject
         Start();
     }
 
-    private static Dictionary<Type, bool> CachedExecuteAlways = new();
+    private static readonly Dictionary<Type, bool> CachedExecuteAlways = new();
     internal void Do(Action action)
     {
         bool always;

--- a/Prowl.Runtime/GameObject/TagLayerManager.cs
+++ b/Prowl.Runtime/GameObject/TagLayerManager.cs
@@ -69,7 +69,7 @@ public class TagLayerManager : ScriptableSingleton<TagLayerManager>
     public static string GetLayer(byte index)
     {
         if (index < 0 || index >= Instance.layers.Length)
-            throw new System.ArgumentOutOfRangeException(nameof(index), index, "Layer index is out of range.");
+            throw new ArgumentOutOfRangeException(nameof(index), index, "Layer index is out of range.");
         return Instance.layers[index];
     }
 

--- a/Prowl.Runtime/GameObject/TagLayerManager.cs
+++ b/Prowl.Runtime/GameObject/TagLayerManager.cs
@@ -13,16 +13,15 @@ namespace Prowl.Runtime;
 public class TagLayerManager : ScriptableSingleton<TagLayerManager>
 {
     public List<string> tags =
-        new List<string>
-        {
-            "Untagged",
-            "Main Camera",
-            "Player",
-            "Editor Only",
-            "Re-spawn",
-            "Finish",
-            "Game Controller",
-        };
+    [
+        "Untagged",
+        "Main Camera",
+        "Player",
+        "Editor Only",
+        "Re-spawn",
+        "Finish",
+        "Game Controller"
+    ];
 
     public string[] layers =
         [

--- a/Prowl.Runtime/InputManagement/DefaultInputHandler.cs
+++ b/Prowl.Runtime/InputManagement/DefaultInputHandler.cs
@@ -22,11 +22,11 @@ public class DefaultInputHandler : IInputHandler, IDisposable
         Unset
     }
 
-    private Dictionary<Key, InputState> keyState = new();
-    private Dictionary<Key, InputState> newKeyState = new();
+    private readonly Dictionary<Key, InputState> keyState = new();
+    private readonly Dictionary<Key, InputState> newKeyState = new();
 
-    private Dictionary<MouseButton, InputState> buttonState = new();
-    private Dictionary<MouseButton, InputState> newButtonState = new();
+    private readonly Dictionary<MouseButton, InputState> buttonState = new();
+    private readonly Dictionary<MouseButton, InputState> newButtonState = new();
 
     private Vector2Int _currentMousePos;
     private Vector2Int _prevMousePos;

--- a/Prowl.Runtime/Math/BoundingFrustum.cs
+++ b/Prowl.Runtime/Math/BoundingFrustum.cs
@@ -216,7 +216,7 @@ namespace Prowl.Runtime
 
         public void GetCorners(Vector3[] corners)
         {
-            if (corners == null) throw new ArgumentNullException(nameof(corners));
+            ArgumentNullException.ThrowIfNull(corners);
             if (corners.Length < CornerCount) throw new ArgumentOutOfRangeException(nameof(corners));
 
             this.corners.CopyTo(corners, 0);

--- a/Prowl.Runtime/Math/BoundingFrustum.cs
+++ b/Prowl.Runtime/Math/BoundingFrustum.cs
@@ -216,8 +216,8 @@ namespace Prowl.Runtime
 
         public void GetCorners(Vector3[] corners)
         {
-            if (corners == null) throw new ArgumentNullException("corners");
-            if (corners.Length < CornerCount) throw new ArgumentOutOfRangeException("corners");
+            if (corners == null) throw new ArgumentNullException(nameof(corners));
+            if (corners.Length < CornerCount) throw new ArgumentOutOfRangeException(nameof(corners));
 
             this.corners.CopyTo(corners, 0);
         }

--- a/Prowl.Runtime/Math/BoundingFrustum.cs
+++ b/Prowl.Runtime/Math/BoundingFrustum.cs
@@ -56,9 +56,9 @@ namespace Prowl.Runtime
 
         public BoundingFrustum(Matrix4x4 value)
         {
-            this.matrix = value;
-            this.CreatePlanes();
-            this.CreateCorners();
+            matrix = value;
+            CreatePlanes();
+            CreateCorners();
         }
 
         #endregion Public Constructors
@@ -68,43 +68,43 @@ namespace Prowl.Runtime
 
         public Matrix4x4 Matrix
         {
-            get { return this.matrix; }
+            get { return matrix; }
             set
             {
-                this.matrix = value;
-                this.CreatePlanes();    // FIXME: The odds are the planes will be used a lot more often than the matrix
-                this.CreateCorners();   // is updated, so this should help performance. I hope ;)
+                matrix = value;
+                CreatePlanes();    // FIXME: The odds are the planes will be used a lot more often than the matrix
+                CreateCorners();   // is updated, so this should help performance. I hope ;)
             }
         }
 
         public Plane Near
         {
-            get { return this.planes[0]; }
+            get { return planes[0]; }
         }
 
         public Plane Far
         {
-            get { return this.planes[1]; }
+            get { return planes[1]; }
         }
 
         public Plane Left
         {
-            get { return this.planes[2]; }
+            get { return planes[2]; }
         }
 
         public Plane Right
         {
-            get { return this.planes[3]; }
+            get { return planes[3]; }
         }
 
         public Plane Top
         {
-            get { return this.planes[4]; }
+            get { return planes[4]; }
         }
 
         public Plane Bottom
         {
-            get { return this.planes[5]; }
+            get { return planes[5]; }
         }
 
         #endregion Public Properties
@@ -114,11 +114,11 @@ namespace Prowl.Runtime
 
         public static bool operator ==(BoundingFrustum a, BoundingFrustum b)
         {
-            if (object.Equals(a, null))
-                return (object.Equals(b, null));
+            if (Equals(a, null))
+                return (Equals(b, null));
 
-            if (object.Equals(b, null))
-                return (object.Equals(a, null));
+            if (Equals(b, null))
+                return (Equals(a, null));
 
             return a.matrix == (b.matrix);
         }
@@ -131,7 +131,7 @@ namespace Prowl.Runtime
         public ContainmentType Contains(Bounds box)
         {
             var result = default(ContainmentType);
-            this.Contains(ref box, out result);
+            Contains(ref box, out result);
             return result;
         }
 
@@ -141,7 +141,7 @@ namespace Prowl.Runtime
             for (var i = 0; i < PlaneCount; ++i)
             {
                 var planeIntersectionType = default(PlaneIntersectionType);
-                box.Intersects(ref this.planes[i], out planeIntersectionType);
+                box.Intersects(ref planes[i], out planeIntersectionType);
                 switch (planeIntersectionType)
                 {
                     case PlaneIntersectionType.Front:
@@ -180,7 +180,7 @@ namespace Prowl.Runtime
         public ContainmentType Contains(Vector3 point)
         {
             var result = default(ContainmentType);
-            this.Contains(ref point, out result);
+            Contains(ref point, out result);
             return result;
         }
 
@@ -189,7 +189,7 @@ namespace Prowl.Runtime
             for (var i = 0; i < PlaneCount; ++i)
             {
                 // TODO: we might want to inline this for performance reasons
-                if (this.planes[i].GetSide(point))
+                if (planes[i].GetSide(point))
                 {
                     result = ContainmentType.Disjoint;
                     return;
@@ -206,12 +206,12 @@ namespace Prowl.Runtime
         public override bool Equals(object? obj)
         {
             BoundingFrustum f = obj as BoundingFrustum;
-            return (object.Equals(f, null)) ? false : (this == f);
+            return (Equals(f, null)) ? false : (this == f);
         }
 
         public Vector3[] GetCorners()
         {
-            return (Vector3[])this.corners.Clone();
+            return (Vector3[])corners.Clone();
         }
 
         public void GetCorners(Vector3[] corners)
@@ -224,20 +224,20 @@ namespace Prowl.Runtime
 
         public override int GetHashCode()
         {
-            return this.matrix.GetHashCode();
+            return matrix.GetHashCode();
         }
 
         public bool Intersects(Bounds box)
         {
             var result = false;
-            this.Intersects(ref box, out result);
+            Intersects(ref box, out result);
             return result;
         }
 
         public void Intersects(ref Bounds box, out bool result)
         {
             var containment = default(ContainmentType);
-            this.Contains(ref box, out containment);
+            Contains(ref box, out containment);
             result = containment != ContainmentType.Disjoint;
         }
 
@@ -278,12 +278,12 @@ namespace Prowl.Runtime
             get
             {
                 return string.Concat(
-                    "Near( ", this.planes[0].DebugDisplayString, " )  \r\n",
-                    "Far( ", this.planes[1].DebugDisplayString, " )  \r\n",
-                    "Left( ", this.planes[2].DebugDisplayString, " )  \r\n",
-                    "Right( ", this.planes[3].DebugDisplayString, " )  \r\n",
-                    "Top( ", this.planes[4].DebugDisplayString, " )  \r\n",
-                    "Bottom( ", this.planes[5].DebugDisplayString, " )  "
+                    "Near( ", planes[0].DebugDisplayString, " )  \r\n",
+                    "Far( ", planes[1].DebugDisplayString, " )  \r\n",
+                    "Left( ", planes[2].DebugDisplayString, " )  \r\n",
+                    "Right( ", planes[3].DebugDisplayString, " )  \r\n",
+                    "Top( ", planes[4].DebugDisplayString, " )  \r\n",
+                    "Bottom( ", planes[5].DebugDisplayString, " )  "
                     );
             }
         }
@@ -292,17 +292,17 @@ namespace Prowl.Runtime
         {
             StringBuilder sb = new StringBuilder(256);
             sb.Append("{Near:");
-            sb.Append(this.planes[0].ToString());
+            sb.Append(planes[0].ToString());
             sb.Append(" Far:");
-            sb.Append(this.planes[1].ToString());
+            sb.Append(planes[1].ToString());
             sb.Append(" Left:");
-            sb.Append(this.planes[2].ToString());
+            sb.Append(planes[2].ToString());
             sb.Append(" Right:");
-            sb.Append(this.planes[3].ToString());
+            sb.Append(planes[3].ToString());
             sb.Append(" Top:");
-            sb.Append(this.planes[4].ToString());
+            sb.Append(planes[4].ToString());
             sb.Append(" Bottom:");
-            sb.Append(this.planes[5].ToString());
+            sb.Append(planes[5].ToString());
             sb.Append("}");
             return sb.ToString();
         }
@@ -314,31 +314,31 @@ namespace Prowl.Runtime
 
         private void CreateCorners()
         {
-            IntersectionPoint(ref this.planes[0], ref this.planes[2], ref this.planes[4], out this.corners[0]);
-            IntersectionPoint(ref this.planes[0], ref this.planes[3], ref this.planes[4], out this.corners[1]);
-            IntersectionPoint(ref this.planes[0], ref this.planes[3], ref this.planes[5], out this.corners[2]);
-            IntersectionPoint(ref this.planes[0], ref this.planes[2], ref this.planes[5], out this.corners[3]);
-            IntersectionPoint(ref this.planes[1], ref this.planes[2], ref this.planes[4], out this.corners[4]);
-            IntersectionPoint(ref this.planes[1], ref this.planes[3], ref this.planes[4], out this.corners[5]);
-            IntersectionPoint(ref this.planes[1], ref this.planes[3], ref this.planes[5], out this.corners[6]);
-            IntersectionPoint(ref this.planes[1], ref this.planes[2], ref this.planes[5], out this.corners[7]);
+            IntersectionPoint(ref planes[0], ref planes[2], ref planes[4], out corners[0]);
+            IntersectionPoint(ref planes[0], ref planes[3], ref planes[4], out corners[1]);
+            IntersectionPoint(ref planes[0], ref planes[3], ref planes[5], out corners[2]);
+            IntersectionPoint(ref planes[0], ref planes[2], ref planes[5], out corners[3]);
+            IntersectionPoint(ref planes[1], ref planes[2], ref planes[4], out corners[4]);
+            IntersectionPoint(ref planes[1], ref planes[3], ref planes[4], out corners[5]);
+            IntersectionPoint(ref planes[1], ref planes[3], ref planes[5], out corners[6]);
+            IntersectionPoint(ref planes[1], ref planes[2], ref planes[5], out corners[7]);
         }
 
         private void CreatePlanes()
         {
-            this.planes[0] = new Plane(-this.matrix.M13, -this.matrix.M23, -this.matrix.M33, -this.matrix.M43);
-            this.planes[1] = new Plane(this.matrix.M13 - this.matrix.M14, this.matrix.M23 - this.matrix.M24, this.matrix.M33 - this.matrix.M34, this.matrix.M43 - this.matrix.M44);
-            this.planes[2] = new Plane(-this.matrix.M14 - this.matrix.M11, -this.matrix.M24 - this.matrix.M21, -this.matrix.M34 - this.matrix.M31, -this.matrix.M44 - this.matrix.M41);
-            this.planes[3] = new Plane(this.matrix.M11 - this.matrix.M14, this.matrix.M21 - this.matrix.M24, this.matrix.M31 - this.matrix.M34, this.matrix.M41 - this.matrix.M44);
-            this.planes[4] = new Plane(this.matrix.M12 - this.matrix.M14, this.matrix.M22 - this.matrix.M24, this.matrix.M32 - this.matrix.M34, this.matrix.M42 - this.matrix.M44);
-            this.planes[5] = new Plane(-this.matrix.M14 - this.matrix.M12, -this.matrix.M24 - this.matrix.M22, -this.matrix.M34 - this.matrix.M32, -this.matrix.M44 - this.matrix.M42);
+            planes[0] = new Plane(-matrix.M13, -matrix.M23, -matrix.M33, -matrix.M43);
+            planes[1] = new Plane(matrix.M13 - matrix.M14, matrix.M23 - matrix.M24, matrix.M33 - matrix.M34, matrix.M43 - matrix.M44);
+            planes[2] = new Plane(-matrix.M14 - matrix.M11, -matrix.M24 - matrix.M21, -matrix.M34 - matrix.M31, -matrix.M44 - matrix.M41);
+            planes[3] = new Plane(matrix.M11 - matrix.M14, matrix.M21 - matrix.M24, matrix.M31 - matrix.M34, matrix.M41 - matrix.M44);
+            planes[4] = new Plane(matrix.M12 - matrix.M14, matrix.M22 - matrix.M24, matrix.M32 - matrix.M34, matrix.M42 - matrix.M44);
+            planes[5] = new Plane(-matrix.M14 - matrix.M12, -matrix.M24 - matrix.M22, -matrix.M34 - matrix.M32, -matrix.M44 - matrix.M42);
 
-            this.NormalizePlane(ref this.planes[0]);
-            this.NormalizePlane(ref this.planes[1]);
-            this.NormalizePlane(ref this.planes[2]);
-            this.NormalizePlane(ref this.planes[3]);
-            this.NormalizePlane(ref this.planes[4]);
-            this.NormalizePlane(ref this.planes[5]);
+            NormalizePlane(ref planes[0]);
+            NormalizePlane(ref planes[1]);
+            NormalizePlane(ref planes[2]);
+            NormalizePlane(ref planes[3]);
+            NormalizePlane(ref planes[4]);
+            NormalizePlane(ref planes[5]);
         }
 
         private static void IntersectionPoint(ref Plane a, ref Plane b, ref Plane c, out Vector3 result)

--- a/Prowl.Runtime/Math/Bounds.cs
+++ b/Prowl.Runtime/Math/Bounds.cs
@@ -264,7 +264,8 @@ namespace Prowl.Runtime
 
         public Vector3[] GetCorners()
         {
-            return new Vector3[] {
+            return
+            [
                 new Vector3(this.min.x, this.max.y, this.max.z),
                 new Vector3(this.max.x, this.max.y, this.max.z),
                 new Vector3(this.max.x, this.min.y, this.max.z),
@@ -273,7 +274,7 @@ namespace Prowl.Runtime
                 new Vector3(this.max.x, this.max.y, this.min.z),
                 new Vector3(this.max.x, this.min.y, this.min.z),
                 new Vector3(this.min.x, this.min.y, this.min.z)
-            };
+            ];
         }
 
         public void GetCorners(Vector3[] corners)

--- a/Prowl.Runtime/Math/Bounds.cs
+++ b/Prowl.Runtime/Math/Bounds.cs
@@ -281,11 +281,11 @@ namespace Prowl.Runtime
         {
             if (corners == null)
             {
-                throw new ArgumentNullException("corners");
+                throw new ArgumentNullException(nameof(corners));
             }
             if (corners.Length < 8)
             {
-                throw new ArgumentOutOfRangeException("corners", "Not Enought Corners");
+                throw new ArgumentOutOfRangeException(nameof(corners), "Not Enought Corners");
             }
             corners[0].x = min.x;
             corners[0].y = max.y;

--- a/Prowl.Runtime/Math/Bounds.cs
+++ b/Prowl.Runtime/Math/Bounds.cs
@@ -60,9 +60,9 @@ namespace Prowl.Runtime
         #endregion Public Fields
 
         #region Public Properties
-        public Vector3 center { get { return (this.min + this.max) * 0.5f; } set { var s = this.size * 0.5f; this.min = value - s; this.max = value + s; } }
-        public Vector3 extents { get { return (this.max - this.min) * 0.5f; } set { var c = this.center; this.min = c - value; this.max = c + value; } }
-        public Vector3 size { get { return this.max - this.min; } set { var c = this.center; var s = value * 0.5f; this.min = c - s; this.max = c + s; } }
+        public Vector3 center { get { return (min + max) * 0.5f; } set { var s = size * 0.5f; min = value - s; max = value + s; } }
+        public Vector3 extents { get { return (max - min) * 0.5f; } set { var c = center; min = c - value; max = c + value; } }
+        public Vector3 size { get { return max - min; } set { var c = center; var s = value * 0.5f; min = c - s; max = c + s; } }
         #endregion
 
 
@@ -119,7 +119,7 @@ namespace Prowl.Runtime
             // First we check if frustum is in box
             for (i = 0; i < corners.Length; i++)
             {
-                this.Contains(ref corners[i], out contained);
+                Contains(ref corners[i], out contained);
                 if (contained == ContainmentType.Disjoint)
                     break;
             }
@@ -137,7 +137,7 @@ namespace Prowl.Runtime
             i++;
             for (; i < corners.Length; i++)
             {
-                this.Contains(ref corners[i], out contained);
+                Contains(ref corners[i], out contained);
                 if (contained != ContainmentType.Contains)
                     return ContainmentType.Intersects;
 
@@ -150,28 +150,28 @@ namespace Prowl.Runtime
         public ContainmentType Contains(Vector3 point)
         {
             ContainmentType result;
-            this.Contains(ref point, out result);
+            Contains(ref point, out result);
             return result;
         }
 
         public void Contains(ref Vector3 point, out ContainmentType result)
         {
             //first we get if point is out of box
-            if (point.x < this.min.x
-                || point.x > this.max.x
-                || point.y < this.min.y
-                || point.y > this.max.y
-                || point.z < this.min.z
-                || point.z > this.max.z)
+            if (point.x < min.x
+                || point.x > max.x
+                || point.y < min.y
+                || point.y > max.y
+                || point.z < min.z
+                || point.z > max.z)
             {
                 result = ContainmentType.Disjoint;
             }//or if point is on box because coordonate of point is lesser or equal
-            else if (point.x == this.min.x
-                || point.x == this.max.x
-                || point.y == this.min.y
-                || point.y == this.max.y
-                || point.z == this.min.z
-                || point.z == this.max.z)
+            else if (point.x == min.x
+                || point.x == max.x
+                || point.y == min.y
+                || point.y == max.y
+                || point.z == min.z
+                || point.z == max.z)
                 result = ContainmentType.Intersects;
             else
                 result = ContainmentType.Contains;
@@ -254,26 +254,26 @@ namespace Prowl.Runtime
 
         public bool Equals(Bounds other)
         {
-            return (this.min == other.min) && (this.max == other.max);
+            return (min == other.min) && (max == other.max);
         }
 
         public override bool Equals(object? obj)
         {
-            return (obj is Bounds bounds) ? this.Equals(bounds) : false;
+            return (obj is Bounds bounds) ? Equals(bounds) : false;
         }
 
         public Vector3[] GetCorners()
         {
             return
             [
-                new Vector3(this.min.x, this.max.y, this.max.z),
-                new Vector3(this.max.x, this.max.y, this.max.z),
-                new Vector3(this.max.x, this.min.y, this.max.z),
-                new Vector3(this.min.x, this.min.y, this.max.z),
-                new Vector3(this.min.x, this.max.y, this.min.z),
-                new Vector3(this.max.x, this.max.y, this.min.z),
-                new Vector3(this.max.x, this.min.y, this.min.z),
-                new Vector3(this.min.x, this.min.y, this.min.z)
+                new Vector3(min.x, max.y, max.z),
+                new Vector3(max.x, max.y, max.z),
+                new Vector3(max.x, min.y, max.z),
+                new Vector3(min.x, min.y, max.z),
+                new Vector3(min.x, max.y, min.z),
+                new Vector3(max.x, max.y, min.z),
+                new Vector3(max.x, min.y, min.z),
+                new Vector3(min.x, min.y, min.z)
             ];
         }
 
@@ -287,35 +287,35 @@ namespace Prowl.Runtime
             {
                 throw new ArgumentOutOfRangeException("corners", "Not Enought Corners");
             }
-            corners[0].x = this.min.x;
-            corners[0].y = this.max.y;
-            corners[0].z = this.max.z;
-            corners[1].x = this.max.x;
-            corners[1].y = this.max.y;
-            corners[1].z = this.max.z;
-            corners[2].x = this.max.x;
-            corners[2].y = this.min.y;
-            corners[2].z = this.max.z;
-            corners[3].x = this.min.x;
-            corners[3].y = this.min.y;
-            corners[3].z = this.max.z;
-            corners[4].x = this.min.x;
-            corners[4].y = this.max.y;
-            corners[4].z = this.min.z;
-            corners[5].x = this.max.x;
-            corners[5].y = this.max.y;
-            corners[5].z = this.min.z;
-            corners[6].x = this.max.x;
-            corners[6].y = this.min.y;
-            corners[6].z = this.min.z;
-            corners[7].x = this.min.x;
-            corners[7].y = this.min.y;
-            corners[7].z = this.min.z;
+            corners[0].x = min.x;
+            corners[0].y = max.y;
+            corners[0].z = max.z;
+            corners[1].x = max.x;
+            corners[1].y = max.y;
+            corners[1].z = max.z;
+            corners[2].x = max.x;
+            corners[2].y = min.y;
+            corners[2].z = max.z;
+            corners[3].x = min.x;
+            corners[3].y = min.y;
+            corners[3].z = max.z;
+            corners[4].x = min.x;
+            corners[4].y = max.y;
+            corners[4].z = min.z;
+            corners[5].x = max.x;
+            corners[5].y = max.y;
+            corners[5].z = min.z;
+            corners[6].x = max.x;
+            corners[6].y = min.y;
+            corners[6].z = min.z;
+            corners[7].x = min.x;
+            corners[7].y = min.y;
+            corners[7].z = min.z;
         }
 
         public override int GetHashCode()
         {
-            return this.min.GetHashCode() + this.max.GetHashCode();
+            return min.GetHashCode() + max.GetHashCode();
         }
 
         public bool Intersects(Bounds box)
@@ -327,15 +327,15 @@ namespace Prowl.Runtime
 
         public void Intersects(ref Bounds box, out bool result)
         {
-            if ((this.max.x >= box.min.x) && (this.min.x <= box.max.x))
+            if ((max.x >= box.min.x) && (min.x <= box.max.x))
             {
-                if ((this.max.y < box.min.y) || (this.min.y > box.max.y))
+                if ((max.y < box.min.y) || (min.y > box.max.y))
                 {
                     result = false;
                     return;
                 }
 
-                result = (this.max.z >= box.min.z) && (this.min.z <= box.max.z);
+                result = (max.z >= box.min.z) && (min.z <= box.max.z);
                 return;
             }
 
@@ -473,15 +473,15 @@ namespace Prowl.Runtime
             get
             {
                 return string.Concat(
-                    "Min( ", this.min.ToString(), " )  \r\n",
-                    "Max( ", this.max.ToString(), " )"
+                    "Min( ", min.ToString(), " )  \r\n",
+                    "Max( ", max.ToString(), " )"
                     );
             }
         }
 
         public override string ToString()
         {
-            return "{{Min:" + this.min.ToString() + " Max:" + this.max.ToString() + "}}";
+            return "{{Min:" + min.ToString() + " Max:" + max.ToString() + "}}";
         }
 
         #endregion Public Methods

--- a/Prowl.Runtime/Math/Bounds.cs
+++ b/Prowl.Runtime/Math/Bounds.cs
@@ -188,8 +188,7 @@ namespace Prowl.Runtime
         /// <exception cref="System.ArgumentException">Thrown if the given list has no points.</exception>
         public static Bounds CreateFromPoints(IEnumerable<Vector3> points)
         {
-            if (points == null)
-                throw new ArgumentNullException();
+            ArgumentNullException.ThrowIfNull(points);
 
             var empty = true;
             var minVec = MaxVector3;
@@ -279,10 +278,7 @@ namespace Prowl.Runtime
 
         public void GetCorners(Vector3[] corners)
         {
-            if (corners == null)
-            {
-                throw new ArgumentNullException(nameof(corners));
-            }
+            ArgumentNullException.ThrowIfNull(corners);
             if (corners.Length < 8)
             {
                 throw new ArgumentOutOfRangeException(nameof(corners), "Not Enought Corners");

--- a/Prowl.Runtime/Math/MathD.cs
+++ b/Prowl.Runtime/Math/MathD.cs
@@ -126,7 +126,7 @@ namespace Prowl.Runtime
 
         [MethodImpl(IN)] public static int CeilToInt(double value) => (int)Math.Ceiling(value);
 
-        [MethodImpl(IN)] public static double Round(double value, MidpointRounding midpointRounding = MidpointRounding.ToEven) => (double)Math.Round(value, midpointRounding);
+        [MethodImpl(IN)] public static double Round(double value, MidpointRounding midpointRounding = MidpointRounding.ToEven) => Math.Round(value, midpointRounding);
 
         [MethodImpl(IN)] public static double Round(double value, double snapInterval, MidpointRounding midpointRounding = MidpointRounding.ToEven) => Math.Round(value / snapInterval, midpointRounding) * snapInterval;
 
@@ -419,13 +419,13 @@ namespace Prowl.Runtime
             return new Vector3(pitch, yaw, roll);
         }
 
-        [MethodImpl(IN)] public static Vector3 ToDeg(this Vector3 v) => new((double)(v.x * Rad2Deg), (double)(v.y * Rad2Deg), (double)(v.z * Rad2Deg));
+        [MethodImpl(IN)] public static Vector3 ToDeg(this Vector3 v) => new(v.x * Rad2Deg, v.y * Rad2Deg, v.z * Rad2Deg);
 
-        [MethodImpl(IN)] public static Vector3 ToRad(this Vector3 v) => new((double)(v.x * Deg2Rad), (double)(v.y * Deg2Rad), (double)(v.z * Deg2Rad));
+        [MethodImpl(IN)] public static Vector3 ToRad(this Vector3 v) => new(v.x * Deg2Rad, v.y * Deg2Rad, v.z * Deg2Rad);
 
-        [MethodImpl(IN)] public static double ToDeg(this double v) => (double)(v * Rad2Deg);
+        [MethodImpl(IN)] public static double ToDeg(this double v) => v * Rad2Deg;
 
-        [MethodImpl(IN)] public static double ToRad(this double v) => (double)(v * Deg2Rad);
+        [MethodImpl(IN)] public static double ToRad(this double v) => v * Deg2Rad;
 
         [MethodImpl(IN)] public static float ToDeg(this float v) => (float)(v * Rad2Deg);
 

--- a/Prowl.Runtime/Math/MathD.cs
+++ b/Prowl.Runtime/Math/MathD.cs
@@ -195,7 +195,7 @@ namespace Prowl.Runtime
 
         [MethodImpl(IN)] public static int ComputeMipLevels(int width, int height) => (int)Math.Log2(Math.Max(width, height));
 
-        [MethodImpl(IN)] public static bool ApproximatelyEquals(double a, double b) => MathD.Abs(a - b) < 0.00001f;
+        [MethodImpl(IN)] public static bool ApproximatelyEquals(double a, double b) => Abs(a - b) < 0.00001f;
         [MethodImpl(IN)] public static bool ApproximatelyEquals(Vector2 a, Vector2 b) => ApproximatelyEquals(a.x, b.x) && ApproximatelyEquals(a.y, b.y);
         [MethodImpl(IN)] public static bool ApproximatelyEquals(Vector3 a, Vector3 b) => ApproximatelyEquals(a.x, b.x) && ApproximatelyEquals(a.y, b.y) && ApproximatelyEquals(a.z, b.z);
         [MethodImpl(IN)] public static bool ApproximatelyEquals(Vector4 a, Vector4 b) => ApproximatelyEquals(a.x, b.x) && ApproximatelyEquals(a.y, b.y) && ApproximatelyEquals(a.z, b.z) && ApproximatelyEquals(a.w, b.w);

--- a/Prowl.Runtime/Math/Matrix4x4.cs
+++ b/Prowl.Runtime/Math/Matrix4x4.cs
@@ -158,10 +158,10 @@ namespace Prowl.Runtime
                          double m31, double m32, double m33, double m34,
                          double m41, double m42, double m43, double m44)
         {
-            this.M1 = new(m11, m12, m13, m14);
-            this.M2 = new(m21, m22, m23, m24);
-            this.M3 = new(m31, m32, m33, m34);
-            this.M4 = new(m41, m42, m43, m44);
+            M1 = new(m11, m12, m13, m14);
+            M2 = new(m21, m22, m23, m24);
+            M3 = new(m31, m32, m33, m34);
+            M4 = new(m41, m42, m43, m44);
         }
 
         public Matrix4x4(Vector4 row1, Vector4 row2, Vector4 row3, Vector4 row4)
@@ -225,7 +225,7 @@ namespace Prowl.Runtime
         }
 
         public static Matrix4x4 TRS(Vector3 m_LocalPosition, Quaternion m_LocalRotation, Vector3 m_LocalScale)
-            => Matrix4x4.CreateScale(m_LocalScale) * Matrix4x4.CreateFromQuaternion(m_LocalRotation) * Matrix4x4.CreateTranslation(m_LocalPosition);
+            => CreateScale(m_LocalScale) * CreateFromQuaternion(m_LocalRotation) * CreateTranslation(m_LocalPosition);
 
         public Vector3 MultiplyPoint(Vector3 v) => Vector3.Transform(v, this);
 
@@ -999,7 +999,7 @@ namespace Prowl.Runtime
         {
             Quaternion q = Quaternion.CreateFromYawPitchRoll(yaw, pitch, roll);
 
-            return Matrix4x4.CreateFromQuaternion(q);
+            return CreateFromQuaternion(q);
         }
 
         /// <summary>
@@ -1346,7 +1346,7 @@ namespace Prowl.Runtime
                     VectorBasis vectorBasis;
                     Vector3** pVectorBasis = (Vector3**)&vectorBasis;
 
-                    Matrix4x4 matTemp = Matrix4x4.Identity;
+                    Matrix4x4 matTemp = Identity;
                     CanonicalBasis canonicalBasis = new CanonicalBasis();
                     Vector3* pCanonicalBasis = &canonicalBasis.Row0;
 

--- a/Prowl.Runtime/Math/Matrix4x4.cs
+++ b/Prowl.Runtime/Math/Matrix4x4.cs
@@ -255,7 +255,7 @@ namespace Prowl.Runtime
             }
             else
             {
-                zaxis = zaxis * (1.0 / (double)Math.Sqrt(norm));
+                zaxis = zaxis * (1.0 / Math.Sqrt(norm));
             }
 
             Vector3 xaxis = Vector3.Normalize(Vector3.Cross(cameraUpVector, zaxis));
@@ -281,7 +281,7 @@ namespace Prowl.Runtime
         public static Matrix4x4 CreateConstrainedBillboard(Vector3 objectPosition, Vector3 cameraPosition, Vector3 rotateAxis, Vector3 cameraForwardVector, Vector3 objectForwardVector)
         {
             const double epsilon = 1e-4;
-            const double minAngle = 1.0 - (0.1 * ((double)Math.PI / 180.0)); // 0.1 degrees
+            const double minAngle = 1.0 - (0.1 * (Math.PI / 180.0)); // 0.1 degrees
 
             // Treat the case when object and camera positions are too close.
             Vector3 faceDir = new Vector3(
@@ -297,7 +297,7 @@ namespace Prowl.Runtime
             }
             else
             {
-                faceDir = faceDir * ((1.0 / (double)Math.Sqrt(norm)));
+                faceDir = faceDir * ((1.0 / Math.Sqrt(norm)));
             }
 
             Vector3 yaxis = rotateAxis;
@@ -493,8 +493,8 @@ namespace Prowl.Runtime
         {
             Matrix4x4 result = new();
 
-            double c = (double)Math.Cos(radians);
-            double s = (double)Math.Sin(radians);
+            double c = Math.Cos(radians);
+            double s = Math.Sin(radians);
 
             // [  1  0  0  0 ]
             // [  0  c  s  0 ]
@@ -518,8 +518,8 @@ namespace Prowl.Runtime
         {
             Matrix4x4 result = new();
 
-            double c = (double)Math.Cos(radians);
-            double s = (double)Math.Sin(radians);
+            double c = Math.Cos(radians);
+            double s = Math.Sin(radians);
 
             double y = centerPoint.y * (1 - c) + centerPoint.z * s;
             double z = centerPoint.z * (1 - c) - centerPoint.y * s;
@@ -545,8 +545,8 @@ namespace Prowl.Runtime
         {
             Matrix4x4 result = new();
 
-            double c = (double)Math.Cos(radians);
-            double s = (double)Math.Sin(radians);
+            double c = Math.Cos(radians);
+            double s = Math.Sin(radians);
 
             // [  c  0 -s  0 ]
             // [  0  1  0  0 ]
@@ -570,8 +570,8 @@ namespace Prowl.Runtime
         {
             Matrix4x4 result = new();
 
-            double c = (double)Math.Cos(radians);
-            double s = (double)Math.Sin(radians);
+            double c = Math.Cos(radians);
+            double s = Math.Sin(radians);
 
             double x = centerPoint.x * (1 - c) - centerPoint.z * s;
             double z = centerPoint.z * (1 - c) + centerPoint.x * s;
@@ -597,8 +597,8 @@ namespace Prowl.Runtime
         {
             Matrix4x4 result = new();
 
-            double c = (double)Math.Cos(radians);
-            double s = (double)Math.Sin(radians);
+            double c = Math.Cos(radians);
+            double s = Math.Sin(radians);
 
             // [  c  s  0  0 ]
             // [ -s  c  0  0 ]
@@ -622,8 +622,8 @@ namespace Prowl.Runtime
         {
             Matrix4x4 result = new();
 
-            double c = (double)Math.Cos(radians);
-            double s = (double)Math.Sin(radians);
+            double c = Math.Cos(radians);
+            double s = Math.Sin(radians);
 
             double x = centerPoint.x * (1 - c) + centerPoint.y * s;
             double y = centerPoint.y * (1 - c) - centerPoint.x * s;
@@ -674,7 +674,7 @@ namespace Prowl.Runtime
             //     [ zx-cosa*zx-sina*y zy-cosa*zy+sina*x   zz+cosa*(1-zz)  ]
             //
             double x = axis.x, y = axis.y, z = axis.z;
-            double sa = (double)Math.Sin(angle), ca = (double)Math.Cos(angle);
+            double sa = Math.Sin(angle), ca = Math.Cos(angle);
             double xx = x * x, yy = y * y, zz = z * z;
             double xy = x * y, xz = x * z, yz = y * z;
 
@@ -720,7 +720,7 @@ namespace Prowl.Runtime
             if (nearPlaneDistance >= farPlaneDistance)
                 throw new ArgumentOutOfRangeException(nameof(nearPlaneDistance));
 
-            double yScale = 1.0 / (double)Math.Tan(fieldOfView * 0.5);
+            double yScale = 1.0 / Math.Tan(fieldOfView * 0.5);
             double xScale = yScale / aspectRatio;
 
             Matrix4x4 result;
@@ -1436,9 +1436,9 @@ namespace Prowl.Runtime
                         uint cc;
                         double fAbsX, fAbsY, fAbsZ;
 
-                        fAbsX = (double)Math.Abs(pVectorBasis[a]->x);
-                        fAbsY = (double)Math.Abs(pVectorBasis[a]->y);
-                        fAbsZ = (double)Math.Abs(pVectorBasis[a]->z);
+                        fAbsX = Math.Abs(pVectorBasis[a]->x);
+                        fAbsY = Math.Abs(pVectorBasis[a]->y);
+                        fAbsZ = Math.Abs(pVectorBasis[a]->z);
 
                         #region Ranking
                         if (fAbsX < fAbsY)

--- a/Prowl.Runtime/Math/Plane.cs
+++ b/Prowl.Runtime/Math/Plane.cs
@@ -122,8 +122,8 @@ namespace Prowl.Runtime
             double factor;
             Vector3 normal = this.normal;
             this.normal = Vector3.Normalize(this.normal);
-            factor = (double)Math.Sqrt(normal.x * normal.x + normal.y * normal.y + normal.z * normal.z) /
-                    (double)Math.Sqrt(normal.x * normal.x + normal.y * normal.y + normal.z * normal.z);
+            factor = Math.Sqrt(normal.x * normal.x + normal.y * normal.y + normal.z * normal.z) /
+                    Math.Sqrt(normal.x * normal.x + normal.y * normal.y + normal.z * normal.z);
             distance = distance * factor;
         }
 
@@ -144,8 +144,8 @@ namespace Prowl.Runtime
         {
             double factor;
             result.normal = Vector3.Normalize(value.normal);
-            factor = (double)Math.Sqrt(result.normal.x * result.normal.x + result.normal.y * result.normal.y + result.normal.z * result.normal.z) /
-                    (double)Math.Sqrt(value.normal.x * value.normal.x + value.normal.y * value.normal.y + value.normal.z * value.normal.z);
+            factor = Math.Sqrt(result.normal.x * result.normal.x + result.normal.y * result.normal.y + result.normal.z * result.normal.z) /
+                    Math.Sqrt(value.normal.x * value.normal.x + value.normal.y * value.normal.y + value.normal.z * value.normal.z);
             result.distance = value.distance * factor;
         }
 
@@ -189,7 +189,7 @@ namespace Prowl.Runtime
 
             double dist = (Vector3.Dot(normal, lineStart) - distance) / den;
 
-            if (dist < (double)-MathD.Small || dist > (1.0f + (double)MathD.Small))
+            if (dist < -MathD.Small || dist > (1.0f + MathD.Small))
                 return false;
 
             dist = -dist;

--- a/Prowl.Runtime/Math/Plane.cs
+++ b/Prowl.Runtime/Math/Plane.cs
@@ -88,22 +88,22 @@ namespace Prowl.Runtime
         #region Public Methods
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public double Dot(Vector4 value) => ((((this.normal.x * value.x) + (this.normal.y * value.y)) + (this.normal.z * value.z)) + (this.distance * value.w));
+        public double Dot(Vector4 value) => ((((normal.x * value.x) + (normal.y * value.y)) + (normal.z * value.z)) + (distance * value.w));
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public void Dot(ref Vector4 value, out double result) => result = (((this.normal.x * value.x) + (this.normal.y * value.y)) + (this.normal.z * value.z)) + (this.distance * value.w);
+        public void Dot(ref Vector4 value, out double result) => result = (((normal.x * value.x) + (normal.y * value.y)) + (normal.z * value.z)) + (distance * value.w);
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public double DotCoordinate(Vector3 value) => ((((this.normal.x * value.x) + (this.normal.y * value.y)) + (this.normal.z * value.z)) + this.distance);
+        public double DotCoordinate(Vector3 value) => ((((normal.x * value.x) + (normal.y * value.y)) + (normal.z * value.z)) + distance);
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public void DotCoordinate(ref Vector3 value, out double result) => result = (((this.normal.x * value.x) + (this.normal.y * value.y)) + (this.normal.z * value.z)) + this.distance;
+        public void DotCoordinate(ref Vector3 value, out double result) => result = (((normal.x * value.x) + (normal.y * value.y)) + (normal.z * value.z)) + distance;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public double DotNormal(Vector3 value) => (((this.normal.x * value.x) + (this.normal.y * value.y)) + (this.normal.z * value.z));
+        public double DotNormal(Vector3 value) => (((normal.x * value.x) + (normal.y * value.y)) + (normal.z * value.z));
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public void DotNormal(ref Vector3 value, out double result) => result = ((this.normal.x * value.x) + (this.normal.y * value.y)) + (this.normal.z * value.z);
+        public void DotNormal(ref Vector3 value, out double result) => result = ((normal.x * value.x) + (normal.y * value.y)) + (normal.z * value.z);
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public bool GetSide(Vector3 inPt) => Vector3.Dot(normal, inPt) + distance > 0.0;
@@ -153,7 +153,7 @@ namespace Prowl.Runtime
 
         public static bool operator ==(Plane plane1, Plane plane2) => plane1.Equals(plane2);
 
-        public override bool Equals(object? other) => (other is Plane plane) ? this.Equals(plane) : false;
+        public override bool Equals(object? other) => (other is Plane plane) ? Equals(plane) : false;
 
         public bool Equals(Plane other) => ((normal == other.normal) && (distance == other.distance));
 
@@ -198,7 +198,7 @@ namespace Prowl.Runtime
             return true;
         }
 
-        internal string DebugDisplayString => string.Concat(this.normal.ToString(), "  ", this.distance.ToString());
+        internal string DebugDisplayString => string.Concat(normal.ToString(), "  ", distance.ToString());
 
         public override string ToString() => "{Normal:" + normal + " Distance:" + distance + "}";
 

--- a/Prowl.Runtime/Math/Quaternion.cs
+++ b/Prowl.Runtime/Math/Quaternion.cs
@@ -102,7 +102,7 @@ namespace Prowl.Runtime
         public double Magnitude()
         {
             double ls = x * x + y * y + z * z + w * w;
-            return (double)Math.Sqrt((double)ls);
+            return Math.Sqrt(ls);
         }
 
         /// <summary>
@@ -131,7 +131,7 @@ namespace Prowl.Runtime
 
             double ls = value.x * value.x + value.y * value.y + value.z * value.z + value.w * value.w;
 
-            double invNorm = 1.0 / (double)Math.Sqrt((double)ls);
+            double invNorm = 1.0 / Math.Sqrt(ls);
 
             ans.x = value.x * invNorm;
             ans.y = value.y * invNorm;
@@ -198,8 +198,8 @@ namespace Prowl.Runtime
             Quaternion ans;
 
             double halfAngle = angle * 0.5;
-            double s = (double)Math.Sin(halfAngle);
-            double c = (double)Math.Cos(halfAngle);
+            double s = Math.Sin(halfAngle);
+            double c = Math.Cos(halfAngle);
 
             ans.x = axis.x * s;
             ans.y = axis.y * s;
@@ -223,16 +223,16 @@ namespace Prowl.Runtime
             double sr, cr, sp, cp, sy, cy;
 
             double halfRoll = roll * 0.5;
-            sr = (double)Math.Sin(halfRoll);
-            cr = (double)Math.Cos(halfRoll);
+            sr = Math.Sin(halfRoll);
+            cr = Math.Cos(halfRoll);
 
             double halfPitch = pitch * 0.5;
-            sp = (double)Math.Sin(halfPitch);
-            cp = (double)Math.Cos(halfPitch);
+            sp = Math.Sin(halfPitch);
+            cp = Math.Cos(halfPitch);
 
             double halfYaw = yaw * 0.5;
-            sy = (double)Math.Sin(halfYaw);
-            cy = (double)Math.Cos(halfYaw);
+            sy = Math.Sin(halfYaw);
+            cy = Math.Cos(halfYaw);
 
             Quaternion result;
 
@@ -257,7 +257,7 @@ namespace Prowl.Runtime
 
             if (trace > 0.0)
             {
-                double s = (double)Math.Sqrt(trace + 1.0);
+                double s = Math.Sqrt(trace + 1.0);
                 q.w = s * 0.5;
                 s = 0.5 / s;
                 q.x = (matrix.M23 - matrix.M32) * s;
@@ -268,7 +268,7 @@ namespace Prowl.Runtime
             {
                 if (matrix.M11 >= matrix.M22 && matrix.M11 >= matrix.M33)
                 {
-                    double s = (double)Math.Sqrt(1.0 + matrix.M11 - matrix.M22 - matrix.M33);
+                    double s = Math.Sqrt(1.0 + matrix.M11 - matrix.M22 - matrix.M33);
                     double invS = 0.5 / s;
                     q.x = 0.5 * s;
                     q.y = (matrix.M12 + matrix.M21) * invS;
@@ -277,7 +277,7 @@ namespace Prowl.Runtime
                 }
                 else if (matrix.M22 > matrix.M33)
                 {
-                    double s = (double)Math.Sqrt(1.0 + matrix.M22 - matrix.M11 - matrix.M33);
+                    double s = Math.Sqrt(1.0 + matrix.M22 - matrix.M11 - matrix.M33);
                     double invS = 0.5 / s;
                     q.x = (matrix.M21 + matrix.M12) * invS;
                     q.y = 0.5 * s;
@@ -286,7 +286,7 @@ namespace Prowl.Runtime
                 }
                 else
                 {
-                    double s = (double)Math.Sqrt(1.0 + matrix.M33 - matrix.M11 - matrix.M22);
+                    double s = Math.Sqrt(1.0 + matrix.M33 - matrix.M11 - matrix.M22);
                     double invS = 0.5 / s;
                     q.x = (matrix.M31 + matrix.M13) * invS;
                     q.y = (matrix.M32 + matrix.M23) * invS;
@@ -346,13 +346,13 @@ namespace Prowl.Runtime
             }
             else
             {
-                double omega = (double)Math.Acos(cosOmega);
-                double invSinOmega = (double)(1 / Math.Sin(omega));
+                double omega = Math.Acos(cosOmega);
+                double invSinOmega = 1 / Math.Sin(omega);
 
-                s1 = (double)Math.Sin((1.0 - t) * omega) * invSinOmega;
+                s1 = Math.Sin((1.0 - t) * omega) * invSinOmega;
                 s2 = (flip)
-                    ? (double)-Math.Sin(t * omega) * invSinOmega
-                    : (double)Math.Sin(t * omega) * invSinOmega;
+                    ? -Math.Sin(t * omega) * invSinOmega
+                    : Math.Sin(t * omega) * invSinOmega;
             }
 
             Quaternion ans;
@@ -399,7 +399,7 @@ namespace Prowl.Runtime
 
             // Normalize it.
             double ls = r.x * r.x + r.y * r.y + r.z * r.z + r.w * r.w;
-            double invNorm = 1.0 / (double)Math.Sqrt((double)ls);
+            double invNorm = 1.0 / Math.Sqrt(ls);
 
             r.x *= invNorm;
             r.y *= invNorm;

--- a/Prowl.Runtime/Math/Quaternion.cs
+++ b/Prowl.Runtime/Math/Quaternion.cs
@@ -115,7 +115,7 @@ namespace Prowl.Runtime
         {
             double mag = q.Magnitude();
             if (mag < MathD.Epsilon)
-                return Quaternion.identity;
+                return identity;
             else
                 return q / mag;
         }

--- a/Prowl.Runtime/Math/Random.cs
+++ b/Prowl.Runtime/Math/Random.cs
@@ -30,7 +30,7 @@ namespace Prowl.Runtime
         {
             get
             {
-                double angle = (double)(Value * 6.283185307179586476925286766559);
+                double angle = Value * 6.283185307179586476925286766559;
                 return Vector2.Normalize(new Vector2(Math.Cos(angle), Math.Sin(angle)));
             }
         }
@@ -46,8 +46,8 @@ namespace Prowl.Runtime
         {
             get
             {
-                double a = (double)(Value * 6.283185307179586476925286766559);
-                double b = (double)(Value * Math.PI);
+                double a = Value * 6.283185307179586476925286766559;
+                double b = Value * Math.PI;
                 double sinB = Math.Sin(b);
                 return Vector3.Normalize(new Vector3(sinB * Math.Cos(a), sinB * Math.Sin(a), Math.Cos(b)));
             }

--- a/Prowl.Runtime/Math/Ray.cs
+++ b/Prowl.Runtime/Math/Ray.cs
@@ -50,7 +50,7 @@ namespace Prowl.Runtime
 
         public Ray(Vector3 position, Vector3 direction)
         {
-            this.origin = position;
+            origin = position;
             this.direction = direction;
         }
 
@@ -61,13 +61,13 @@ namespace Prowl.Runtime
 
         public override bool Equals(object? obj)
         {
-            return (obj is Ray ray) ? this.Equals(ray) : false;
+            return (obj is Ray ray) ? Equals(ray) : false;
         }
 
 
         public bool Equals(Ray other)
         {
-            return this.origin.Equals(other.origin) && this.direction.Equals(other.direction);
+            return origin.Equals(other.origin) && direction.Equals(other.direction);
         }
 
 

--- a/Prowl.Runtime/Math/Rect.cs
+++ b/Prowl.Runtime/Math/Rect.cs
@@ -42,7 +42,7 @@ namespace Prowl.Runtime
         {
             get
             {
-                return Rect.CreateFromMinMax(
+                return CreateFromMinMax(
                     new Vector2(double.MaxValue, double.MaxValue),
                     new Vector2(double.MinValue, double.MinValue));
             }

--- a/Prowl.Runtime/Math/Transform.cs
+++ b/Prowl.Runtime/Math/Transform.cs
@@ -188,14 +188,14 @@ namespace Prowl.Runtime
 
         public Transform? Find(string path)
         {
-            ArgumentNullException.ThrowIfNullOrEmpty(path, nameof(path));
+            ArgumentException.ThrowIfNullOrEmpty(path, nameof(path));
 
             var names = path.Split('/');
             var currentTransform = this;
 
             foreach (var name in names)
             {
-                ArgumentNullException.ThrowIfNullOrEmpty(path, nameof(path));
+                ArgumentException.ThrowIfNullOrEmpty(path, nameof(path));
 
                 var childTransform = FindImmediateChild(currentTransform, name);
                 if (childTransform == null)

--- a/Prowl.Runtime/Math/Vector2.cs
+++ b/Prowl.Runtime/Math/Vector2.cs
@@ -71,7 +71,7 @@ namespace Prowl.Runtime
         public void Normalize()
         {
             double ls = x * x + y * y;
-            double invNorm = 1.0 / (double)Math.Sqrt((double)ls);
+            double invNorm = 1.0 / Math.Sqrt(ls);
             x *= invNorm;
             y *= invNorm;
         }
@@ -185,7 +185,7 @@ namespace Prowl.Runtime
 
             double ls = dx * dx + dy * dy;
 
-            return (double)Math.Sqrt((double)ls);
+            return Math.Sqrt(ls);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -206,7 +206,7 @@ namespace Prowl.Runtime
         public static Vector2 Normalize(Vector2 value)
         {
             double ls = value.x * value.x + value.y * value.y;
-            double invNorm = 1.0 / (double)Math.Sqrt((double)ls);
+            double invNorm = 1.0 / Math.Sqrt(ls);
 
             return new Vector2(
                 value.x * invNorm,
@@ -389,7 +389,7 @@ namespace Prowl.Runtime
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static Vector2 SquareRoot(Vector2 value)
         {
-            return new Vector2((Double)Math.Sqrt(value.x), (Double)Math.Sqrt(value.y));
+            return new Vector2(Math.Sqrt(value.x), Math.Sqrt(value.y));
         }
         #endregion Public Static Methods
 

--- a/Prowl.Runtime/Math/Vector2.cs
+++ b/Prowl.Runtime/Math/Vector2.cs
@@ -83,8 +83,8 @@ namespace Prowl.Runtime
         /// <returns>The hash code.</returns>
         public override int GetHashCode()
         {
-            int hash = this.x.GetHashCode();
-            hash = HashCode.Combine(hash, this.y.GetHashCode());
+            int hash = x.GetHashCode();
+            hash = HashCode.Combine(hash, y.GetHashCode());
             return hash;
         }
 
@@ -108,7 +108,7 @@ namespace Prowl.Runtime
         /// <returns>True if the other Vector2 is equal to this instance; False otherwise.</returns>
         public bool Equals(Vector2 other)
         {
-            return this.x == other.x && this.y == other.y;
+            return x == other.x && y == other.y;
         }
 
 
@@ -143,10 +143,10 @@ namespace Prowl.Runtime
             StringBuilder sb = new StringBuilder();
             string separator = NumberFormatInfo.GetInstance(formatProvider).NumberGroupSeparator;
             sb.Append('<');
-            sb.Append(this.x.ToString(format, formatProvider));
+            sb.Append(x.ToString(format, formatProvider));
             sb.Append(separator);
             sb.Append(' ');
-            sb.Append(this.y.ToString(format, formatProvider));
+            sb.Append(y.ToString(format, formatProvider));
             sb.Append('>');
             return sb.ToString();
         }

--- a/Prowl.Runtime/Math/Vector2Int.cs
+++ b/Prowl.Runtime/Math/Vector2Int.cs
@@ -64,8 +64,8 @@ namespace Prowl.Runtime
         /// <returns>The hash code.</returns>
         public override int GetHashCode()
         {
-            int hash = this.x.GetHashCode();
-            hash = HashCode.Combine(hash, this.y.GetHashCode());
+            int hash = x.GetHashCode();
+            hash = HashCode.Combine(hash, y.GetHashCode());
             return hash;
         }
 
@@ -89,7 +89,7 @@ namespace Prowl.Runtime
         /// <returns>True if the other Vector2Int is equal to this instance; False otherwise.</returns>
         public bool Equals(Vector2Int other)
         {
-            return this.x == other.x && this.y == other.y;
+            return x == other.x && y == other.y;
         }
 
 
@@ -124,10 +124,10 @@ namespace Prowl.Runtime
             StringBuilder sb = new StringBuilder();
             string separator = NumberFormatInfo.GetInstance(formatProvider).NumberGroupSeparator;
             sb.Append('<');
-            sb.Append(this.x.ToString(format, formatProvider));
+            sb.Append(x.ToString(format, formatProvider));
             sb.Append(separator);
             sb.Append(' ');
-            sb.Append(this.y.ToString(format, formatProvider));
+            sb.Append(y.ToString(format, formatProvider));
             sb.Append('>');
             return sb.ToString();
         }

--- a/Prowl.Runtime/Math/Vector2Int.cs
+++ b/Prowl.Runtime/Math/Vector2Int.cs
@@ -153,7 +153,7 @@ namespace Prowl.Runtime
 
             double ls = dx * dx + dy * dy;
 
-            return (double)Math.Sqrt((double)ls);
+            return Math.Sqrt(ls);
         }
 
         /// <summary>

--- a/Prowl.Runtime/Math/Vector3.cs
+++ b/Prowl.Runtime/Math/Vector3.cs
@@ -82,7 +82,7 @@ namespace Prowl.Runtime
         public void Normalize()
         {
             double ls = x * x + y * y + z * z;
-            double invNorm = 1.0 / (double)Math.Sqrt((double)ls);
+            double invNorm = 1.0 / Math.Sqrt(ls);
             x *= invNorm;
             y *= invNorm;
             z *= invNorm;
@@ -157,13 +157,13 @@ namespace Prowl.Runtime
             StringBuilder sb = new StringBuilder();
             string separator = NumberFormatInfo.GetInstance(formatProvider).NumberGroupSeparator;
             sb.Append('<');
-            sb.Append(((IFormattable)x).ToString(format, formatProvider));
+            sb.Append(x.ToString(format, formatProvider));
             sb.Append(separator);
             sb.Append(' ');
-            sb.Append(((IFormattable)y).ToString(format, formatProvider));
+            sb.Append(y.ToString(format, formatProvider));
             sb.Append(separator);
             sb.Append(' ');
-            sb.Append(((IFormattable)z).ToString(format, formatProvider));
+            sb.Append(z.ToString(format, formatProvider));
             sb.Append('>');
             return sb.ToString();
         }
@@ -201,7 +201,7 @@ namespace Prowl.Runtime
 
             double ls = dx * dx + dy * dy + dz * dz;
 
-            return (double)Math.Sqrt((double)ls);
+            return Math.Sqrt(ls);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -248,7 +248,7 @@ namespace Prowl.Runtime
         public static Vector3 Normalize(Vector3 value)
         {
             double ls = value.x * value.x + value.y * value.y + value.z * value.z;
-            double length = (double)Math.Sqrt(ls);
+            double length = Math.Sqrt(ls);
             return new Vector3(value.x / length, value.y / length, value.z / length);
         }
 
@@ -456,7 +456,7 @@ namespace Prowl.Runtime
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static Vector3 SquareRoot(Vector3 value)
         {
-            return new Vector3((Double)Math.Sqrt(value.x), (Double)Math.Sqrt(value.y), (Double)Math.Sqrt(value.z));
+            return new Vector3(Math.Sqrt(value.x), Math.Sqrt(value.y), Math.Sqrt(value.z));
         }
 
         public static Vector3 ProjectOnPlane(Vector3 vector, Vector3 planeNormal)

--- a/Prowl.Runtime/Math/Vector3.cs
+++ b/Prowl.Runtime/Math/Vector3.cs
@@ -95,9 +95,9 @@ namespace Prowl.Runtime
         /// <returns>The hash code.</returns>
         public override int GetHashCode()
         {
-            int hash = this.x.GetHashCode();
-            hash = HashCode.Combine(hash, this.y.GetHashCode());
-            hash = HashCode.Combine(hash, this.z.GetHashCode());
+            int hash = x.GetHashCode();
+            hash = HashCode.Combine(hash, y.GetHashCode());
+            hash = HashCode.Combine(hash, z.GetHashCode());
             return hash;
         }
 
@@ -157,13 +157,13 @@ namespace Prowl.Runtime
             StringBuilder sb = new StringBuilder();
             string separator = NumberFormatInfo.GetInstance(formatProvider).NumberGroupSeparator;
             sb.Append('<');
-            sb.Append(((IFormattable)this.x).ToString(format, formatProvider));
+            sb.Append(((IFormattable)x).ToString(format, formatProvider));
             sb.Append(separator);
             sb.Append(' ');
-            sb.Append(((IFormattable)this.y).ToString(format, formatProvider));
+            sb.Append(((IFormattable)y).ToString(format, formatProvider));
             sb.Append(separator);
             sb.Append(' ');
-            sb.Append(((IFormattable)this.z).ToString(format, formatProvider));
+            sb.Append(((IFormattable)z).ToString(format, formatProvider));
             sb.Append('>');
             return sb.ToString();
         }
@@ -201,7 +201,7 @@ namespace Prowl.Runtime
 
             double ls = dx * dx + dy * dy + dz * dz;
 
-            return (double)global::System.Math.Sqrt((double)ls);
+            return (double)Math.Sqrt((double)ls);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -248,7 +248,7 @@ namespace Prowl.Runtime
         public static Vector3 Normalize(Vector3 value)
         {
             double ls = value.x * value.x + value.y * value.y + value.z * value.z;
-            double length = (double)global::System.Math.Sqrt(ls);
+            double length = (double)Math.Sqrt(ls);
             return new Vector3(value.x / length, value.y / length, value.z / length);
         }
 
@@ -462,10 +462,10 @@ namespace Prowl.Runtime
         public static Vector3 ProjectOnPlane(Vector3 vector, Vector3 planeNormal)
         {
             // Normalize the plane normal to ensure it's a unit vector.
-            planeNormal = Vector3.Normalize(planeNormal);
+            planeNormal = Normalize(planeNormal);
 
             // Calculate the distance of the vector from the plane along the normal.
-            double distance = Vector3.Dot(vector, planeNormal);
+            double distance = Dot(vector, planeNormal);
 
             // Project the vector onto the plane.
             Vector3 projectedVector = vector - distance * planeNormal;

--- a/Prowl.Runtime/Math/Vector3Int.cs
+++ b/Prowl.Runtime/Math/Vector3Int.cs
@@ -161,7 +161,7 @@ namespace Prowl.Runtime
 
             double ls = dx * dx + dy * dy + dz * dz;
 
-            return (double)Math.Sqrt((double)ls);
+            return Math.Sqrt(ls);
         }
 
         /// <summary>

--- a/Prowl.Runtime/Math/Vector3Int.cs
+++ b/Prowl.Runtime/Math/Vector3Int.cs
@@ -67,9 +67,9 @@ namespace Prowl.Runtime
         /// <returns>The hash code.</returns>
         public override int GetHashCode()
         {
-            int hash = this.x.GetHashCode();
-            hash = HashCode.Combine(hash, this.y.GetHashCode());
-            hash = HashCode.Combine(hash, this.z.GetHashCode());
+            int hash = x.GetHashCode();
+            hash = HashCode.Combine(hash, y.GetHashCode());
+            hash = HashCode.Combine(hash, z.GetHashCode());
             return hash;
         }
 
@@ -93,7 +93,7 @@ namespace Prowl.Runtime
         /// <returns>True if the other Vector3Int is equal to this instance; False otherwise.</returns>
         public bool Equals(Vector3Int other)
         {
-            return this.x == other.x && this.y == other.y && this.z == other.z;
+            return x == other.x && y == other.y && z == other.z;
         }
 
 
@@ -128,13 +128,13 @@ namespace Prowl.Runtime
             StringBuilder sb = new StringBuilder();
             string separator = NumberFormatInfo.GetInstance(formatProvider).NumberGroupSeparator;
             sb.Append('<');
-            sb.Append(this.x.ToString(format, formatProvider));
+            sb.Append(x.ToString(format, formatProvider));
             sb.Append(separator);
             sb.Append(' ');
-            sb.Append(this.y.ToString(format, formatProvider));
+            sb.Append(y.ToString(format, formatProvider));
             sb.Append(separator);
             sb.Append(' ');
-            sb.Append(this.z.ToString(format, formatProvider));
+            sb.Append(z.ToString(format, formatProvider));
             sb.Append('>');
             return sb.ToString();
         }

--- a/Prowl.Runtime/Math/Vector4.cs
+++ b/Prowl.Runtime/Math/Vector4.cs
@@ -131,10 +131,10 @@ namespace Prowl.Runtime
         /// <returns>The hash code.</returns>
         public override int GetHashCode()
         {
-            int hash = this.x.GetHashCode();
-            hash = HashCode.Combine(hash, this.y.GetHashCode());
-            hash = HashCode.Combine(hash, this.z.GetHashCode());
-            hash = HashCode.Combine(hash, this.w.GetHashCode());
+            int hash = x.GetHashCode();
+            hash = HashCode.Combine(hash, y.GetHashCode());
+            hash = HashCode.Combine(hash, z.GetHashCode());
+            hash = HashCode.Combine(hash, w.GetHashCode());
             return hash;
         }
 
@@ -158,10 +158,10 @@ namespace Prowl.Runtime
         /// <returns>True if the other Vector4 is equal to this instance; False otherwise.</returns>
         public bool Equals(Vector4 other)
         {
-            return this.x == other.x
-                && this.y == other.y
-                && this.z == other.z
-                && this.w == other.w;
+            return x == other.x
+                && y == other.y
+                && z == other.z
+                && w == other.w;
         }
 
         /// <summary>
@@ -195,16 +195,16 @@ namespace Prowl.Runtime
             StringBuilder sb = new StringBuilder();
             string separator = NumberFormatInfo.GetInstance(formatProvider).NumberGroupSeparator;
             sb.Append('<');
-            sb.Append(this.x.ToString(format, formatProvider));
+            sb.Append(x.ToString(format, formatProvider));
             sb.Append(separator);
             sb.Append(' ');
-            sb.Append(this.y.ToString(format, formatProvider));
+            sb.Append(y.ToString(format, formatProvider));
             sb.Append(separator);
             sb.Append(' ');
-            sb.Append(this.z.ToString(format, formatProvider));
+            sb.Append(z.ToString(format, formatProvider));
             sb.Append(separator);
             sb.Append(' ');
-            sb.Append(this.w.ToString(format, formatProvider));
+            sb.Append(w.ToString(format, formatProvider));
             sb.Append('>');
             return sb.ToString();
         }

--- a/Prowl.Runtime/Math/Vector4.cs
+++ b/Prowl.Runtime/Math/Vector4.cs
@@ -118,7 +118,7 @@ namespace Prowl.Runtime
         public void Normalize()
         {
             double ls = x * x + y * y + z * z + w * w;
-            double invNorm = 1.0 / (double)Math.Sqrt((double)ls);
+            double invNorm = 1.0 / Math.Sqrt(ls);
             x *= invNorm;
             y *= invNorm;
             z *= invNorm;
@@ -239,7 +239,7 @@ namespace Prowl.Runtime
 
             double ls = dx * dx + dy * dy + dz * dz + dw * dw;
 
-            return (double)Math.Sqrt((double)ls);
+            return Math.Sqrt(ls);
         }
 
         /// <summary>
@@ -268,7 +268,7 @@ namespace Prowl.Runtime
         public static Vector4 Normalize(Vector4 vector)
         {
             double ls = vector.x * vector.x + vector.y * vector.y + vector.z * vector.z + vector.w * vector.w;
-            double invNorm = 1.0 / (double)Math.Sqrt((double)ls);
+            double invNorm = 1.0 / Math.Sqrt(ls);
 
             return new Vector4(
                 vector.x * invNorm,
@@ -530,7 +530,7 @@ namespace Prowl.Runtime
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static Vector4 SquareRoot(Vector4 value)
         {
-            return new Vector4((Double)Math.Sqrt(value.x), (Double)Math.Sqrt(value.y), (Double)Math.Sqrt(value.z), (Double)Math.Sqrt(value.w));
+            return new Vector4(Math.Sqrt(value.x), Math.Sqrt(value.y), Math.Sqrt(value.z), Math.Sqrt(value.w));
         }
         #endregion Public Static Methods
 

--- a/Prowl.Runtime/Math/Vector4Int .cs
+++ b/Prowl.Runtime/Math/Vector4Int .cs
@@ -71,10 +71,10 @@ namespace Prowl.Runtime
         /// <returns>The hash code.</returns>
         public override int GetHashCode()
         {
-            int hash = this.x.GetHashCode();
-            hash = HashCode.Combine(hash, this.y.GetHashCode());
-            hash = HashCode.Combine(hash, this.z.GetHashCode());
-            hash = HashCode.Combine(hash, this.w.GetHashCode());
+            int hash = x.GetHashCode();
+            hash = HashCode.Combine(hash, y.GetHashCode());
+            hash = HashCode.Combine(hash, z.GetHashCode());
+            hash = HashCode.Combine(hash, w.GetHashCode());
             return hash;
         }
 
@@ -98,7 +98,7 @@ namespace Prowl.Runtime
         /// <returns>True if the other Vector4Int is equal to this instance; False otherwise.</returns>
         public bool Equals(Vector4Int other)
         {
-            return this.x == other.x && this.y == other.y && this.z == other.z && this.w == other.w;
+            return x == other.x && y == other.y && z == other.z && w == other.w;
         }
 
 
@@ -133,16 +133,16 @@ namespace Prowl.Runtime
             StringBuilder sb = new StringBuilder();
             string separator = NumberFormatInfo.GetInstance(formatProvider).NumberGroupSeparator;
             sb.Append('<');
-            sb.Append(this.x.ToString(format, formatProvider));
+            sb.Append(x.ToString(format, formatProvider));
             sb.Append(separator);
             sb.Append(' ');
-            sb.Append(this.y.ToString(format, formatProvider));
+            sb.Append(y.ToString(format, formatProvider));
             sb.Append(separator);
             sb.Append(' ');
-            sb.Append(this.z.ToString(format, formatProvider));
+            sb.Append(z.ToString(format, formatProvider));
             sb.Append(separator);
             sb.Append(' ');
-            sb.Append(this.w.ToString(format, formatProvider));
+            sb.Append(w.ToString(format, formatProvider));
             sb.Append('>');
 
             return sb.ToString();

--- a/Prowl.Runtime/Rendering/BindableResourceSet.cs
+++ b/Prowl.Runtime/Rendering/BindableResourceSet.cs
@@ -18,8 +18,8 @@ namespace Prowl.Runtime
         public ResourceSetDescription description;
         private ResourceSet resources;
 
-        private DeviceBuffer[] uniformBuffers;
-        private byte[][] intermediateBuffers;
+        private readonly DeviceBuffer[] uniformBuffers;
+        private readonly byte[][] intermediateBuffers;
 
 
         public BindableResourceSet(ShaderPipeline pipeline, ResourceSetDescription description, DeviceBuffer[] buffers, byte[][] intermediate)

--- a/Prowl.Runtime/Rendering/BindableResourceSet.cs
+++ b/Prowl.Runtime/Rendering/BindableResourceSet.cs
@@ -24,10 +24,10 @@ namespace Prowl.Runtime
 
         public BindableResourceSet(ShaderPipeline pipeline, ResourceSetDescription description, DeviceBuffer[] buffers, byte[][] intermediate)
         {
-            this.Pipeline = pipeline;
+            Pipeline = pipeline;
             this.description = description;
-            this.uniformBuffers = buffers;
-            this.intermediateBuffers = buffers.Select(x => new byte[x.SizeInBytes]).ToArray();
+            uniformBuffers = buffers;
+            intermediateBuffers = buffers.Select(x => new byte[x.SizeInBytes]).ToArray();
         }
 
 

--- a/Prowl.Runtime/Rendering/CommandBuffer.cs
+++ b/Prowl.Runtime/Rendering/CommandBuffer.cs
@@ -15,7 +15,7 @@ namespace Prowl.Runtime
         private Framebuffer _activeFramebuffer;
         private KeywordState _keywordState;
 
-        private PropertyState _bufferProperties;
+        private readonly PropertyState _bufferProperties;
         private IGeometryDrawData _activeDrawData;
 
         private ShaderPipelineDescription _pipelineDescription;

--- a/Prowl.Runtime/Rendering/GraphicsBuffer.cs
+++ b/Prowl.Runtime/Rendering/GraphicsBuffer.cs
@@ -21,8 +21,8 @@ namespace Prowl.Runtime
 
         public GraphicsBuffer(uint count, uint stride, bool writable)
         {
-            this.Count = count;
-            this.Stride = stride;
+            Count = count;
+            Stride = stride;
             Buffer = Graphics.Factory.CreateBuffer(new BufferDescription(count * stride,
                 writable ? BufferUsage.StructuredBufferReadWrite : BufferUsage.StructuredBufferReadOnly));
         }

--- a/Prowl.Runtime/Rendering/KeywordState.cs
+++ b/Prowl.Runtime/Rendering/KeywordState.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Collections.Immutable;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 

--- a/Prowl.Runtime/Rendering/KeywordState.cs
+++ b/Prowl.Runtime/Rendering/KeywordState.cs
@@ -56,9 +56,9 @@ namespace Prowl.Runtime
 
         public KeywordState(KeywordState other)
         {
-            this._hash = other._hash;
-            this._hasValidHash = other._hasValidHash;
-            this._keyValuePairs = new(other._keyValuePairs);
+            _hash = other._hash;
+            _hasValidHash = other._hasValidHash;
+            _keyValuePairs = new(other._keyValuePairs);
         }
 
         public static KeywordState Combine(KeywordState source, KeywordState add)

--- a/Prowl.Runtime/Rendering/Mesh.cs
+++ b/Prowl.Runtime/Rendering/Mesh.cs
@@ -352,8 +352,7 @@ namespace Prowl.Runtime
 
         public void RecalculateBounds()
         {
-            if (vertices == null)
-                throw new ArgumentNullException();
+             ArgumentNullException.ThrowIfNull(vertices);
 
             if (vertices.Length < 1)
                 throw new ArgumentException();

--- a/Prowl.Runtime/Rendering/Mesh.cs
+++ b/Prowl.Runtime/Rendering/Mesh.cs
@@ -502,9 +502,9 @@ namespace Prowl.Runtime
         {
             Mesh mesh = new Mesh();
 
-            List<Vector3F> vertices = new List<Vector3F>();
-            List<Vector2F> uvs = new List<Vector2F>();
-            List<ushort> indices = new List<ushort>();
+            List<Vector3F> vertices = [];
+            List<Vector2F> uvs = [];
+            List<ushort> indices = [];
 
             for (int i = 0; i <= rings; i++)
             {
@@ -562,7 +562,7 @@ namespace Prowl.Runtime
             float z = (float)size.z / 2f;
 
             Vector3F[] vertices =
-            {
+            [
                 // Front face
                 new(-x, -y, z), new(x, -y, z), new(x, y, z), new(-x, y, z),
 
@@ -580,10 +580,10 @@ namespace Prowl.Runtime
 
                 // Bottom face
                 new(-x, -y, -z), new(x, -y, -z), new(x, -y, z), new(-x, -y, z)
-            };
+            ];
 
             Vector2F[] uvs =
-            {
+            [
                 // Front face
                 new(0, 0), new(1, 0), new(1, 1), new(0, 1),
                 // Back face
@@ -596,17 +596,17 @@ namespace Prowl.Runtime
                 new(0, 1), new(1, 1), new(1, 0), new(0, 0),
                 // Bottom face
                 new(0, 0), new(1, 0), new(1, 1), new(0, 1)
-            };
+            ];
 
             ushort[] indices =
-            {
+            [
                 1, 2, 0, 0, 2, 3,       // Front face
                 5, 4, 6, 6, 4, 7,       // Back face
                 9, 8, 10, 10, 8, 11,    // Left face
                 13, 12, 14, 14, 12, 15, // Right face
                 17, 18, 16, 16, 18, 19, // Top face
                 21, 22, 20, 20, 22, 23  // Bottom face
-            };
+            ];
 
             mesh.Vertices = vertices;
             mesh.UV = uvs;
@@ -625,9 +625,9 @@ namespace Prowl.Runtime
 #warning TODO: Test, This hasent been tested like at all just assumed it will work
             Mesh mesh = new Mesh();
 
-            List<Vector3F> vertices = new List<Vector3F>();
-            List<Vector2F> uvs = new List<Vector2F>();
-            List<ushort> indices = new List<ushort>();
+            List<Vector3F> vertices = [];
+            List<Vector2F> uvs = [];
+            List<ushort> indices = [];
 
             float halfLength = length / 2.0f;
 

--- a/Prowl.Runtime/Rendering/PropertyBlock.cs
+++ b/Prowl.Runtime/Rendering/PropertyBlock.cs
@@ -1,10 +1,6 @@
 // This file is part of the Prowl Game Engine
 // Licensed under the MIT License. See the LICENSE file in the project root for details.
 
-using System;
-using System.Collections.Generic;
-using System.Runtime.InteropServices;
-
 using Matrix4x4F = System.Numerics.Matrix4x4;
 using Vector2F = System.Numerics.Vector2;
 using Vector3F = System.Numerics.Vector3;

--- a/Prowl.Runtime/Rendering/PropertyBlock.cs
+++ b/Prowl.Runtime/Rendering/PropertyBlock.cs
@@ -11,7 +11,7 @@ namespace Prowl.Runtime
     public class PropertyBlock
     {
         [SerializeField, HideInInspector]
-        private PropertyState _internalState;
+        private readonly PropertyState _internalState;
 
         public PropertyBlock()
         {

--- a/Prowl.Runtime/Rendering/PropertyState.cs
+++ b/Prowl.Runtime/Rendering/PropertyState.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 using Matrix4x4F = System.Numerics.Matrix4x4;

--- a/Prowl.Runtime/Rendering/RenderPipeline/IRenderable.cs
+++ b/Prowl.Runtime/Rendering/RenderPipeline/IRenderable.cs
@@ -1,9 +1,6 @@
 // This file is part of the Prowl Game Engine
 // Licensed under the MIT License. See the LICENSE file in the project root for details.
 
-using Veldrid;
-
-
 namespace Prowl.Runtime
 {
     public interface IRenderable

--- a/Prowl.Runtime/Rendering/RenderPipeline/RenderPipeline.cs
+++ b/Prowl.Runtime/Rendering/RenderPipeline/RenderPipeline.cs
@@ -31,9 +31,9 @@ namespace Prowl.Runtime.RenderPipelines
 
     public abstract class RenderPipeline : EngineObject
     {
-        private static Dictionary<Material, List<IRenderable>> s_batchedRenderables = [];
+        private static readonly Dictionary<Material, List<IRenderable>> s_batchedRenderables = [];
 
-        private static List<IRenderableLight> s_lights = [];
+        private static readonly List<IRenderableLight> s_lights = [];
 
 
         public static void AddRenderable(IRenderable renderable)

--- a/Prowl.Runtime/Rendering/Shader/Shader.cs
+++ b/Prowl.Runtime/Rendering/Shader/Shader.cs
@@ -32,12 +32,12 @@ namespace Prowl.Runtime
     public sealed class Shader : EngineObject, ISerializationCallbackReceiver
     {
         [SerializeField, HideInInspector]
-        private ShaderProperty[] properties;
+        private readonly ShaderProperty[] properties;
         public IEnumerable<ShaderProperty> Properties => properties;
 
 
         [SerializeField, HideInInspector]
-        private ShaderPass[] passes;
+        private readonly ShaderPass[] passes;
         public IEnumerable<ShaderPass> Passes => passes;
 
 

--- a/Prowl.Runtime/Rendering/Shader/ShaderPass.cs
+++ b/Prowl.Runtime/Rendering/Shader/ShaderPass.cs
@@ -103,19 +103,19 @@ namespace Prowl.Runtime
 
         public ShaderPass(string name, ShaderPassDescription description, ShaderVariant[] variants)
         {
-            this._name = name;
+            _name = name;
 
-            this._tags = description.Tags ?? new();
-            this._blend = description.BlendState ?? BlendStateDescription.SingleOverrideBlend;
-            this._depthStencilState = description.DepthStencilState ?? DepthStencilStateDescription.DepthOnlyLessEqual;
-            this._cullMode = description.CullingMode ?? FaceCullMode.Back;
-            this._depthClipEnabled = description.DepthClipEnabled ?? true;
-            this._keywords = description.Keywords ?? new() { { string.Empty, [string.Empty] } };
+            _tags = description.Tags ?? new();
+            _blend = description.BlendState ?? BlendStateDescription.SingleOverrideBlend;
+            _depthStencilState = description.DepthStencilState ?? DepthStencilStateDescription.DepthOnlyLessEqual;
+            _cullMode = description.CullingMode ?? FaceCullMode.Back;
+            _depthClipEnabled = description.DepthClipEnabled ?? true;
+            _keywords = description.Keywords ?? new() { { string.Empty, [string.Empty] } };
 
-            this._variants = new();
+            _variants = new();
 
             foreach (var variant in variants)
-                this._variants[variant.VariantKeywords] = variant;
+                _variants[variant.VariantKeywords] = variant;
         }
 
         public ShaderVariant GetVariant(KeywordState? keywordID = null)

--- a/Prowl.Runtime/Rendering/Shader/ShaderPass.cs
+++ b/Prowl.Runtime/Rendering/Shader/ShaderPass.cs
@@ -172,7 +172,7 @@ namespace Prowl.Runtime
             _keywords = new();
 
             for (int i = 0; i < _serializedKeywordKeys.Length; i++)
-                _keywords.Add(_serializedKeywordKeys[i], new(_serializedKeywordValues[i]));
+                _keywords.Add(_serializedKeywordKeys[i], [.._serializedKeywordValues[i]]);
 
             _variants = new();
 

--- a/Prowl.Runtime/Rendering/Shader/ShaderPass.cs
+++ b/Prowl.Runtime/Rendering/Shader/ShaderPass.cs
@@ -40,22 +40,22 @@ namespace Prowl.Runtime
     public sealed class ShaderPass : ISerializationCallbackReceiver
     {
         [SerializeField, HideInInspector]
-        private string _name;
+        private readonly string _name;
 
         [SerializeField, HideInInspector]
-        private Dictionary<string, string> _tags;
+        private readonly Dictionary<string, string> _tags;
 
         [SerializeField, HideInInspector]
-        private BlendStateDescription _blend;
+        private readonly BlendStateDescription _blend;
 
         [SerializeField, HideInInspector]
-        private DepthStencilStateDescription _depthStencilState;
+        private readonly DepthStencilStateDescription _depthStencilState;
 
         [SerializeField, HideInInspector]
-        private FaceCullMode _cullMode = FaceCullMode.Back;
+        private readonly FaceCullMode _cullMode = FaceCullMode.Back;
 
         [SerializeField, HideInInspector]
-        private bool _depthClipEnabled = true;
+        private readonly bool _depthClipEnabled = true;
 
         [NonSerialized]
         private Dictionary<string, HashSet<string>> _keywords;

--- a/Prowl.Runtime/Rendering/Shader/ShaderPipeline.cs
+++ b/Prowl.Runtime/Rendering/Shader/ShaderPipeline.cs
@@ -55,7 +55,7 @@ namespace Prowl.Runtime
 
         public ShaderUniform[] Uniforms => shader.Uniforms;
 
-        private Veldrid.GraphicsPipelineDescription description;
+        private GraphicsPipelineDescription description;
 
         private static readonly int pipelineCount = 20; // 20 possible combinations (5 topologies, 2 fill modes, 2 scissor modes)
         private readonly Pipeline[] pipelines;
@@ -80,14 +80,14 @@ namespace Prowl.Runtime
 
         public ShaderPipeline(ShaderPipelineDescription description)
         {
-            this.shader = description.variant;
+            shader = description.variant;
 
             ShaderDescription[] shaderDescriptions = shader.GetProgramsForBackend();
 
             // Create shader set description
             Veldrid.Shader[] shaders = new Veldrid.Shader[shaderDescriptions.Length];
 
-            this.semanticLookup = new();
+            semanticLookup = new();
 
             for (int shaderIndex = 0; shaderIndex < shaders.Length; shaderIndex++)
                 shaders[shaderIndex] = Graphics.Factory.CreateShader(shaderDescriptions[shaderIndex]);
@@ -105,10 +105,10 @@ namespace Prowl.Runtime
                 semanticLookup[input.semantic] = (uint)inputIndex;
             }
 
-            this.shaderSet = new ShaderSetDescription(vertexLayouts, shaders);
+            shaderSet = new ShaderSetDescription(vertexLayouts, shaders);
 
             // Create resource layout and uniform lookups
-            this.bufferLookup = new();
+            bufferLookup = new();
 
             ResourceLayoutDescription layoutDescription = new ResourceLayoutDescription(
                 new ResourceLayoutElementDescription[Uniforms.Length]);
@@ -128,9 +128,9 @@ namespace Prowl.Runtime
                 bufferCount++;
             }
 
-            this.resourceLayout = Graphics.Factory.CreateResourceLayout(layoutDescription);
+            resourceLayout = Graphics.Factory.CreateResourceLayout(layoutDescription);
 
-            this.pipelines = new Pipeline[pipelineCount];
+            pipelines = new Pipeline[pipelineCount];
 
             RasterizerStateDescription rasterizerState = new(
                 description.pass.CullMode,

--- a/Prowl.Runtime/Rendering/Shader/ShaderPipeline.cs
+++ b/Prowl.Runtime/Rendering/Shader/ShaderPipeline.cs
@@ -48,17 +48,17 @@ namespace Prowl.Runtime
         public readonly ShaderSetDescription shaderSet;
         public readonly ResourceLayout resourceLayout;
 
-        private Dictionary<string, uint> semanticLookup;
-        private Dictionary<string, uint> bufferLookup;
+        private readonly Dictionary<string, uint> semanticLookup;
+        private readonly Dictionary<string, uint> bufferLookup;
 
-        private byte bufferCount;
+        private readonly byte bufferCount;
 
         public ShaderUniform[] Uniforms => shader.Uniforms;
 
         private Veldrid.GraphicsPipelineDescription description;
 
         private static readonly int pipelineCount = 20; // 20 possible combinations (5 topologies, 2 fill modes, 2 scissor modes)
-        private Pipeline[] pipelines;
+        private readonly Pipeline[] pipelines;
 
 
         public Pipeline GetPipeline(PolygonFillMode fill, PrimitiveTopology topology, bool scissor)

--- a/Prowl.Runtime/Rendering/Shader/ShaderPipelineCache.cs
+++ b/Prowl.Runtime/Rendering/Shader/ShaderPipelineCache.cs
@@ -8,7 +8,7 @@ namespace Prowl.Runtime
 {
     public static class ShaderPipelineCache
     {
-        private static Dictionary<ShaderPipelineDescription, ShaderPipeline> pipelineCache = new();
+        private static readonly Dictionary<ShaderPipelineDescription, ShaderPipeline> pipelineCache = new();
 
 
         internal static ShaderPipeline GetPipeline(in ShaderPipelineDescription description)

--- a/Prowl.Runtime/Rendering/Shader/ShaderUniform.cs
+++ b/Prowl.Runtime/Rendering/Shader/ShaderUniform.cs
@@ -1,7 +1,6 @@
 // This file is part of the Prowl Game Engine
 // Licensed under the MIT License. See the LICENSE file in the project root for details.
 
-using System;
 using System.Linq;
 using System.Text;
 

--- a/Prowl.Runtime/Rendering/Shader/ShaderUniform.cs
+++ b/Prowl.Runtime/Rendering/Shader/ShaderUniform.cs
@@ -52,16 +52,16 @@ namespace Prowl.Runtime
         public ShaderUniform(string rawName, uint binding, ResourceKind kind)
         {
             this.kind = kind;
-            this.name = CleanseName(rawName);
+            name = CleanseName(rawName);
             this.binding = binding;
-            this.members = [];
+            members = [];
         }
 
 
         public ShaderUniform(string rawName, uint binding, uint size, ShaderUniformMember[] members)
         {
-            this.kind = ResourceKind.UniformBuffer;
-            this.name = CleanseName(rawName);
+            kind = ResourceKind.UniformBuffer;
+            name = CleanseName(rawName);
             this.binding = binding;
             this.size = size;
             this.members = members;

--- a/Prowl.Runtime/Rendering/Shader/ShaderVariant.cs
+++ b/Prowl.Runtime/Rendering/Shader/ShaderVariant.cs
@@ -11,7 +11,7 @@ namespace Prowl.Runtime
     public sealed class ShaderVariant : ISerializationCallbackReceiver
     {
         [SerializeField, HideInInspector]
-        private KeywordState variantKeywords;
+        private readonly KeywordState variantKeywords;
 
 
         [HideInInspector]

--- a/Prowl.Runtime/Rendering/Shader/ShaderVariant.cs
+++ b/Prowl.Runtime/Rendering/Shader/ShaderVariant.cs
@@ -47,7 +47,7 @@ namespace Prowl.Runtime
 
         public ShaderVariant(KeywordState keywords)
         {
-            this.variantKeywords = keywords;
+            variantKeywords = keywords;
         }
 
         public ShaderDescription[] GetProgramsForBackend()

--- a/Prowl.Runtime/Rendering/Texture/RenderTexture.cs
+++ b/Prowl.Runtime/Rendering/Texture/RenderTexture.cs
@@ -291,7 +291,7 @@ namespace Prowl.Runtime
 
         #region Pool
 
-        private static Dictionary<RenderTextureDescription, List<(RenderTexture, long frameCreated)>> pool = [];
+        private static readonly Dictionary<RenderTextureDescription, List<(RenderTexture, long frameCreated)>> pool = [];
 
         private const int MaxUnusedFrames = 10;
 

--- a/Prowl.Runtime/Rendering/Texture/RenderTexture.cs
+++ b/Prowl.Runtime/Rendering/Texture/RenderTexture.cs
@@ -28,26 +28,26 @@ namespace Prowl.Runtime
             PixelFormat? depthFormat,
             PixelFormat[] colorFormats,
             bool sampled = true, bool randomWrite = false,
-            TextureSampleCount sampleCount = Veldrid.TextureSampleCount.Count1)
+            TextureSampleCount sampleCount = TextureSampleCount.Count1)
         {
             this.width = width;
             this.height = height;
-            this.depthBufferFormat = depthFormat;
-            this.colorBufferFormats = colorFormats;
+            depthBufferFormat = depthFormat;
+            colorBufferFormats = colorFormats;
             this.sampled = sampled;
-            this.enableRandomWrite = randomWrite;
+            enableRandomWrite = randomWrite;
             this.sampleCount = sampleCount;
         }
 
         public RenderTextureDescription(RenderTexture texture)
         {
-            this.width = texture.Width;
-            this.height = texture.Height;
-            this.depthBufferFormat = texture.DepthBuffer?.Format;
-            this.colorBufferFormats = texture.ColorBuffers.Select(x => x.Format).ToArray();
-            this.sampled = texture.Sampled;
-            this.enableRandomWrite = texture.RandomWriteEnabled;
-            this.sampleCount = texture.SampleCount;
+            width = texture.Width;
+            height = texture.Height;
+            depthBufferFormat = texture.DepthBuffer?.Format;
+            colorBufferFormats = texture.ColorBuffers.Select(x => x.Format).ToArray();
+            sampled = texture.Sampled;
+            enableRandomWrite = texture.RandomWriteEnabled;
+            sampleCount = texture.SampleCount;
         }
 
         public override bool Equals([NotNullWhen(true)] object? obj)
@@ -156,11 +156,11 @@ namespace Prowl.Runtime
             if (colorFormats != null && colorFormats.Length > colorAttachmentLimit)
                 throw new Exception($"Invalid number of color buffers! [0-{colorAttachmentLimit}]");
 
-            this.Width = width;
-            this.Height = height;
-            this.Sampled = sampled;
-            this.RandomWriteEnabled = enableRandomWrite;
-            this.SampleCount = sampleCount;
+            Width = width;
+            Height = height;
+            Sampled = sampled;
+            RandomWriteEnabled = enableRandomWrite;
+            SampleCount = sampleCount;
 
             if (depthFormat != null)
             {
@@ -184,7 +184,7 @@ namespace Prowl.Runtime
 
             FramebufferDescription description = new FramebufferDescription(DepthBuffer?.InternalTexture, ColorBuffers.Select(x => x.InternalTexture).ToArray());
 
-            this.Framebuffer = Graphics.Factory.CreateFramebuffer(description);
+            Framebuffer = Graphics.Factory.CreateFramebuffer(description);
         }
 
         public override void OnDispose()

--- a/Prowl.Runtime/Rendering/Texture/Texture.cs
+++ b/Prowl.Runtime/Rendering/Texture/Texture.cs
@@ -50,7 +50,7 @@ namespace Prowl.Runtime
         internal Veldrid.Texture InternalTexture { get; private set; }
 
         /// <inheritdoc cref="Veldrid.TextureView"/>
-        internal Veldrid.TextureView TextureView { get; private set; }
+        internal TextureView TextureView { get; private set; }
 
 
         private Veldrid.Texture stagingTexture = null;

--- a/Prowl.Runtime/Rendering/Texture/Texture2D.cs
+++ b/Prowl.Runtime/Rendering/Texture/Texture2D.cs
@@ -143,10 +143,10 @@ namespace Prowl.Runtime
             {
                 Width = width,
                 Height = height,
-                MipLevels = this.MipLevels,
-                Format = this.Format,
-                Usage = this.Usage,
-                Type = this.Type,
+                MipLevels = MipLevels,
+                Format = Format,
+                Usage = Usage,
+                Type = Type,
             });
         }
 

--- a/Prowl.Runtime/Rendering/Texture/Texture2D.cs
+++ b/Prowl.Runtime/Rendering/Texture/Texture2D.cs
@@ -176,7 +176,7 @@ namespace Prowl.Runtime
 
             uint width = (uint)value["Width"].IntValue;
             uint height = (uint)value["Height"].IntValue;
-            uint mips = (uint)value["MipLevels"].UIntValue;
+            uint mips = value["MipLevels"].UIntValue;
             bool isMipMapped = value["IsMipMapped"].BoolValue;
             PixelFormat imageFormat = (PixelFormat)value["ImageFormat"].IntValue;
             TextureUsage usage = (TextureUsage)value["Usage"].IntValue;

--- a/Prowl.Runtime/Rendering/Texture/Texture2DArray.cs
+++ b/Prowl.Runtime/Rendering/Texture/Texture2DArray.cs
@@ -113,11 +113,11 @@ namespace Prowl.Runtime
             {
                 Width = width,
                 Height = height,
-                MipLevels = this.MipLevels,
+                MipLevels = MipLevels,
                 ArrayLayers = layers,
-                Format = this.Format,
-                Usage = this.Usage,
-                Type = this.Type,
+                Format = Format,
+                Usage = Usage,
+                Type = Type,
             });
         }
 

--- a/Prowl.Runtime/Rendering/Texture/Texture3D.cs
+++ b/Prowl.Runtime/Rendering/Texture/Texture3D.cs
@@ -107,10 +107,10 @@ namespace Prowl.Runtime
                 Width = width,
                 Height = height,
                 Depth = depth,
-                MipLevels = this.MipLevels,
-                Format = this.Format,
-                Usage = this.Usage,
-                Type = this.Type,
+                MipLevels = MipLevels,
+                Format = Format,
+                Usage = Usage,
+                Type = Type,
             });
         }
 

--- a/Prowl.Runtime/Rendering/Texture/TextureSampler.cs
+++ b/Prowl.Runtime/Rendering/Texture/TextureSampler.cs
@@ -102,15 +102,15 @@ namespace Prowl.Runtime
 
         public void Copy(TextureSampler other)
         {
-            this.WrapModeU = other.WrapModeU;
-            this.WrapModeV = other.WrapModeV;
-            this.WrapModeW = other.WrapModeW;
-            this.BorderColor = other.BorderColor;
-            this.Filter = other.Filter;
-            this.LodBias = other.LodBias;
-            this.MaximumAnisotropy = other.MaximumAnisotropy;
-            this.MaximumLod = other.MaximumLod;
-            this.MinimumLod = other.MinimumLod;
+            WrapModeU = other.WrapModeU;
+            WrapModeV = other.WrapModeV;
+            WrapModeW = other.WrapModeW;
+            BorderColor = other.BorderColor;
+            Filter = other.Filter;
+            LodBias = other.LodBias;
+            MaximumAnisotropy = other.MaximumAnisotropy;
+            MaximumLod = other.MaximumLod;
+            MinimumLod = other.MinimumLod;
         }
 
         public void SetWrapMode(SamplerAxis axis, TextureWrapMode mode)

--- a/Prowl.Runtime/Resources/Font.cs
+++ b/Prowl.Runtime/Resources/Font.cs
@@ -726,7 +726,7 @@ namespace Prowl.Runtime
                 using (MemoryStream ms = new())
                 {
                     stream.CopyTo(ms);
-                    builder.Add(ms.ToArray(), 40, [Font.CharacterRange.BasicLatin]);
+                    builder.Add(ms.ToArray(), 40, [CharacterRange.BasicLatin]);
                 }
             }
             using (Stream stream = assembly.GetManifestResourceStream($"Prowl.Runtime.EmbeddedResources.{FontAwesome6.FontIconFileNameFAR}"))
@@ -734,7 +734,7 @@ namespace Prowl.Runtime
                 using (MemoryStream ms = new())
                 {
                     stream.CopyTo(ms);
-                    builder.Add(ms.ToArray(), 40 * 2.0f / 3.0f, [new Font.CharacterRange(FontAwesome6.IconMin, FontAwesome6.IconMax)]);
+                    builder.Add(ms.ToArray(), 40 * 2.0f / 3.0f, [new CharacterRange(FontAwesome6.IconMin, FontAwesome6.IconMax)]);
                 }
             }
             using (Stream stream = assembly.GetManifestResourceStream($"Prowl.Runtime.EmbeddedResources.{FontAwesome6.FontIconFileNameFAS}"))
@@ -742,7 +742,7 @@ namespace Prowl.Runtime
                 using (MemoryStream ms = new())
                 {
                     stream.CopyTo(ms);
-                    builder.Add(ms.ToArray(), 40 * 2.0f / 3.0f, [new Font.CharacterRange(FontAwesome6.IconMin, FontAwesome6.IconMax)]);
+                    builder.Add(ms.ToArray(), 40 * 2.0f / 3.0f, [new CharacterRange(FontAwesome6.IconMin, FontAwesome6.IconMax)]);
                 }
             }
 

--- a/Prowl.Runtime/Resources/Font.cs
+++ b/Prowl.Runtime/Resources/Font.cs
@@ -636,7 +636,7 @@ namespace Prowl.Runtime
                 if (fontInfo == null)
                     throw new Exception("Failed to init font.");
 
-                var scaleFactor = StbTrueType.stbtt_ScaleForPixelHeight(fontInfo, (float)fontsize);
+                var scaleFactor = StbTrueType.stbtt_ScaleForPixelHeight(fontInfo, fontsize);
 
                 int ascent, descent, lineGap;
                 StbTrueType.stbtt_GetFontVMetrics(fontInfo, &ascent, &descent, &lineGap);
@@ -649,7 +649,7 @@ namespace Prowl.Runtime
                     var cd = new StbTrueType.stbtt_packedchar[range.End - range.Start + 1];
                     fixed (StbTrueType.stbtt_packedchar* chardataPtr = cd)
                     {
-                        StbTrueType.stbtt_PackFontRange(_context, fontInfo.data, 0, (float)fontsize,
+                        StbTrueType.stbtt_PackFontRange(_context, fontInfo.data, 0, fontsize,
                             range.Start,
                             range.End - range.Start + 1,
                             chardataPtr);

--- a/Prowl.Runtime/Serializer/Formats/StringTagConverter.cs
+++ b/Prowl.Runtime/Serializer/Formats/StringTagConverter.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
-using System.Linq;
 
 namespace Prowl.Runtime
 {

--- a/Prowl.Runtime/Serializer/SerializedProperty.Compound.cs
+++ b/Prowl.Runtime/Serializer/SerializedProperty.Compound.cs
@@ -113,7 +113,7 @@ namespace Prowl.Runtime
         /// </summary>
         public static SerializedProperty Merge(List<SerializedProperty> allTags)
         {
-            SerializedProperty result = SerializedProperty.NewCompound();
+            SerializedProperty result = NewCompound();
             if (allTags.Count == 0) return result;
 
             var referenceTag = allTags[0];
@@ -215,7 +215,7 @@ namespace Prowl.Runtime
                 throw new InvalidOperationException("Cannot get the difference from a non-compound tag");
 
 
-            SerializedProperty result = SerializedProperty.NewCompound();
+            SerializedProperty result = NewCompound();
 
             foreach (var kvp in Tags)
             {

--- a/Prowl.Runtime/Serializer/SerializedProperty.Compound.cs
+++ b/Prowl.Runtime/Serializer/SerializedProperty.Compound.cs
@@ -19,9 +19,9 @@ namespace Prowl.Runtime
                 if (TagType != PropertyType.Compound)
                     throw new InvalidOperationException("Cannot set tag on non-compound tag");
                 else if (tagName == null)
-                    throw new ArgumentNullException("tagName");
+                    throw new ArgumentNullException(nameof(tagName));
                 else if (value == null)
-                    throw new ArgumentNullException("value");
+                    throw new ArgumentNullException(nameof(value));
                 Tags[tagName] = value;
                 value.Parent = this;
             }

--- a/Prowl.Runtime/Utils/AssetBundle.cs
+++ b/Prowl.Runtime/Utils/AssetBundle.cs
@@ -168,7 +168,7 @@ namespace Prowl.Runtime.Utils
         {
             folderPath = NormalizePath(folderPath);
 
-            List<string> assets = new();
+            List<string> assets = [];
             foreach (var path in _pathToEntry.Keys)
             {
                 // Check if the path is within the specified folder (or subdirectory)
@@ -196,7 +196,7 @@ namespace Prowl.Runtime.Utils
 
         public List<string> GetRootFolders()
         {
-            HashSet<string> folders = new();
+            HashSet<string> folders = [];
 
             foreach (var path in _pathToEntry.Keys)
             {
@@ -208,14 +208,14 @@ namespace Prowl.Runtime.Utils
                 }
             }
 
-            return new List<string>(folders);
+            return [..folders];
         }
 
         public List<string> GetFolders(string folderPath)
         {
             folderPath = NormalizePath(folderPath);
 
-            List<string> folders = new();
+            List<string> folders = [];
 
             foreach (var path in _pathToEntry.Keys)
             {

--- a/Prowl.Runtime/Utils/MultiValueDictionary.cs
+++ b/Prowl.Runtime/Utils/MultiValueDictionary.cs
@@ -133,8 +133,7 @@ namespace Prowl.Runtime
         /// <remarks>If <paramref name="comparer"/> is set to null, then the default <see cref="IEqualityComparer" /> for <typeparamref name="TKey"/> is used.</remarks>
         public MultiValueDictionary(IEnumerable<KeyValuePair<TKey, IReadOnlyCollection<TValue>>> enumerable, IEqualityComparer<TKey> comparer)
         {
-            if (enumerable == null)
-                throw new ArgumentNullException(nameof(enumerable));
+            ArgumentNullException.ThrowIfNull(enumerable);
 
             _dictionary = new Dictionary<TKey, InnerCollectionView>(comparer);
             foreach (var pair in enumerable)
@@ -631,8 +630,8 @@ namespace Prowl.Runtime
         /// </remarks>
         public void Add(TKey key, TValue value)
         {
-            if (key == null)
-                throw new ArgumentNullException(nameof(key));
+            ArgumentNullException.ThrowIfNull(key);
+
             if (!_dictionary.TryGetValue(key, out InnerCollectionView collection))
             {
                 collection = new InnerCollectionView(key, NewCollectionFactory());

--- a/Prowl.Runtime/Utils/NodeSystem/Node.cs
+++ b/Prowl.Runtime/Utils/NodeSystem/Node.cs
@@ -112,7 +112,7 @@ namespace Prowl.Runtime.NodeSystem
         /// <summary> Convenience function. </summary>
         /// <seealso cref="AddInstancePort"/>
         /// <seealso cref="AddInstanceOutput"/>
-        public NodePort AddDynamicInput(Type type, Node.ConnectionType connectionType = Node.ConnectionType.Override, Node.TypeConstraint typeConstraint = TypeConstraint.None, string fieldName = null, bool onHeader = false)
+        public NodePort AddDynamicInput(Type type, ConnectionType connectionType = ConnectionType.Override, TypeConstraint typeConstraint = TypeConstraint.None, string fieldName = null, bool onHeader = false)
         {
             return AddDynamicPort(type, NodePort.IO.Input, connectionType, typeConstraint, fieldName);
         }
@@ -120,7 +120,7 @@ namespace Prowl.Runtime.NodeSystem
         /// <summary> Convenience function. </summary>
         /// <seealso cref="AddInstancePort"/>
         /// <seealso cref="AddInstanceInput"/>
-        public NodePort AddDynamicOutput(Type type, Node.ConnectionType connectionType = Node.ConnectionType.Override, Node.TypeConstraint typeConstraint = TypeConstraint.None, string fieldName = null, bool onHeader = false)
+        public NodePort AddDynamicOutput(Type type, ConnectionType connectionType = ConnectionType.Override, TypeConstraint typeConstraint = TypeConstraint.None, string fieldName = null, bool onHeader = false)
         {
             return AddDynamicPort(type, NodePort.IO.Output, connectionType, typeConstraint, fieldName);
         }
@@ -128,7 +128,7 @@ namespace Prowl.Runtime.NodeSystem
         /// <summary> Add a dynamic, serialized port to this node. </summary>
         /// <seealso cref="AddDynamicInput"/>
         /// <seealso cref="AddDynamicOutput"/>
-        private NodePort AddDynamicPort(Type type, NodePort.IO direction, Node.ConnectionType connectionType = Node.ConnectionType.Override, Node.TypeConstraint typeConstraint = TypeConstraint.None, string fieldName = null, bool onHeader = false)
+        private NodePort AddDynamicPort(Type type, NodePort.IO direction, ConnectionType connectionType = ConnectionType.Override, TypeConstraint typeConstraint = TypeConstraint.None, string fieldName = null, bool onHeader = false)
         {
             if (fieldName == null)
             {
@@ -447,7 +447,7 @@ namespace Prowl.Runtime.NodeSystem
                 dictionary.Clear();
 
                 if (keys.Count != values.Count)
-                    throw new System.Exception("there are " + keys.Count + " keys and " + values.Count + " values after deserialization. Make sure that both key and value types are serializable.");
+                    throw new Exception("there are " + keys.Count + " keys and " + values.Count + " values after deserialization. Make sure that both key and value types are serializable.");
 
                 for (int i = 0; i < keys.Count; i++)
                     dictionary.Add(keys[i], values[i]);

--- a/Prowl.Runtime/Utils/NodeSystem/Node.cs
+++ b/Prowl.Runtime/Utils/NodeSystem/Node.cs
@@ -167,7 +167,7 @@ namespace Prowl.Runtime.NodeSystem
         //[ContextMenu("Clear Dynamic Ports")]
         public void ClearDynamicPorts()
         {
-            List<NodePort> dynamicPorts = new List<NodePort>(DynamicPorts);
+            List<NodePort> dynamicPorts = [..DynamicPorts];
             foreach (NodePort port in dynamicPorts)
             {
                 RemoveDynamicPort(port);
@@ -350,8 +350,8 @@ namespace Prowl.Runtime.NodeSystem
         [Serializable]
         public class NodePortDictionary : ISerializationCallbackReceiver
         {
-            [SerializeField] private List<string> keys = new List<string>();
-            [SerializeField] private List<NodePort> values = new List<NodePort>();
+            [SerializeField] private List<string> keys = [];
+            [SerializeField] private List<NodePort> values = [];
             private Dictionary<string, NodePort> dictionary = new Dictionary<string, NodePort>();
 
             /// <summary>

--- a/Prowl.Runtime/Utils/NodeSystem/Node.cs
+++ b/Prowl.Runtime/Utils/NodeSystem/Node.cs
@@ -155,10 +155,10 @@ namespace Prowl.Runtime.NodeSystem
         }
 
         /// <summary> Remove an dynamic port from the node </summary>
+        /// <exception cref="ArgumentNullException"></exception>
         public void RemoveDynamicPort(NodePort port)
         {
-            if (port == null) throw new ArgumentNullException(nameof(port));
-            else if (port.IsStatic) throw new ArgumentException("cannot remove static port");
+            if (port.IsStatic) throw new ArgumentException("cannot remove static port");
             port.ClearConnections();
             ports.Remove(port.fieldName);
         }

--- a/Prowl.Runtime/Utils/NodeSystem/Node.cs
+++ b/Prowl.Runtime/Utils/NodeSystem/Node.cs
@@ -157,7 +157,7 @@ namespace Prowl.Runtime.NodeSystem
         /// <summary> Remove an dynamic port from the node </summary>
         public void RemoveDynamicPort(NodePort port)
         {
-            if (port == null) throw new ArgumentNullException("port");
+            if (port == null) throw new ArgumentNullException(nameof(port));
             else if (port.IsStatic) throw new ArgumentException("cannot remove static port");
             port.ClearConnections();
             ports.Remove(port.fieldName);

--- a/Prowl.Runtime/Utils/NodeSystem/NodeDataCache.cs
+++ b/Prowl.Runtime/Utils/NodeSystem/NodeDataCache.cs
@@ -171,7 +171,7 @@ namespace Prowl.Runtime.Utils.NodeSystem
             portDataCache = new PortDataCache();
             System.Type baseType = typeof(Node);
             List<System.Type> nodeTypes = [];
-            System.Reflection.Assembly[] assemblies = System.AppDomain.CurrentDomain.GetAssemblies();
+            Assembly[] assemblies = System.AppDomain.CurrentDomain.GetAssemblies();
 
             // Loop through assemblies and add node types to list
             foreach (Assembly assembly in assemblies)
@@ -204,7 +204,7 @@ namespace Prowl.Runtime.Utils.NodeSystem
 
         public static List<FieldInfo> GetNodeFields(System.Type nodeType)
         {
-            List<System.Reflection.FieldInfo> fieldInfo =
+            List<FieldInfo> fieldInfo =
                 [..nodeType.GetFields(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance)];
 
             // GetFields doesnt return inherited private fields, so walk through base types and pick those up
@@ -227,7 +227,7 @@ namespace Prowl.Runtime.Utils.NodeSystem
 
         private static void CachePorts(System.Type nodeType)
         {
-            List<System.Reflection.FieldInfo> fieldInfo = GetNodeFields(nodeType);
+            List<FieldInfo> fieldInfo = GetNodeFields(nodeType);
 
             for (int i = 0; i < fieldInfo.Count; i++)
             {

--- a/Prowl.Runtime/Utils/NodeSystem/NodeDataCache.cs
+++ b/Prowl.Runtime/Utils/NodeSystem/NodeDataCache.cs
@@ -41,7 +41,7 @@ namespace Prowl.Runtime.Utils.NodeSystem
             Dictionary<string, string> formerlySerializedAs = null;
             if (formerlySerializedAsCache != null) formerlySerializedAsCache.TryGetValue(nodeType, out formerlySerializedAs);
 
-            List<NodePort> dynamicListPorts = new List<NodePort>();
+            List<NodePort> dynamicListPorts = [];
 
             Dictionary<string, NodePort> staticPorts;
             if (!portDataCache.TryGetValue(nodeType, out staticPorts))
@@ -170,7 +170,7 @@ namespace Prowl.Runtime.Utils.NodeSystem
         {
             portDataCache = new PortDataCache();
             System.Type baseType = typeof(Node);
-            List<System.Type> nodeTypes = new List<System.Type>();
+            List<System.Type> nodeTypes = [];
             System.Reflection.Assembly[] assemblies = System.AppDomain.CurrentDomain.GetAssemblies();
 
             // Loop through assemblies and add node types to list
@@ -204,7 +204,8 @@ namespace Prowl.Runtime.Utils.NodeSystem
 
         public static List<FieldInfo> GetNodeFields(System.Type nodeType)
         {
-            List<System.Reflection.FieldInfo> fieldInfo = new List<System.Reflection.FieldInfo>(nodeType.GetFields(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance));
+            List<System.Reflection.FieldInfo> fieldInfo =
+                [..nodeType.GetFields(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance)];
 
             // GetFields doesnt return inherited private fields, so walk through base types and pick those up
             System.Type tempType = nodeType;

--- a/Prowl.Runtime/Utils/NodeSystem/NodeGraph.cs
+++ b/Prowl.Runtime/Utils/NodeSystem/NodeGraph.cs
@@ -41,10 +41,10 @@ namespace Prowl.Runtime.NodeSystem
 
         /// <summary> All nodes in the graph. <para/>
         /// See: <see cref="AddNode{T}"/> </summary>
-        public List<Node> nodes = new List<Node>();
+        public List<Node> nodes = [];
 
-        public virtual (string, Type)[] NodeTypes { get; } = Array.Empty<(string, Type)>();
-        public virtual (string, Type)[] NodeReflectionTypes { get; } = Array.Empty<(string, Type)>();
+        public virtual (string, Type)[] NodeTypes { get; } = [];
+        public virtual (string, Type)[] NodeReflectionTypes { get; } = [];
         public abstract string[] NodeCategories { get; }
 
         public List<GraphParameter> parameters = [];

--- a/Prowl.Runtime/Utils/NodeSystem/NodeGraph.cs
+++ b/Prowl.Runtime/Utils/NodeSystem/NodeGraph.cs
@@ -51,7 +51,7 @@ namespace Prowl.Runtime.NodeSystem
 
         public void Validate()
         {
-            var attrib = this.GetType().GetCustomAttribute<RequireNodeAttribute>(true);
+            var attrib = GetType().GetCustomAttribute<RequireNodeAttribute>(true);
             if (attrib != null)
                 foreach (Type type in attrib.types)
                     if (!nodes.Where(n => n.GetType() == type).Any())
@@ -121,7 +121,7 @@ namespace Prowl.Runtime.NodeSystem
         public virtual void RemoveNode(Node node)
         {
             // check if we have a RequireNode attribute
-            var attrib = this.GetType().GetCustomAttribute<RequireNodeAttribute>(true);
+            var attrib = GetType().GetCustomAttribute<RequireNodeAttribute>(true);
             if (attrib != null)
             {
                 if (attrib.Requires(node.GetType()))

--- a/Prowl.Runtime/Utils/NodeSystem/NodePort.cs
+++ b/Prowl.Runtime/Utils/NodeSystem/NodePort.cs
@@ -138,7 +138,7 @@ namespace Prowl.Runtime.NodeSystem
         public NodePort(string fieldName, Type type, IO direction, Node.ConnectionType connectionType, Node.TypeConstraint typeConstraint, Node node, bool onHeader)
         {
             _fieldName = fieldName;
-            this.ValueType = type;
+            ValueType = type;
             _direction = direction;
             _node = node;
             _dynamic = true;

--- a/Prowl.Runtime/Utils/NodeSystem/Nodes/Flow Control/ForLoopNode.cs
+++ b/Prowl.Runtime/Utils/NodeSystem/Nodes/Flow Control/ForLoopNode.cs
@@ -30,8 +30,8 @@ namespace Prowl.Runtime.NodeSystem
                 return;
             }
 
-            var index = GetInputValue<int>("FirstIndex", FirstIndex);
-            var lastIndex = GetInputValue<int>("LastIndex", LastIndex);
+            var index = GetInputValue("FirstIndex", FirstIndex);
+            var lastIndex = GetInputValue("LastIndex", LastIndex);
 
             for (int i = index; i < lastIndex; i++)
             {

--- a/Prowl.Runtime/Utils/NodeSystem/Nodes/Flow Control/RandomNode.cs
+++ b/Prowl.Runtime/Utils/NodeSystem/Nodes/Flow Control/RandomNode.cs
@@ -1,7 +1,6 @@
 ﻿// This file is part of the Prowl Game Engine
 // Licensed under the MIT License. See the LICENSE file in the project root for details.
 
-using System;
 using System.Linq;
 
 namespace Prowl.Runtime.NodeSystem

--- a/Prowl.Runtime/Utils/NodeSystem/Nodes/Flow Control/SequenceNode.cs
+++ b/Prowl.Runtime/Utils/NodeSystem/Nodes/Flow Control/SequenceNode.cs
@@ -1,7 +1,6 @@
 ﻿// This file is part of the Prowl Game Engine
 // Licensed under the MIT License. See the LICENSE file in the project root for details.
 
-using System;
 using System.Linq;
 
 namespace Prowl.Runtime.NodeSystem

--- a/Prowl.Runtime/Utils/NodeSystem/Nodes/Flow Control/WhileLoopNode.cs
+++ b/Prowl.Runtime/Utils/NodeSystem/Nodes/Flow Control/WhileLoopNode.cs
@@ -17,7 +17,7 @@ namespace Prowl.Runtime.NodeSystem
         public override void Execute(NodePort port)
         {
             int i = 0;
-            while (GetInputValue<bool>("Condition", Condition))
+            while (GetInputValue("Condition", Condition))
             {
                 ExecuteNext();
                 i++;

--- a/Prowl.Runtime/Utils/NodeSystem/Nodes/General/LogNode.cs
+++ b/Prowl.Runtime/Utils/NodeSystem/Nodes/General/LogNode.cs
@@ -21,7 +21,7 @@ namespace Prowl.Runtime.NodeSystem
 
         public override void Execute(NodePort input)
         {
-            var message = GetInputValue<string>("Message", Message);
+            var message = GetInputValue("Message", Message);
 
             switch (Type)
             {

--- a/Prowl.Runtime/Utils/NodeSystem/Nodes/General/OperatorNodes.cs
+++ b/Prowl.Runtime/Utils/NodeSystem/Nodes/General/OperatorNodes.cs
@@ -62,7 +62,7 @@ namespace Prowl.Runtime.NodeSystem
                 return null;
 
             MethodInfo mi = aPort.Connection.ValueType.GetMethod(MethodName, BindingFlags.Static | BindingFlags.Public);
-            return mi.Invoke(null, new object[] { GetInputValue("A", A), GetInputValue<object>("B") });
+            return mi.Invoke(null, [GetInputValue("A", A), GetInputValue<object>("B")]);
         }
     }
 

--- a/Prowl.Runtime/Utils/OnAssemblyUnloadAttribute.cs
+++ b/Prowl.Runtime/Utils/OnAssemblyUnloadAttribute.cs
@@ -15,7 +15,7 @@ namespace Prowl.Runtime.Utils
         {
         }
 
-        private static List<MethodInfo> methodInfos = [];
+        private static readonly List<MethodInfo> methodInfos = [];
 
         public static void Invoke()
         {
@@ -51,8 +51,8 @@ namespace Prowl.Runtime.Utils
     [AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
     public class OnAssemblyLoadAttribute(int order = 0) : Attribute
     {
-        int order = order;
-        private static List<MethodInfo> methodInfos = [];
+        readonly int order = order;
+        private static readonly List<MethodInfo> methodInfos = [];
 
         public static void Invoke()
         {

--- a/Prowl.Runtime/Utils/RuntimeUtils.cs
+++ b/Prowl.Runtime/Utils/RuntimeUtils.cs
@@ -52,7 +52,7 @@ namespace Prowl.Runtime
         public static IEnumerable<FieldInfo> GetAllFields(Type? t)
         {
             if (t == null)
-                return Enumerable.Empty<FieldInfo>();
+                return [];
 
             BindingFlags flags = BindingFlags.Public | BindingFlags.NonPublic |
                                  BindingFlags.Instance | BindingFlags.DeclaredOnly;
@@ -119,7 +119,7 @@ namespace Prowl.Runtime
 
         public static List<Type> FindTypesImplementing(Type propertyType)
         {
-            List<Type> types = new List<Type>();
+            List<Type> types = [];
             foreach (Assembly asm in AppDomain.CurrentDomain.GetAssemblies())
             {
                 foreach (Type type in asm.GetTypes())

--- a/Prowl.Runtime/Utils/SerializedAsset.cs
+++ b/Prowl.Runtime/Utils/SerializedAsset.cs
@@ -108,7 +108,7 @@ namespace Prowl.Runtime.Utils
         {
             if (obj == null) throw new Exception("Asset cannot be null");
             if (SubAssets.Contains(obj)) throw new Exception("Asset already contains this object: " + obj);
-            obj.FileID = (ushort)0;
+            obj.FileID = 0;
             Main = obj;
         }
 

--- a/Prowl.Runtime/Utils/SerializedAsset.cs
+++ b/Prowl.Runtime/Utils/SerializedAsset.cs
@@ -86,7 +86,7 @@ namespace Prowl.Runtime.Utils
                 SceneManager.AllowGameObjectConstruction = prev; // Restore state
                 return obj;
             }
-            catch (Exception e)
+            catch (Exception)
             {
                 SceneManager.AllowGameObjectConstruction = prev; // Restore state
                 throw;


### PR DESCRIPTION
Several little code enhancements and fixes. It reduces the number of warnings during build from 1800+ to about 1400. It's far from over, but it's a start.

- remove unnecessary `using`
- remove unnecessary variable initialization (`int variable = 0;`)
- remove unused Exception variable (`catch (Exception e)`)
- remove redundant type cast argument
- remove redundant qualifier (ie: `this.field` or `Runtime.GUI.Gui`)
- remove redundant type cast (like =`(float)1.0f`)
- use the new C# list/array initializing `[1, 2, 3]`
- use `nameof(var)` instead string during exceptions
- use `ArgumentNullException.ThrowIfNull` instead `if (variable == null) throw new`
- use `readonly` on fields that do not change (specially collections) for better performance