### PR TITLE
feat: command line options for open an existing project and creating a new one

### DIFF
--- a/Prowl.Editor/Editor/CLI/CliCreateOptions.cs
+++ b/Prowl.Editor/Editor/CLI/CliCreateOptions.cs
@@ -1,0 +1,19 @@
+// This file is part of the Prowl Game Engine
+// Licensed under the MIT License. See the LICENSE file in the project root for details.
+
+using CommandLine;
+
+namespace Prowl.Editor.Editor.CLI;
+
+/// <summary>
+/// Command line options for the `create` command.
+/// </summary>
+[Verb("create", false, HelpText = "create a project")]
+internal class CliCreateOptions
+{
+    /// <summary>
+    /// The path of the project to be created.
+    /// </summary>
+    [Option('p', "project", Required = false, HelpText = "Project path", Default = "./")]
+    public required DirectoryInfo ProjectPath { get; set; }
+}

--- a/Prowl.Editor/Editor/CLI/CliOpenOptions.cs
+++ b/Prowl.Editor/Editor/CLI/CliOpenOptions.cs
@@ -1,0 +1,19 @@
+// This file is part of the Prowl Game Engine
+// Licensed under the MIT License. See the LICENSE file in the project root for details.
+
+using CommandLine;
+
+namespace Prowl.Editor.Editor.CLI;
+
+/// <summary>
+/// Command line options for the `open` command.
+/// </summary>
+[Verb("open", true, HelpText = "Open a given project")]
+internal class CliOpenOptions
+{
+    /// <summary>
+    /// The path of the project to be open.
+    /// </summary>
+    [Option('p', "project", Required = false, HelpText = "Project path")]
+    public required DirectoryInfo ProjectPath { get; set; }
+}

--- a/Prowl.Editor/Editor/ProjectsWindow.cs
+++ b/Prowl.Editor/Editor/ProjectsWindow.cs
@@ -33,8 +33,7 @@ namespace Prowl.Editor
         protected override bool LockSize => true;
         protected override double Padding => 0;
 
-
-        public ProjectsWindow() : base()
+        public ProjectsWindow()
         {
             Title = FontAwesome6.Book + " Project Window";
 
@@ -43,7 +42,6 @@ namespace Prowl.Editor
                 (FontAwesome6.BookOpen + "  Learn", () => {})
             ];
         }
-
 
         protected override void Draw()
         {

--- a/Prowl.Editor/Project.cs
+++ b/Prowl.Editor/Project.cs
@@ -37,7 +37,7 @@ public class Project
     public static event Action OnProjectChanged;
 
     public static Project? Active { get; private set; }
-    public static bool HasProject => Active != null;
+    public static bool HasProject => Active is not null;
 
     #endregion
 
@@ -130,7 +130,7 @@ public class Project
     /// <summary>
     /// Will create a new Project file and its main Folders in a Dedicated folder
     /// </summary>
-    /// <param name="ProjectName">Name of project</param>
+    /// <param name="projectPath">Path for the new project</param>
     public static Project CreateNew(DirectoryInfo projectPath)
     {
         Project project = new Project(projectPath);

--- a/Prowl.Editor/Prowl.Editor.csproj
+++ b/Prowl.Editor/Prowl.Editor.csproj
@@ -45,6 +45,7 @@
 
     <ItemGroup>
         <PackageReference Include="AssimpNet" Version="5.0.0-beta1" />
+        <PackageReference Include="CommandLineParser" Version="2.9.1" />
         <PackageReference Include="DirectXShaderCompiler.NET" Version="1.1.0" />
         <PackageReference Include="NuGet.Protocol" Version="6.11.0" />
         <PackageReference Include="NuGet.Resolver" Version="6.11.0" />

--- a/Prowl.Runtime/Utils/ScriptableSingleton.cs
+++ b/Prowl.Runtime/Utils/ScriptableSingleton.cs
@@ -78,7 +78,8 @@ namespace Prowl.Runtime.Utils
                         break;
                     case FilePathAttribute.Location.EditorPreference:
                         // Persistent across all projects
-                        if (Application.isEditor == false)
+                        // TODO: !Application.isRunning is just a hack to allow CLI operations that do not depend on the editor
+                        if (!Application.isRunning || Application.isEditor == false)
                             throw new InvalidOperationException("Preferences are only available in the editor");
                         directory = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "Prowl", "Editor");
                         break;


### PR DESCRIPTION
#151 

Open and Create project commands

- `prowl --project PATH` or `prowl  open --project PATH`  will open Prowl project located in PATH (open keyword is optional)
- `prowl  create --project PATH`  will create a new Prowl project located in PATH 

---

During development, one could run dotnet CLI using

`dotnet run --project Prowl.Editor/ -- open --project PATH`

or

`dotnet run --project Prowl.Editor/ -- --project PATH`
