### PR TITLE
Fix: never compare equality of floating numbers

### DIFF
--- a/Prowl.Editor/Assets/Importers/ModelImporter.cs
+++ b/Prowl.Editor/Assets/Importers/ModelImporter.cs
@@ -1,6 +1,8 @@
 ﻿// This file is part of the Prowl Game Engine
 // Licensed under the MIT License. See the LICENSE file in the project root for details.
 
+using System.Net.Mime;
+
 using Assimp;
 
 using Prowl.Editor.Preferences;
@@ -174,7 +176,7 @@ public class ModelImporter : ScriptedImporter
             }
 
             GameObject rootNode = GOs[0].Item1;
-            if (UnitScale != 1f)
+            if (Math.Abs(UnitScale - 1f) > Application.FloatEqualThreshold)
                 rootNode.Transform.localScale = Vector3.one * UnitScale;
 
             // Add Animation Component with all the animations assigned

--- a/Prowl.Editor/Assets/Importers/ModelImporter.cs
+++ b/Prowl.Editor/Assets/Importers/ModelImporter.cs
@@ -174,7 +174,7 @@ public class ModelImporter : ScriptedImporter
             }
 
             GameObject rootNode = GOs[0].Item1;
-            if (Math.Abs(UnitScale - 1f) > Application.FloatEqualThreshold)
+            if (Mathf.ApproximatelyEquals(UnitScale , 1f))
                 rootNode.Transform.localScale = Vector3.one * UnitScale;
 
             // Add Animation Component with all the animations assigned

--- a/Prowl.Editor/Assets/Importers/ModelImporter.cs
+++ b/Prowl.Editor/Assets/Importers/ModelImporter.cs
@@ -1,8 +1,6 @@
 ﻿// This file is part of the Prowl Game Engine
 // Licensed under the MIT License. See the LICENSE file in the project root for details.
 
-using System.Net.Mime;
-
 using Assimp;
 
 using Prowl.Editor.Preferences;

--- a/Prowl.Editor/Editor/GameWindow.cs
+++ b/Prowl.Editor/Editor/GameWindow.cs
@@ -140,7 +140,7 @@ public class GameWindow : EditorWindow
                 var renderSize = innerRect.Size;
                 renderSize.x = MathD.Max(renderSize.x, 1);
                 renderSize.y = MathD.Max(renderSize.y, 1);
-                if (Math.Abs(renderSize.x - RenderTarget.Width) > Application.FloatEqualThreshold || Math.Abs(renderSize.y - RenderTarget.Height) > Application.FloatEqualThreshold)
+                if (MathD.ApproximatelyEquals(renderSize.x, RenderTarget.Width) || MathD.ApproximatelyEquals(renderSize.y, RenderTarget.Height))
                 {
                     GeneralPreferences.Instance.CurrentWidth = (int)renderSize.x;
                     GeneralPreferences.Instance.CurrentHeight = (int)renderSize.y;

--- a/Prowl.Editor/Editor/GameWindow.cs
+++ b/Prowl.Editor/Editor/GameWindow.cs
@@ -140,7 +140,7 @@ public class GameWindow : EditorWindow
                 var renderSize = innerRect.Size;
                 renderSize.x = MathD.Max(renderSize.x, 1);
                 renderSize.y = MathD.Max(renderSize.y, 1);
-                if (renderSize.x != RenderTarget.Width || renderSize.y != RenderTarget.Height)
+                if (Math.Abs(renderSize.x - RenderTarget.Width) > Application.FloatEqualThreshold || Math.Abs(renderSize.y - RenderTarget.Height) > Application.FloatEqualThreshold)
                 {
                     GeneralPreferences.Instance.CurrentWidth = (int)renderSize.x;
                     GeneralPreferences.Instance.CurrentHeight = (int)renderSize.y;

--- a/Prowl.Editor/Editor/NodeEditor/NodeEditor.cs
+++ b/Prowl.Editor/Editor/NodeEditor/NodeEditor.cs
@@ -635,7 +635,7 @@ public class NodeEditor
 
             gui.PointerWheel = Input.MouseWheelDelta;
 
-            if ((RenderTarget == null) || (MathD.Max(width, 1) != RenderTarget.Width || MathD.Max(height, 1) != RenderTarget.Height))
+            if ((RenderTarget == null) || (Math.Abs(MathD.Max(width, 1) - RenderTarget.Width) > Application.FloatEqualThreshold || Math.Abs(MathD.Max(height, 1) - RenderTarget.Height) > Application.FloatEqualThreshold))
                 RefreshRenderTexture(new(MathD.Max(width, 1), MathD.Max(height, 1)));
 
             Veldrid.CommandList commandList = Graphics.GetCommandList();

--- a/Prowl.Editor/Editor/NodeEditor/NodeEditor.cs
+++ b/Prowl.Editor/Editor/NodeEditor/NodeEditor.cs
@@ -635,7 +635,7 @@ public class NodeEditor
 
             gui.PointerWheel = Input.MouseWheelDelta;
 
-            if ((RenderTarget == null) || (Math.Abs(MathD.Max(width, 1) - RenderTarget.Width) > Application.FloatEqualThreshold || Math.Abs(MathD.Max(height, 1) - RenderTarget.Height) > Application.FloatEqualThreshold))
+            if ((RenderTarget == null) || (MathD.ApproximatelyEquals(MathD.Max(width, 1), RenderTarget.Width) || MathD.ApproximatelyEquals(MathD.Max(height, 1), RenderTarget.Height)))
                 RefreshRenderTexture(new(MathD.Max(width, 1), MathD.Max(height, 1)));
 
             Veldrid.CommandList commandList = Graphics.GetCommandList();

--- a/Prowl.Editor/Program.cs
+++ b/Prowl.Editor/Program.cs
@@ -119,7 +119,7 @@ public static class Program
                 else if (Hotkeys.IsHotkeyDown("SaveScene", new() { Key = Key.S, Ctrl = true }))
                     EditorGuiManager.SaveScene();
 
-                Application.isPlaying = PlayMode.Current == PlayMode.Mode.Playing;
+                Application.IsPlaying = PlayMode.Current == PlayMode.Mode.Playing;
 
 
                 try

--- a/Prowl.Players/Prowl.Desktop/Program.cs
+++ b/Prowl.Players/Prowl.Desktop/Program.cs
@@ -12,7 +12,7 @@ internal class Program
     public static int Main(string[] args)
     {
 
-        Application.isPlaying = true;
+        Application.IsPlaying = true;
         Application.DataPath = Data.FullName;
 
 

--- a/Prowl.Runtime/AnimationCurve.cs
+++ b/Prowl.Runtime/AnimationCurve.cs
@@ -411,10 +411,10 @@ public class KeyFrame : IEquatable<KeyFrame>, IComparable<KeyFrame>
         if (Equals(value2, null))
             return Equals(value1, null);
 
-        return (value1.Position == value2.Position)
-               && (value1.Value == value2.Value)
-               && (value1.TangentIn == value2.TangentIn)
-               && (value1.TangentOut == value2.TangentOut)
+        return (Math.Abs(value1.Position - value2.Position) < Application.FloatEqualThreshold)
+               && (Math.Abs(value1.Value - value2.Value) < Application.FloatEqualThreshold)
+               && (Math.Abs(value1.TangentIn - value2.TangentIn) < Application.FloatEqualThreshold)
+               && (Math.Abs(value1.TangentOut - value2.TangentOut) < Application.FloatEqualThreshold)
                && (value1.Continuity == value2.Continuity);
     }
 
@@ -453,7 +453,7 @@ public class CurveKeyCollection : ICollection<KeyFrame>
             if (index >= _keys.Count)
                 throw new IndexOutOfRangeException();
 
-            if (_keys[index].Position == value.Position)
+            if (Math.Abs(_keys[index].Position - value.Position) < Application.FloatEqualThreshold)
                 _keys[index] = value;
             else
             {

--- a/Prowl.Runtime/AnimationCurve.cs
+++ b/Prowl.Runtime/AnimationCurve.cs
@@ -411,10 +411,10 @@ public class KeyFrame : IEquatable<KeyFrame>, IComparable<KeyFrame>
         if (Equals(value2, null))
             return Equals(value1, null);
 
-        return (Math.Abs(value1.Position - value2.Position) < Application.FloatEqualThreshold)
-               && (Math.Abs(value1.Value - value2.Value) < Application.FloatEqualThreshold)
-               && (Math.Abs(value1.TangentIn - value2.TangentIn) < Application.FloatEqualThreshold)
-               && (Math.Abs(value1.TangentOut - value2.TangentOut) < Application.FloatEqualThreshold)
+        return (MathD.ApproximatelyEquals(value1.Position, value2.Position))
+               && (MathD.ApproximatelyEquals(value1.Value, value2.Value))
+               && (MathD.ApproximatelyEquals(value1.TangentIn, value2.TangentIn))
+               && (MathD.ApproximatelyEquals(value1.TangentOut, value2.TangentOut))
                && (value1.Continuity == value2.Continuity);
     }
 
@@ -453,7 +453,7 @@ public class CurveKeyCollection : ICollection<KeyFrame>
             if (index >= _keys.Count)
                 throw new IndexOutOfRangeException();
 
-            if (Math.Abs(_keys[index].Position - value.Position) < Application.FloatEqualThreshold)
+            if (MathD.ApproximatelyEquals(_keys[index].Position, value.Position))
                 _keys[index] = value;
             else
             {

--- a/Prowl.Runtime/Application.cs
+++ b/Prowl.Runtime/Application.cs
@@ -12,9 +12,10 @@ namespace Prowl.Runtime;
 
 public static class Application
 {
-    public static bool isRunning;
-    public static bool isPlaying = false;
-    public static bool isEditor { get; private set; }
+    public static readonly float FloatEqualThreshold = 0.001f;
+    public static bool IsRunning;
+    public static bool IsPlaying = false;
+    public static bool IsEditor { get; private set; }
 
     public static string? DataPath = null;
 
@@ -25,9 +26,9 @@ public static class Application
     public static event Action Render;
     public static event Action Quitting;
 
-    private static readonly TimeData AppTime = new();
+    private static readonly TimeData s_appTime = new();
 
-    private static readonly GraphicsBackend[] preferredWindowsBackends = // Covers Windows/UWP
+    private static readonly GraphicsBackend[] s_preferredWindowsBackends = // Covers Windows/UWP
     [
         GraphicsBackend.Vulkan,
         GraphicsBackend.OpenGL,
@@ -35,14 +36,14 @@ public static class Application
         GraphicsBackend.OpenGLES,
     ];
 
-    private static readonly GraphicsBackend[] preferredUnixBackends = // Cover Unix-like (Linux, FreeBSD, OpenBSD)
+    private static readonly GraphicsBackend[] s_preferredUnixBackends = // Cover Unix-like (Linux, FreeBSD, OpenBSD)
     [
         GraphicsBackend.Vulkan,
         GraphicsBackend.OpenGL,
         GraphicsBackend.OpenGLES,
     ];
 
-    private static readonly GraphicsBackend[] preferredMacBackends = // Covers MacOS/Apple
+    private static readonly GraphicsBackend[] s_preferredMacBackends = // Covers MacOS/Apple
     [
         GraphicsBackend.Metal,
         GraphicsBackend.OpenGL,
@@ -53,20 +54,20 @@ public static class Application
     {
         if (RuntimeUtils.IsWindows())
         {
-            return preferredWindowsBackends[0];
+            return s_preferredWindowsBackends[0];
         }
         else if (RuntimeUtils.IsMac())
         {
-            return preferredMacBackends[0];
+            return s_preferredMacBackends[0];
         }
 
-        return preferredUnixBackends[0];
+        return s_preferredUnixBackends[0];
     }
 
     public static void Run(string title, int width, int height, IAssetProvider assetProvider, bool editor)
     {
         AssetProvider = assetProvider;
-        isEditor = editor;
+        IsEditor = editor;
 
         Debug.Log("Initializing...");
 
@@ -76,8 +77,8 @@ public static class Application
 
         Screen.Closing += AppClose;
 
-        isRunning = true;
-        isPlaying = true; // Base application is not the editor, isplaying is always true
+        IsRunning = true;
+        IsPlaying = true; // Base application is not the editor, isplaying is always true
 
         Screen.Start($"{title} - {GetBackend()}", new Vector2Int(width, height), new Vector2Int(100, 100), WindowState.Normal);
     }
@@ -103,9 +104,9 @@ public static class Application
         {
             AudioSystem.UpdatePool();
 
-            AppTime.Update();
+            s_appTime.Update();
 
-            Time.TimeStack.Push(AppTime);
+            Time.TimeStack.Push(s_appTime);
 
             Update?.Invoke();
             Render?.Invoke();
@@ -120,7 +121,7 @@ public static class Application
 
     static void AppClose()
     {
-        isRunning = false;
+        IsRunning = false;
         Quitting?.Invoke();
         Graphics.Dispose();
         Physics.Dispose();

--- a/Prowl.Runtime/Application.cs
+++ b/Prowl.Runtime/Application.cs
@@ -12,7 +12,7 @@ namespace Prowl.Runtime;
 
 public static class Application
 {
-    public static readonly float FloatEqualThreshold = 0.001f;
+    public static readonly float FloatEqualThreshold = 0.0001f;
     public static bool IsRunning;
     public static bool IsPlaying = false;
     public static bool IsEditor { get; private set; }

--- a/Prowl.Runtime/Application.cs
+++ b/Prowl.Runtime/Application.cs
@@ -12,7 +12,6 @@ namespace Prowl.Runtime;
 
 public static class Application
 {
-    public static readonly float FloatEqualThreshold = 0.0001f;
     public static bool IsRunning;
     public static bool IsPlaying = false;
     public static bool IsEditor { get; private set; }

--- a/Prowl.Runtime/Components/Audio/AudioSource.cs
+++ b/Prowl.Runtime/Components/Audio/AudioSource.cs
@@ -1,6 +1,8 @@
 ﻿// This file is part of the Prowl Game Engine
 // Licensed under the MIT License. See the LICENSE file in the project root for details.
 
+using System;
+
 using Prowl.Icons;
 using Prowl.Runtime.Audio;
 
@@ -72,13 +74,13 @@ public sealed class AudioSource : MonoBehaviour
             _looping = Looping;
         }
 
-        if (_gain != Volume)
+        if (Math.Abs(_gain - Volume) > Application.FloatEqualThreshold)
         {
             _source.Gain = Volume;
             _gain = Volume;
         }
 
-        if (_maxDistance != MaxDistance)
+        if (Math.Abs(_maxDistance - MaxDistance) > Application.FloatEqualThreshold)
         {
             _source.MaxDistance = MaxDistance;
             _maxDistance = MaxDistance;

--- a/Prowl.Runtime/Components/Audio/AudioSource.cs
+++ b/Prowl.Runtime/Components/Audio/AudioSource.cs
@@ -74,13 +74,13 @@ public sealed class AudioSource : MonoBehaviour
             _looping = Looping;
         }
 
-        if (Math.Abs(_gain - Volume) > Application.FloatEqualThreshold)
+        if (Mathf.ApproximatelyEquals(_gain , Volume))
         {
             _source.Gain = Volume;
             _gain = Volume;
         }
 
-        if (Math.Abs(_maxDistance - MaxDistance) > Application.FloatEqualThreshold)
+        if (Mathf.ApproximatelyEquals(_maxDistance , MaxDistance))
         {
             _source.MaxDistance = MaxDistance;
             _maxDistance = MaxDistance;

--- a/Prowl.Runtime/Components/Physics/Rigidbody.cs
+++ b/Prowl.Runtime/Components/Physics/Rigidbody.cs
@@ -48,7 +48,7 @@ public class Rigidbody : PhysicsBody
         get => _sleepThreshold;
         set
         {
-            if (_sleepThreshold == value)
+            if (Math.Abs(_sleepThreshold - value) < Application.FloatEqualThreshold)
                 return;
 
             _sleepThreshold = value;

--- a/Prowl.Runtime/Components/Physics/Rigidbody.cs
+++ b/Prowl.Runtime/Components/Physics/Rigidbody.cs
@@ -48,7 +48,7 @@ public class Rigidbody : PhysicsBody
         get => _sleepThreshold;
         set
         {
-            if (Math.Abs(_sleepThreshold - value) < Application.FloatEqualThreshold)
+            if (MathD.ApproximatelyEquals(_sleepThreshold, value))
                 return;
 
             _sleepThreshold = value;

--- a/Prowl.Runtime/Components/Physics/Types/BepuNarrowPhaseCallbacks.cs
+++ b/Prowl.Runtime/Components/Physics/Types/BepuNarrowPhaseCallbacks.cs
@@ -49,7 +49,7 @@ public unsafe struct BepuNarrowPhaseCallbacks : INarrowPhaseCallbacks
         var b = CollidableMaterials[pair.B];
         pairMaterial.FrictionCoefficient = a.FrictionCoefficient * b.FrictionCoefficient;
         pairMaterial.MaximumRecoveryVelocity = (float)MathD.Max(a.MaximumRecoveryVelocity, b.MaximumRecoveryVelocity);
-        pairMaterial.SpringSettings = Math.Abs(pairMaterial.MaximumRecoveryVelocity - a.MaximumRecoveryVelocity) < Application.FloatEqualThreshold ? a.SpringSettings : b.SpringSettings;
+        pairMaterial.SpringSettings = MathD.ApproximatelyEquals(pairMaterial.MaximumRecoveryVelocity, a.MaximumRecoveryVelocity) ? a.SpringSettings : b.SpringSettings;
         //For the purposes of the demo, contact constraints are always generated.
         ContactEvents.HandleManifold(workerIndex, pair, ref manifold);
         Physics.Characters.TryReportContacts(pair, ref manifold, workerIndex, ref pairMaterial);

--- a/Prowl.Runtime/Components/Physics/Types/BepuNarrowPhaseCallbacks.cs
+++ b/Prowl.Runtime/Components/Physics/Types/BepuNarrowPhaseCallbacks.cs
@@ -1,6 +1,7 @@
 ﻿// This file is part of the Prowl Game Engine
 // Licensed under the MIT License. See the LICENSE file in the project root for details.
 
+using System;
 using System.Runtime.CompilerServices;
 
 using BepuPhysics;
@@ -48,7 +49,7 @@ public unsafe struct BepuNarrowPhaseCallbacks : INarrowPhaseCallbacks
         var b = CollidableMaterials[pair.B];
         pairMaterial.FrictionCoefficient = a.FrictionCoefficient * b.FrictionCoefficient;
         pairMaterial.MaximumRecoveryVelocity = (float)MathD.Max(a.MaximumRecoveryVelocity, b.MaximumRecoveryVelocity);
-        pairMaterial.SpringSettings = pairMaterial.MaximumRecoveryVelocity == a.MaximumRecoveryVelocity ? a.SpringSettings : b.SpringSettings;
+        pairMaterial.SpringSettings = Math.Abs(pairMaterial.MaximumRecoveryVelocity - a.MaximumRecoveryVelocity) < Application.FloatEqualThreshold ? a.SpringSettings : b.SpringSettings;
         //For the purposes of the demo, contact constraints are always generated.
         ContactEvents.HandleManifold(workerIndex, pair, ref manifold);
         Physics.Characters.TryReportContacts(pair, ref manifold, workerIndex, ref pairMaterial);

--- a/Prowl.Runtime/Components/Physics/Types/Controller/CharacterControllersManager.cs
+++ b/Prowl.Runtime/Components/Physics/Types/Controller/CharacterControllersManager.cs
@@ -515,7 +515,7 @@ public unsafe class CharacterControllersManager : IDisposable
                 //2) The character was previously supported by a body, and is now supported by a different body.
                 //3) The character was previously supported by a static, and is now supported by a body.
                 //4) The character was previously supported by a body, and is now supported by a static.
-                var shouldRemove = character.Supported && (character.TryJump || Math.Abs(supportCandidate.Depth - float.MinValue) < Application.FloatEqualThreshold || character.Support.Packed != supportCandidate.Support.Packed);
+                var shouldRemove = character.Supported && (character.TryJump || MathD.ApproximatelyEquals(supportCandidate.Depth, float.MinValue) || character.Support.Packed != supportCandidate.Support.Packed);
                 if (shouldRemove)
                 {
                     //Mark the constraint for removal.

--- a/Prowl.Runtime/Components/Physics/Types/Controller/CharacterControllersManager.cs
+++ b/Prowl.Runtime/Components/Physics/Types/Controller/CharacterControllersManager.cs
@@ -515,7 +515,7 @@ public unsafe class CharacterControllersManager : IDisposable
                 //2) The character was previously supported by a body, and is now supported by a different body.
                 //3) The character was previously supported by a static, and is now supported by a body.
                 //4) The character was previously supported by a body, and is now supported by a static.
-                var shouldRemove = character.Supported && (character.TryJump || supportCandidate.Depth == float.MinValue || character.Support.Packed != supportCandidate.Support.Packed);
+                var shouldRemove = character.Supported && (character.TryJump || Math.Abs(supportCandidate.Depth - float.MinValue) < Application.FloatEqualThreshold || character.Support.Packed != supportCandidate.Support.Packed);
                 if (shouldRemove)
                 {
                     //Mark the constraint for removal.

--- a/Prowl.Runtime/GUI/Graphics/UIDrawList.cs
+++ b/Prowl.Runtime/GUI/Graphics/UIDrawList.cs
@@ -686,7 +686,7 @@ namespace Prowl.Runtime.GUI.Graphics
 
         public void PathLineToMergeDuplicate(Vector2 pos)
         {
-            if (_buildingPath.Count == 0 || Math.Abs(_buildingPath[_buildingPath.Count - 1].x - pos.x) > Application.FloatEqualThreshold || Math.Abs(_buildingPath[_buildingPath.Count - 1].y - pos.y) > Application.FloatEqualThreshold)
+            if (_buildingPath.Count == 0 || MathD.ApproximatelyEquals(_buildingPath[ 1].x, pos.x) || MathD.ApproximatelyEquals(_buildingPath[^1].y, pos.y))
                 _buildingPath.Add(pos);
         }
 

--- a/Prowl.Runtime/GUI/Graphics/UIDrawList.cs
+++ b/Prowl.Runtime/GUI/Graphics/UIDrawList.cs
@@ -686,7 +686,7 @@ namespace Prowl.Runtime.GUI.Graphics
 
         public void PathLineToMergeDuplicate(Vector2 pos)
         {
-            if (_buildingPath.Count == 0 || _buildingPath[_buildingPath.Count - 1].x != pos.x || _buildingPath[_buildingPath.Count - 1].y != pos.y)
+            if (_buildingPath.Count == 0 || Math.Abs(_buildingPath[_buildingPath.Count - 1].x - pos.x) > Application.FloatEqualThreshold || Math.Abs(_buildingPath[_buildingPath.Count - 1].y - pos.y) > Application.FloatEqualThreshold)
                 _buildingPath.Add(pos);
         }
 

--- a/Prowl.Runtime/GUI/Gui.Animation.cs
+++ b/Prowl.Runtime/GUI/Gui.Animation.cs
@@ -1,6 +1,7 @@
 ﻿// This file is part of the Prowl Game Engine
 // Licensed under the MIT License. See the LICENSE file in the project root for details.
 
+using System;
 using System.Collections.Generic;
 
 using Prowl.Runtime.Utils;
@@ -184,8 +185,8 @@ public partial class Gui
     static double QuintInOut(double time) => time < 0.5 ? 16 * time * time * time * time * time : 1 - MathD.Pow(-2 * time + 2, 5) / 2;
 
     static double ExpoIn(double time) => time == 0 ? 0 : MathD.Pow(2, 10 * time - 10);
-    static double ExpoOut(double time) => time == 1 ? 1 : 1 - MathD.Pow(2, -10 * time);
-    static double ExpoInOut(double time) => time == 0 ? 0 : time == 1 ? 1 : time < 0.5 ? MathD.Pow(2, 20 * time - 10) / 2 : (2 - MathD.Pow(2, -20 * time + 10)) / 2;
+    static double ExpoOut(double time) => Math.Abs(time - 1) < Application.FloatEqualThreshold ? 1 : 1 - MathD.Pow(2, -10 * time);
+    static double ExpoInOut(double time) => time == 0 ? 0 : Math.Abs(time - 1) < Application.FloatEqualThreshold ? 1 : time < 0.5 ? MathD.Pow(2, 20 * time - 10) / 2 : (2 - MathD.Pow(2, -20 * time + 10)) / 2;
 
     static double CircIn(double time) => 1 - MathD.Sqrt(1 - MathD.Pow(time, 2));
     static double CircOut(double time) => MathD.Sqrt(1 - MathD.Pow(time - 1, 2));
@@ -197,9 +198,9 @@ public partial class Gui
         MathD.Pow(2 * time, 2) * ((ConstantB + 1) * 2 * time - ConstantB) / 2 :
         (MathD.Pow(2 * time - 2, 2) * ((ConstantB + 1) * (time * 2 - 2) + ConstantB) + 2) / 2;
 
-    static double ElasticIn(double time) => time == 0 ? 0 : time == 1 ? 1 : -MathD.Pow(2, 10 * time - 10) * MathD.Sin((time * 10.0 - 10.75) * ConstantD);
-    static double ElasticOut(double time) => time == 0 ? 0 : time == 1 ? 1 : MathD.Pow(2, -10 * time) * MathD.Sin((time * 10 - 0.75) * ConstantD) + 1;
-    static double ElasticInOut(double time) => time == 0 ? 0 : time == 1 ? 1 : time < 0.5 ? -(MathD.Pow(2, 20 * time - 10) * MathD.Sin((20 * time - 11.125) * ConstantE)) / 2 : MathD.Pow(2, -20 * time + 10) * MathD.Sin((20 * time - 11.125) * ConstantE) / 2 + 1;
+    static double ElasticIn(double time) => time == 0 ? 0 : Math.Abs(time - 1) < Application.FloatEqualThreshold ? 1 : -MathD.Pow(2, 10 * time - 10) * MathD.Sin((time * 10.0 - 10.75) * ConstantD);
+    static double ElasticOut(double time) => time == 0 ? 0 : Math.Abs(time - 1) < Application.FloatEqualThreshold ? 1 : MathD.Pow(2, -10 * time) * MathD.Sin((time * 10 - 0.75) * ConstantD) + 1;
+    static double ElasticInOut(double time) => time == 0 ? 0 : Math.Abs(time - 1) < Application.FloatEqualThreshold ? 1 : time < 0.5 ? -(MathD.Pow(2, 20 * time - 10) * MathD.Sin((20 * time - 11.125) * ConstantE)) / 2 : MathD.Pow(2, -20 * time + 10) * MathD.Sin((20 * time - 11.125) * ConstantE) / 2 + 1;
 
     static double BounceIn(double t) => 1 - BounceOut(1 - t);
     static double BounceOut(double t)

--- a/Prowl.Runtime/GUI/Gui.Animation.cs
+++ b/Prowl.Runtime/GUI/Gui.Animation.cs
@@ -185,8 +185,8 @@ public partial class Gui
     static double QuintInOut(double time) => time < 0.5 ? 16 * time * time * time * time * time : 1 - MathD.Pow(-2 * time + 2, 5) / 2;
 
     static double ExpoIn(double time) => time == 0 ? 0 : MathD.Pow(2, 10 * time - 10);
-    static double ExpoOut(double time) => Math.Abs(time - 1) < Application.FloatEqualThreshold ? 1 : 1 - MathD.Pow(2, -10 * time);
-    static double ExpoInOut(double time) => time == 0 ? 0 : Math.Abs(time - 1) < Application.FloatEqualThreshold ? 1 : time < 0.5 ? MathD.Pow(2, 20 * time - 10) / 2 : (2 - MathD.Pow(2, -20 * time + 10)) / 2;
+    static double ExpoOut(double time) => MathD.ApproximatelyEquals(time, 1) ? 1 : 1 - MathD.Pow(2, -10 * time);
+    static double ExpoInOut(double time) => time == 0 ? 0 : MathD.ApproximatelyEquals(time, 1) ? 1 : time < 0.5 ? MathD.Pow(2, 20 * time - 10) / 2 : (2 - MathD.Pow(2, -20 * time + 10)) / 2;
 
     static double CircIn(double time) => 1 - MathD.Sqrt(1 - MathD.Pow(time, 2));
     static double CircOut(double time) => MathD.Sqrt(1 - MathD.Pow(time - 1, 2));
@@ -198,9 +198,9 @@ public partial class Gui
         MathD.Pow(2 * time, 2) * ((ConstantB + 1) * 2 * time - ConstantB) / 2 :
         (MathD.Pow(2 * time - 2, 2) * ((ConstantB + 1) * (time * 2 - 2) + ConstantB) + 2) / 2;
 
-    static double ElasticIn(double time) => time == 0 ? 0 : Math.Abs(time - 1) < Application.FloatEqualThreshold ? 1 : -MathD.Pow(2, 10 * time - 10) * MathD.Sin((time * 10.0 - 10.75) * ConstantD);
-    static double ElasticOut(double time) => time == 0 ? 0 : Math.Abs(time - 1) < Application.FloatEqualThreshold ? 1 : MathD.Pow(2, -10 * time) * MathD.Sin((time * 10 - 0.75) * ConstantD) + 1;
-    static double ElasticInOut(double time) => time == 0 ? 0 : Math.Abs(time - 1) < Application.FloatEqualThreshold ? 1 : time < 0.5 ? -(MathD.Pow(2, 20 * time - 10) * MathD.Sin((20 * time - 11.125) * ConstantE)) / 2 : MathD.Pow(2, -20 * time + 10) * MathD.Sin((20 * time - 11.125) * ConstantE) / 2 + 1;
+    static double ElasticIn(double time) => time == 0 ? 0 : MathD.ApproximatelyEquals(time, 1) ? 1 : -MathD.Pow(2, 10 * time - 10) * MathD.Sin((time * 10.0 - 10.75) * ConstantD);
+    static double ElasticOut(double time) => time == 0 ? 0 : MathD.ApproximatelyEquals(time, 1) ? 1 : MathD.Pow(2, -10 * time) * MathD.Sin((time * 10 - 0.75) * ConstantD) + 1;
+    static double ElasticInOut(double time) => time == 0 ? 0 : MathD.ApproximatelyEquals(time, 1) ? 1 : time < 0.5 ? -(MathD.Pow(2, 20 * time - 10) * MathD.Sin((20 * time - 11.125) * ConstantE)) / 2 : MathD.Pow(2, -20 * time + 10) * MathD.Sin((20 * time - 11.125) * ConstantE) / 2 + 1;
 
     static double BounceIn(double t) => 1 - BounceOut(1 - t);
     static double BounceOut(double t)

--- a/Prowl.Runtime/GUI/Gui.Core.cs
+++ b/Prowl.Runtime/GUI/Gui.Core.cs
@@ -91,7 +91,7 @@ public partial class Gui
             layoutDirty = true;
         _computedNodeHashes = newNodeHashes;
 
-        if (lastUIScale == uiScale)
+        if (Math.Abs(lastUIScale - uiScale) < Application.FloatEqualThreshold)
             layoutDirty = true;
 
         // Now that we have the nodes we can properly process their LayoutNode

--- a/Prowl.Runtime/GUI/Gui.Core.cs
+++ b/Prowl.Runtime/GUI/Gui.Core.cs
@@ -91,7 +91,7 @@ public partial class Gui
             layoutDirty = true;
         _computedNodeHashes = newNodeHashes;
 
-        if (Math.Abs(lastUIScale - uiScale) < Application.FloatEqualThreshold)
+        if (MathD.ApproximatelyEquals(lastUIScale, uiScale))
             layoutDirty = true;
 
         // Now that we have the nodes we can properly process their LayoutNode

--- a/Prowl.Runtime/GUI/Gui.Interaction.cs
+++ b/Prowl.Runtime/GUI/Gui.Interaction.cs
@@ -124,7 +124,7 @@ public partial class Gui
     /// </summary>
     public bool IsBlockedByInteractable(Vector2 pos, double zIndex = -1, ulong ignoreID = 0)
     {
-        if (Math.Abs(zIndex - (-1)) < Application.FloatEqualThreshold)
+        if (Math.Abs(zIndex - (-1)) < Mathf.Epsilon)
         {
             if (!_zInteractableCounter.TryGetValue(CurrentZIndex, out int count))
                 count = 0;

--- a/Prowl.Runtime/GUI/Gui.Interaction.cs
+++ b/Prowl.Runtime/GUI/Gui.Interaction.cs
@@ -1,6 +1,7 @@
 ﻿// This file is part of the Prowl Game Engine
 // Licensed under the MIT License. See the LICENSE file in the project root for details.
 
+using System;
 using System.Collections.Generic;
 
 using Prowl.Runtime.GUI.Layout;
@@ -123,7 +124,7 @@ public partial class Gui
     /// </summary>
     public bool IsBlockedByInteractable(Vector2 pos, double zIndex = -1, ulong ignoreID = 0)
     {
-        if (zIndex == -1)
+        if (Math.Abs(zIndex - (-1)) < Application.FloatEqualThreshold)
         {
             if (!_zInteractableCounter.TryGetValue(CurrentZIndex, out int count))
                 count = 0;

--- a/Prowl.Runtime/GUI/Gui.Interaction.cs
+++ b/Prowl.Runtime/GUI/Gui.Interaction.cs
@@ -124,7 +124,7 @@ public partial class Gui
     /// </summary>
     public bool IsBlockedByInteractable(Vector2 pos, double zIndex = -1, ulong ignoreID = 0)
     {
-        if (Math.Abs(zIndex - (-1)) < Mathf.Epsilon)
+        if (MathD.ApproximatelyEquals(zIndex, -1))
         {
             if (!_zInteractableCounter.TryGetValue(CurrentZIndex, out int count))
                 count = 0;

--- a/Prowl.Runtime/GUI/Layout/Spacing.cs
+++ b/Prowl.Runtime/GUI/Layout/Spacing.cs
@@ -31,18 +31,18 @@ public struct Spacing
 
     public static bool operator ==(Spacing s1, Spacing s2)
     {
-        return Math.Abs(s1.Left - s2.Left) < Application.FloatEqualThreshold &&
-               Math.Abs(s1.Right - s2.Right) < Application.FloatEqualThreshold &&
-               Math.Abs(s1.Top - s2.Top) < Application.FloatEqualThreshold &&
-               Math.Abs(s1.Bottom - s2.Bottom) < Application.FloatEqualThreshold;
+        return MathD.ApproximatelyEquals(s1.Left, s2.Left) &&
+               MathD.ApproximatelyEquals(s1.Right, s2.Right) &&
+               MathD.ApproximatelyEquals(s1.Top, s2.Top) &&
+               MathD.ApproximatelyEquals(s1.Bottom, s2.Bottom);
     }
 
     public static bool operator !=(Spacing s1, Spacing s2)
     {
-        return Math.Abs(s1.Left - s2.Left) > Application.FloatEqualThreshold ||
-               Math.Abs(s1.Right - s2.Right) > Application.FloatEqualThreshold ||
-               Math.Abs(s1.Top - s2.Top) > Application.FloatEqualThreshold ||
-               Math.Abs(s1.Bottom - s2.Bottom) > Application.FloatEqualThreshold;
+        return MathD.ApproximatelyEquals(s1.Left , s2.Left) ||
+               MathD.ApproximatelyEquals(s1.Right , s2.Right) ||
+               MathD.ApproximatelyEquals(s1.Top , s2.Top) ||
+               MathD.ApproximatelyEquals(s1.Bottom , s2.Bottom);
     }
 
     public override bool Equals(object obj)

--- a/Prowl.Runtime/GUI/Layout/Spacing.cs
+++ b/Prowl.Runtime/GUI/Layout/Spacing.cs
@@ -1,6 +1,8 @@
 ﻿// This file is part of the Prowl Game Engine
 // Licensed under the MIT License. See the LICENSE file in the project root for details.
 
+using System;
+
 namespace Prowl.Runtime.GUI;
 
 public struct Spacing
@@ -29,18 +31,18 @@ public struct Spacing
 
     public static bool operator ==(Spacing s1, Spacing s2)
     {
-        return s1.Left == s2.Left &&
-               s1.Right == s2.Right &&
-               s1.Top == s2.Top &&
-               s1.Bottom == s2.Bottom;
+        return Math.Abs(s1.Left - s2.Left) < Application.FloatEqualThreshold &&
+               Math.Abs(s1.Right - s2.Right) < Application.FloatEqualThreshold &&
+               Math.Abs(s1.Top - s2.Top) < Application.FloatEqualThreshold &&
+               Math.Abs(s1.Bottom - s2.Bottom) < Application.FloatEqualThreshold;
     }
 
     public static bool operator !=(Spacing s1, Spacing s2)
     {
-        return s1.Left != s2.Left ||
-               s1.Right != s2.Right ||
-               s1.Top != s2.Top ||
-               s1.Bottom != s2.Bottom;
+        return Math.Abs(s1.Left - s2.Left) > Application.FloatEqualThreshold ||
+               Math.Abs(s1.Right - s2.Right) > Application.FloatEqualThreshold ||
+               Math.Abs(s1.Top - s2.Top) > Application.FloatEqualThreshold ||
+               Math.Abs(s1.Bottom - s2.Bottom) > Application.FloatEqualThreshold;
     }
 
     public override bool Equals(object obj)

--- a/Prowl.Runtime/GameObject/MonoBehaviour.cs
+++ b/Prowl.Runtime/GameObject/MonoBehaviour.cs
@@ -154,7 +154,7 @@ public abstract class MonoBehaviour : EngineObject
 
         try
         {
-            if (Application.isPlaying || always)
+            if (Application.IsPlaying || always)
                 action();
         }
         catch (Exception e)

--- a/Prowl.Runtime/Math/Bounds.cs
+++ b/Prowl.Runtime/Math/Bounds.cs
@@ -166,12 +166,12 @@ public struct Bounds : IEquatable<Bounds>
         {
             result = ContainmentType.Disjoint;
         }//or if point is on box because coordonate of point is lesser or equal
-        else if (point.x == min.x
-                 || point.x == max.x
-                 || point.y == min.y
-                 || point.y == max.y
-                 || point.z == min.z
-                 || point.z == max.z)
+        else if (Math.Abs(point.x - min.x) < Application.FloatEqualThreshold
+                 || Math.Abs(point.x - max.x) < Application.FloatEqualThreshold
+                 || Math.Abs(point.y - min.y) < Application.FloatEqualThreshold
+                 || Math.Abs(point.y - max.y) < Application.FloatEqualThreshold
+                 || Math.Abs(point.z - min.z) < Application.FloatEqualThreshold
+                 || Math.Abs(point.z - max.z) < Application.FloatEqualThreshold)
             result = ContainmentType.Intersects;
         else
             result = ContainmentType.Contains;

--- a/Prowl.Runtime/Math/Bounds.cs
+++ b/Prowl.Runtime/Math/Bounds.cs
@@ -166,12 +166,12 @@ public struct Bounds : IEquatable<Bounds>
         {
             result = ContainmentType.Disjoint;
         }//or if point is on box because coordonate of point is lesser or equal
-        else if (Math.Abs(point.x - min.x) < Application.FloatEqualThreshold
-                 || Math.Abs(point.x - max.x) < Application.FloatEqualThreshold
-                 || Math.Abs(point.y - min.y) < Application.FloatEqualThreshold
-                 || Math.Abs(point.y - max.y) < Application.FloatEqualThreshold
-                 || Math.Abs(point.z - min.z) < Application.FloatEqualThreshold
-                 || Math.Abs(point.z - max.z) < Application.FloatEqualThreshold)
+        else if (MathD.ApproximatelyEquals(point.x, min.x)
+                 || MathD.ApproximatelyEquals(point.x, max.x)
+                 || MathD.ApproximatelyEquals(point.y, min.y)
+                 || MathD.ApproximatelyEquals(point.y, max.y)
+                 || MathD.ApproximatelyEquals(point.z, min.z)
+                 || MathD.ApproximatelyEquals(point.z, max.z))
             result = ContainmentType.Intersects;
         else
             result = ContainmentType.Contains;

--- a/Prowl.Runtime/Math/MathD.cs
+++ b/Prowl.Runtime/Math/MathD.cs
@@ -10,7 +10,7 @@ namespace Prowl.Runtime;
 
 public static class MathD
 {
-    private const MethodImplOptions IN = MethodImplOptions.AggressiveInlining;
+    public const MethodImplOptions IN = MethodImplOptions.AggressiveInlining;
 
     #region Constants
 
@@ -37,9 +37,6 @@ public static class MathD
 
     /// A small but not tiny value, Used in places like ApproximatelyEquals, where there is some tolerance (0.00001)
     public static readonly double Small = 0.000001;
-
-    /// <inheritdoc cref="double.MinValue"/>
-    public static readonly double Epsilon = double.MinValue;
 
     /// <inheritdoc cref="double.PositiveInfinity"/>
     public const double Infinity = double.PositiveInfinity;
@@ -194,7 +191,7 @@ public static class MathD
 
     [MethodImpl(IN)] public static int ComputeMipLevels(int width, int height) => (int)Math.Log2(Math.Max(width, height));
 
-    [MethodImpl(IN)] public static bool ApproximatelyEquals(double a, double b) => Abs(a - b) < Epsilon;
+    [MethodImpl(IN)] public static bool ApproximatelyEquals(double a, double b) => Abs(a - b) < double.Epsilon;
     [MethodImpl(IN)] public static bool ApproximatelyEquals(Vector2 a, Vector2 b) => ApproximatelyEquals(a.x, b.x) && ApproximatelyEquals(a.y, b.y);
     [MethodImpl(IN)] public static bool ApproximatelyEquals(Vector3 a, Vector3 b) => ApproximatelyEquals(a.x, b.x) && ApproximatelyEquals(a.y, b.y) && ApproximatelyEquals(a.z, b.z);
     [MethodImpl(IN)] public static bool ApproximatelyEquals(Vector4 a, Vector4 b) => ApproximatelyEquals(a.x, b.x) && ApproximatelyEquals(a.y, b.y) && ApproximatelyEquals(a.z, b.z) && ApproximatelyEquals(a.w, b.w);

--- a/Prowl.Runtime/Math/MathD.cs
+++ b/Prowl.Runtime/Math/MathD.cs
@@ -194,7 +194,7 @@ public static class MathD
 
     [MethodImpl(IN)] public static int ComputeMipLevels(int width, int height) => (int)Math.Log2(Math.Max(width, height));
 
-    [MethodImpl(IN)] public static bool ApproximatelyEquals(double a, double b) => Abs(a - b) < 0.00001f;
+    [MethodImpl(IN)] public static bool ApproximatelyEquals(double a, double b) => Abs(a - b) < Epsilon;
     [MethodImpl(IN)] public static bool ApproximatelyEquals(Vector2 a, Vector2 b) => ApproximatelyEquals(a.x, b.x) && ApproximatelyEquals(a.y, b.y);
     [MethodImpl(IN)] public static bool ApproximatelyEquals(Vector3 a, Vector3 b) => ApproximatelyEquals(a.x, b.x) && ApproximatelyEquals(a.y, b.y) && ApproximatelyEquals(a.z, b.z);
     [MethodImpl(IN)] public static bool ApproximatelyEquals(Vector4 a, Vector4 b) => ApproximatelyEquals(a.x, b.x) && ApproximatelyEquals(a.y, b.y) && ApproximatelyEquals(a.z, b.z) && ApproximatelyEquals(a.w, b.w);

--- a/Prowl.Runtime/Math/Mathf.cs
+++ b/Prowl.Runtime/Math/Mathf.cs
@@ -1,0 +1,13 @@
+// This file is part of the Prowl Game Engine
+// Licensed under the MIT License. See the LICENSE file in the project root for details.
+
+using System;
+
+namespace Prowl.Runtime;
+
+public static class Mathf
+{
+    public static readonly float Epsilon = float.MinValue;
+
+    public static bool ApproximatelyEquals(float value1, float value2) => Math.Abs(value1 - value2) < Epsilon;
+}

--- a/Prowl.Runtime/Math/Mathf.cs
+++ b/Prowl.Runtime/Math/Mathf.cs
@@ -2,12 +2,14 @@
 // Licensed under the MIT License. See the LICENSE file in the project root for details.
 
 using System;
+using System.Runtime.CompilerServices;
 
 namespace Prowl.Runtime;
 
 public static class Mathf
 {
-    public static readonly float Epsilon = float.MinValue;
-
-    public static bool ApproximatelyEquals(float value1, float value2) => Math.Abs(value1 - value2) < Epsilon;
+    public static bool ApproximatelyEquals(float value1, float value2) => Math.Abs(value1 - value2) < float.Epsilon;
+    [MethodImpl(MathD.IN)] public static bool ApproximatelyEquals(System.Numerics.Vector2 a, System.Numerics.Vector2 b) => ApproximatelyEquals(a.X, b.X) && ApproximatelyEquals(a.Y, b.Y);
+    [MethodImpl(MathD.IN)] public static bool ApproximatelyEquals(System.Numerics.Vector3 a, System.Numerics.Vector3 b) => ApproximatelyEquals(a.X, b.X) && ApproximatelyEquals(a.Y, b.Y) && ApproximatelyEquals(a.Z, b.Z);
+    [MethodImpl(MathD.IN)] public static bool ApproximatelyEquals(System.Numerics.Vector4 a, System.Numerics.Vector4 b) => ApproximatelyEquals(a.X, b.X) && ApproximatelyEquals(a.Y, b.Y) && ApproximatelyEquals(a.Z, b.Z) && ApproximatelyEquals(a.W, b.W);
 }

--- a/Prowl.Runtime/Math/Matrix4x4.cs
+++ b/Prowl.Runtime/Math/Matrix4x4.cs
@@ -240,8 +240,6 @@ public struct Matrix4x4 : IEquatable<Matrix4x4>
     /// <returns>The created billboard matrix</returns>
     public static Matrix4x4 CreateBillboard(Vector3 objectPosition, Vector3 cameraPosition, Vector3 cameraUpVector, Vector3 cameraForwardVector)
     {
-        const double epsilon = 1e-4;
-
         Vector3 zaxis = new Vector3(
             objectPosition.x - cameraPosition.x,
             objectPosition.y - cameraPosition.y,
@@ -249,7 +247,7 @@ public struct Matrix4x4 : IEquatable<Matrix4x4>
 
         double norm = zaxis.sqrMagnitude;
 
-        if (norm < epsilon)
+        if (norm < MathD.Epsilon)
         {
             zaxis = -cameraForwardVector;
         }
@@ -280,7 +278,6 @@ public struct Matrix4x4 : IEquatable<Matrix4x4>
     /// <returns>The created billboard matrix.</returns>
     public static Matrix4x4 CreateConstrainedBillboard(Vector3 objectPosition, Vector3 cameraPosition, Vector3 rotateAxis, Vector3 cameraForwardVector, Vector3 objectForwardVector)
     {
-        const double epsilon = 1e-4;
         const double minAngle = 1.0 - (0.1 * (Math.PI / 180.0)); // 0.1 degrees
 
         // Treat the case when object and camera positions are too close.
@@ -291,7 +288,7 @@ public struct Matrix4x4 : IEquatable<Matrix4x4>
 
         double norm = faceDir.sqrMagnitude;
 
-        if (norm < epsilon)
+        if (norm < MathD.Epsilon)
         {
             faceDir = -cameraForwardVector;
         }
@@ -1340,7 +1337,6 @@ public struct Matrix4x4 : IEquatable<Matrix4x4>
             fixed (Vector3* scaleBase = &scale)
             {
                 double* pfScales = (double*)scaleBase;
-                const double EPSILON = 0.0001;
                 double det;
 
                 VectorBasis vectorBasis;
@@ -1424,14 +1420,14 @@ public struct Matrix4x4 : IEquatable<Matrix4x4>
                 }
                 #endregion
 
-                if (pfScales[a] < EPSILON)
+                if (pfScales[a] < MathD.Epsilon)
                 {
                     *(pVectorBasis[a]) = pCanonicalBasis[a];
                 }
 
                 *pVectorBasis[a] = Vector3.Normalize(*pVectorBasis[a]);
 
-                if (pfScales[b] < EPSILON)
+                if (pfScales[b] < MathD.Epsilon)
                 {
                     uint cc;
                     double fAbsX, fAbsY, fAbsZ;
@@ -1484,7 +1480,7 @@ public struct Matrix4x4 : IEquatable<Matrix4x4>
 
                 *pVectorBasis[b] = Vector3.Normalize(*pVectorBasis[b]);
 
-                if (pfScales[c] < EPSILON)
+                if (pfScales[c] < MathD.Epsilon)
                 {
                     *pVectorBasis[c] = Vector3.Cross(*pVectorBasis[a], *pVectorBasis[b]);
                 }
@@ -1506,7 +1502,7 @@ public struct Matrix4x4 : IEquatable<Matrix4x4>
                 det -= 1.0;
                 det *= det;
 
-                if ((EPSILON < det))
+                if ((det > MathD.Epsilon))
                 {
                     // Non-SRT matrix encountered
                     rotation = Quaternion.identity;

--- a/Prowl.Runtime/Math/Matrix4x4.cs
+++ b/Prowl.Runtime/Math/Matrix4x4.cs
@@ -247,7 +247,7 @@ public struct Matrix4x4 : IEquatable<Matrix4x4>
 
         double norm = zaxis.sqrMagnitude;
 
-        if (norm < MathD.Epsilon)
+        if (norm < double.Epsilon)
         {
             zaxis = -cameraForwardVector;
         }
@@ -288,7 +288,7 @@ public struct Matrix4x4 : IEquatable<Matrix4x4>
 
         double norm = faceDir.sqrMagnitude;
 
-        if (norm < MathD.Epsilon)
+        if (norm < double.Epsilon)
         {
             faceDir = -cameraForwardVector;
         }
@@ -1420,14 +1420,14 @@ public struct Matrix4x4 : IEquatable<Matrix4x4>
                 }
                 #endregion
 
-                if (pfScales[a] < MathD.Epsilon)
+                if (pfScales[a] < double.Epsilon)
                 {
                     *(pVectorBasis[a]) = pCanonicalBasis[a];
                 }
 
                 *pVectorBasis[a] = Vector3.Normalize(*pVectorBasis[a]);
 
-                if (pfScales[b] < MathD.Epsilon)
+                if (pfScales[b] < double.Epsilon)
                 {
                     uint cc;
                     double fAbsX, fAbsY, fAbsZ;
@@ -1480,7 +1480,7 @@ public struct Matrix4x4 : IEquatable<Matrix4x4>
 
                 *pVectorBasis[b] = Vector3.Normalize(*pVectorBasis[b]);
 
-                if (pfScales[c] < MathD.Epsilon)
+                if (pfScales[c] < double.Epsilon)
                 {
                     *pVectorBasis[c] = Vector3.Cross(*pVectorBasis[a], *pVectorBasis[b]);
                 }
@@ -1502,7 +1502,7 @@ public struct Matrix4x4 : IEquatable<Matrix4x4>
                 det -= 1.0;
                 det *= det;
 
-                if ((det > MathD.Epsilon))
+                if ((det > double.Epsilon))
                 {
                     // Non-SRT matrix encountered
                     rotation = Quaternion.identity;

--- a/Prowl.Runtime/Math/Matrix4x4.cs
+++ b/Prowl.Runtime/Math/Matrix4x4.cs
@@ -71,7 +71,7 @@ public struct Matrix4x4 : IEquatable<Matrix4x4>
     /// <summary>
     /// Returns whether the matrix is the identity matrix.
     /// </summary>
-    public bool IsIdentity => Math.Abs(M11 - 1) < Application.FloatEqualThreshold && Math.Abs(M22 - 1) < Application.FloatEqualThreshold && Math.Abs(M33 - 1) < Application.FloatEqualThreshold && Math.Abs(M44 - 1) < Application.FloatEqualThreshold && // Check diagonal element first for early out.
+    public bool IsIdentity => MathD.ApproximatelyEquals(M11, 1) && MathD.ApproximatelyEquals(M22, 1) && MathD.ApproximatelyEquals(M33, 1) && MathD.ApproximatelyEquals(M44, 1) && // Check diagonal element first for early out.
                               M12 == 0 && M13 == 0 && M14 == 0 &&
                               M21 == 0 && M23 == 0 && M24 == 0 &&
                               M31 == 0 && M32 == 0 && M34 == 0 &&
@@ -1812,14 +1812,7 @@ public struct Matrix4x4 : IEquatable<Matrix4x4>
     /// <param name="value1">The first matrix to compare.</param>
     /// <param name="value2">The second matrix to compare.</param>
     /// <returns>True if the given matrices are equal; False otherwise.</returns>
-    public static bool operator ==(Matrix4x4 value1, Matrix4x4 value2)
-    {
-        return (Math.Abs(value1.M11 - value2.M11) < Application.FloatEqualThreshold && Math.Abs(value1.M22 - value2.M22) < Application.FloatEqualThreshold && Math.Abs(value1.M33 - value2.M33) < Application.FloatEqualThreshold && Math.Abs(value1.M44 - value2.M44) < Application.FloatEqualThreshold && // Check diagonal element first for early out.
-                Math.Abs(value1.M12 - value2.M12) < Application.FloatEqualThreshold && Math.Abs(value1.M13 - value2.M13) < Application.FloatEqualThreshold && Math.Abs(value1.M14 - value2.M14) < Application.FloatEqualThreshold &&
-                Math.Abs(value1.M21 - value2.M21) < Application.FloatEqualThreshold && Math.Abs(value1.M23 - value2.M23) < Application.FloatEqualThreshold && Math.Abs(value1.M24 - value2.M24) < Application.FloatEqualThreshold &&
-                Math.Abs(value1.M31 - value2.M31) < Application.FloatEqualThreshold && Math.Abs(value1.M32 - value2.M32) < Application.FloatEqualThreshold && Math.Abs(value1.M34 - value2.M34) < Application.FloatEqualThreshold &&
-                Math.Abs(value1.M41 - value2.M41) < Application.FloatEqualThreshold && Math.Abs(value1.M42 - value2.M42) < Application.FloatEqualThreshold && Math.Abs(value1.M43 - value2.M43) < Application.FloatEqualThreshold);
-    }
+    public static bool operator ==(Matrix4x4 value1, Matrix4x4 value2) => value1.Equals(value2);
 
     /// <summary>
     /// Returns a boolean indicating whether the given two matrices are not equal.
@@ -1827,42 +1820,26 @@ public struct Matrix4x4 : IEquatable<Matrix4x4>
     /// <param name="value1">The first matrix to compare.</param>
     /// <param name="value2">The second matrix to compare.</param>
     /// <returns>True if the given matrices are not equal; False if they are equal.</returns>
-    public static bool operator !=(Matrix4x4 value1, Matrix4x4 value2)
-    {
-        return (Math.Abs(value1.M11 - value2.M11) > Application.FloatEqualThreshold || Math.Abs(value1.M12 - value2.M12) > Application.FloatEqualThreshold || Math.Abs(value1.M13 - value2.M13) > Application.FloatEqualThreshold || Math.Abs(value1.M14 - value2.M14) > Application.FloatEqualThreshold ||
-                Math.Abs(value1.M21 - value2.M21) > Application.FloatEqualThreshold || Math.Abs(value1.M22 - value2.M22) > Application.FloatEqualThreshold || Math.Abs(value1.M23 - value2.M23) > Application.FloatEqualThreshold || Math.Abs(value1.M24 - value2.M24) > Application.FloatEqualThreshold ||
-                Math.Abs(value1.M31 - value2.M31) > Application.FloatEqualThreshold || Math.Abs(value1.M32 - value2.M32) > Application.FloatEqualThreshold || Math.Abs(value1.M33 - value2.M33) > Application.FloatEqualThreshold || Math.Abs(value1.M34 - value2.M34) > Application.FloatEqualThreshold ||
-                Math.Abs(value1.M41 - value2.M41) > Application.FloatEqualThreshold || Math.Abs(value1.M42 - value2.M42) > Application.FloatEqualThreshold || Math.Abs(value1.M43 - value2.M43) > Application.FloatEqualThreshold || Math.Abs(value1.M44 - value2.M44) > Application.FloatEqualThreshold);
-    }
+    public static bool operator !=(Matrix4x4 value1, Matrix4x4 value2) => !value1.Equals(value2);
 
     /// <summary>
     /// Returns a boolean indicating whether this matrix instance is equal to the other given matrix.
     /// </summary>
     /// <param name="other">The matrix to compare this instance to.</param>
     /// <returns>True if the matrices are equal; False otherwise.</returns>
-    public bool Equals(Matrix4x4 other)
-    {
-        return (Math.Abs(M11 - other.M11) < Application.FloatEqualThreshold && Math.Abs(M22 - other.M22) < Application.FloatEqualThreshold && Math.Abs(M33 - other.M33) < Application.FloatEqualThreshold && Math.Abs(M44 - other.M44) < Application.FloatEqualThreshold && // Check diagonal element first for early out.
-                Math.Abs(M12 - other.M12) < Application.FloatEqualThreshold && Math.Abs(M13 - other.M13) < Application.FloatEqualThreshold && Math.Abs(M14 - other.M14) < Application.FloatEqualThreshold &&
-                Math.Abs(M21 - other.M21) < Application.FloatEqualThreshold && Math.Abs(M23 - other.M23) < Application.FloatEqualThreshold && Math.Abs(M24 - other.M24) < Application.FloatEqualThreshold &&
-                Math.Abs(M31 - other.M31) < Application.FloatEqualThreshold && Math.Abs(M32 - other.M32) < Application.FloatEqualThreshold && Math.Abs(M34 - other.M34) < Application.FloatEqualThreshold &&
-                Math.Abs(M41 - other.M41) < Application.FloatEqualThreshold && Math.Abs(M42 - other.M42) < Application.FloatEqualThreshold && Math.Abs(M43 - other.M43) < Application.FloatEqualThreshold);
-    }
+    public bool Equals(Matrix4x4 other) =>
+        (MathD.ApproximatelyEquals(M11, other.M11) && MathD.ApproximatelyEquals(M22, other.M22) && MathD.ApproximatelyEquals(M33, other.M33) && MathD.ApproximatelyEquals(M44, other.M44) && // Check diagonal element first for early out.
+         MathD.ApproximatelyEquals(M12, other.M12) && MathD.ApproximatelyEquals(M13, other.M13) && MathD.ApproximatelyEquals(M14, other.M14) &&
+         MathD.ApproximatelyEquals(M21, other.M21) && MathD.ApproximatelyEquals(M23, other.M23) && MathD.ApproximatelyEquals(M24, other.M24) &&
+         MathD.ApproximatelyEquals(M31, other.M31) && MathD.ApproximatelyEquals(M32, other.M32) && MathD.ApproximatelyEquals(M34, other.M34) &&
+         MathD.ApproximatelyEquals(M41, other.M41) && MathD.ApproximatelyEquals(M42, other.M42) && MathD.ApproximatelyEquals(M43, other.M43));
 
     /// <summary>
     /// Returns a boolean indicating whether the given Object is equal to this matrix instance.
     /// </summary>
     /// <param name="obj">The Object to compare against.</param>
     /// <returns>True if the Object is equal to this matrix; False otherwise.</returns>
-    public override bool Equals(object? obj)
-    {
-        if (obj is Matrix4x4 x)
-        {
-            return Equals(x);
-        }
-
-        return false;
-    }
+    public override bool Equals(object? obj) => obj is Matrix4x4 x && Equals(x);
 
     /// <summary>
     /// Returns a String representing this matrix instance.
@@ -1895,11 +1872,9 @@ public struct Matrix4x4 : IEquatable<Matrix4x4>
     /// Returns the hash code for this instance.
     /// </summary>
     /// <returns>The hash code.</returns>
-    public override int GetHashCode()
-    {
-        return M11.GetHashCode() + M12.GetHashCode() + M13.GetHashCode() + M14.GetHashCode() +
-               M21.GetHashCode() + M22.GetHashCode() + M23.GetHashCode() + M24.GetHashCode() +
-               M31.GetHashCode() + M32.GetHashCode() + M33.GetHashCode() + M34.GetHashCode() +
-               M41.GetHashCode() + M42.GetHashCode() + M43.GetHashCode() + M44.GetHashCode();
-    }
+    public override int GetHashCode() =>
+        M11.GetHashCode() + M12.GetHashCode() + M13.GetHashCode() + M14.GetHashCode() +
+        M21.GetHashCode() + M22.GetHashCode() + M23.GetHashCode() + M24.GetHashCode() +
+        M31.GetHashCode() + M32.GetHashCode() + M33.GetHashCode() + M34.GetHashCode() +
+        M41.GetHashCode() + M42.GetHashCode() + M43.GetHashCode() + M44.GetHashCode();
 }

--- a/Prowl.Runtime/Math/Matrix4x4.cs
+++ b/Prowl.Runtime/Math/Matrix4x4.cs
@@ -71,7 +71,7 @@ public struct Matrix4x4 : IEquatable<Matrix4x4>
     /// <summary>
     /// Returns whether the matrix is the identity matrix.
     /// </summary>
-    public bool IsIdentity => M11 == 1 && M22 == 1 && M33 == 1 && M44 == 1 && // Check diagonal element first for early out.
+    public bool IsIdentity => Math.Abs(M11 - 1) < Application.FloatEqualThreshold && Math.Abs(M22 - 1) < Application.FloatEqualThreshold && Math.Abs(M33 - 1) < Application.FloatEqualThreshold && Math.Abs(M44 - 1) < Application.FloatEqualThreshold && // Check diagonal element first for early out.
                               M12 == 0 && M13 == 0 && M14 == 0 &&
                               M21 == 0 && M23 == 0 && M24 == 0 &&
                               M31 == 0 && M32 == 0 && M34 == 0 &&
@@ -1814,11 +1814,11 @@ public struct Matrix4x4 : IEquatable<Matrix4x4>
     /// <returns>True if the given matrices are equal; False otherwise.</returns>
     public static bool operator ==(Matrix4x4 value1, Matrix4x4 value2)
     {
-        return (value1.M11 == value2.M11 && value1.M22 == value2.M22 && value1.M33 == value2.M33 && value1.M44 == value2.M44 && // Check diagonal element first for early out.
-                value1.M12 == value2.M12 && value1.M13 == value2.M13 && value1.M14 == value2.M14 &&
-                value1.M21 == value2.M21 && value1.M23 == value2.M23 && value1.M24 == value2.M24 &&
-                value1.M31 == value2.M31 && value1.M32 == value2.M32 && value1.M34 == value2.M34 &&
-                value1.M41 == value2.M41 && value1.M42 == value2.M42 && value1.M43 == value2.M43);
+        return (Math.Abs(value1.M11 - value2.M11) < Application.FloatEqualThreshold && Math.Abs(value1.M22 - value2.M22) < Application.FloatEqualThreshold && Math.Abs(value1.M33 - value2.M33) < Application.FloatEqualThreshold && Math.Abs(value1.M44 - value2.M44) < Application.FloatEqualThreshold && // Check diagonal element first for early out.
+                Math.Abs(value1.M12 - value2.M12) < Application.FloatEqualThreshold && Math.Abs(value1.M13 - value2.M13) < Application.FloatEqualThreshold && Math.Abs(value1.M14 - value2.M14) < Application.FloatEqualThreshold &&
+                Math.Abs(value1.M21 - value2.M21) < Application.FloatEqualThreshold && Math.Abs(value1.M23 - value2.M23) < Application.FloatEqualThreshold && Math.Abs(value1.M24 - value2.M24) < Application.FloatEqualThreshold &&
+                Math.Abs(value1.M31 - value2.M31) < Application.FloatEqualThreshold && Math.Abs(value1.M32 - value2.M32) < Application.FloatEqualThreshold && Math.Abs(value1.M34 - value2.M34) < Application.FloatEqualThreshold &&
+                Math.Abs(value1.M41 - value2.M41) < Application.FloatEqualThreshold && Math.Abs(value1.M42 - value2.M42) < Application.FloatEqualThreshold && Math.Abs(value1.M43 - value2.M43) < Application.FloatEqualThreshold);
     }
 
     /// <summary>
@@ -1829,10 +1829,10 @@ public struct Matrix4x4 : IEquatable<Matrix4x4>
     /// <returns>True if the given matrices are not equal; False if they are equal.</returns>
     public static bool operator !=(Matrix4x4 value1, Matrix4x4 value2)
     {
-        return (value1.M11 != value2.M11 || value1.M12 != value2.M12 || value1.M13 != value2.M13 || value1.M14 != value2.M14 ||
-                value1.M21 != value2.M21 || value1.M22 != value2.M22 || value1.M23 != value2.M23 || value1.M24 != value2.M24 ||
-                value1.M31 != value2.M31 || value1.M32 != value2.M32 || value1.M33 != value2.M33 || value1.M34 != value2.M34 ||
-                value1.M41 != value2.M41 || value1.M42 != value2.M42 || value1.M43 != value2.M43 || value1.M44 != value2.M44);
+        return (Math.Abs(value1.M11 - value2.M11) > Application.FloatEqualThreshold || Math.Abs(value1.M12 - value2.M12) > Application.FloatEqualThreshold || Math.Abs(value1.M13 - value2.M13) > Application.FloatEqualThreshold || Math.Abs(value1.M14 - value2.M14) > Application.FloatEqualThreshold ||
+                Math.Abs(value1.M21 - value2.M21) > Application.FloatEqualThreshold || Math.Abs(value1.M22 - value2.M22) > Application.FloatEqualThreshold || Math.Abs(value1.M23 - value2.M23) > Application.FloatEqualThreshold || Math.Abs(value1.M24 - value2.M24) > Application.FloatEqualThreshold ||
+                Math.Abs(value1.M31 - value2.M31) > Application.FloatEqualThreshold || Math.Abs(value1.M32 - value2.M32) > Application.FloatEqualThreshold || Math.Abs(value1.M33 - value2.M33) > Application.FloatEqualThreshold || Math.Abs(value1.M34 - value2.M34) > Application.FloatEqualThreshold ||
+                Math.Abs(value1.M41 - value2.M41) > Application.FloatEqualThreshold || Math.Abs(value1.M42 - value2.M42) > Application.FloatEqualThreshold || Math.Abs(value1.M43 - value2.M43) > Application.FloatEqualThreshold || Math.Abs(value1.M44 - value2.M44) > Application.FloatEqualThreshold);
     }
 
     /// <summary>
@@ -1842,11 +1842,11 @@ public struct Matrix4x4 : IEquatable<Matrix4x4>
     /// <returns>True if the matrices are equal; False otherwise.</returns>
     public bool Equals(Matrix4x4 other)
     {
-        return (M11 == other.M11 && M22 == other.M22 && M33 == other.M33 && M44 == other.M44 && // Check diagonal element first for early out.
-                M12 == other.M12 && M13 == other.M13 && M14 == other.M14 &&
-                M21 == other.M21 && M23 == other.M23 && M24 == other.M24 &&
-                M31 == other.M31 && M32 == other.M32 && M34 == other.M34 &&
-                M41 == other.M41 && M42 == other.M42 && M43 == other.M43);
+        return (Math.Abs(M11 - other.M11) < Application.FloatEqualThreshold && Math.Abs(M22 - other.M22) < Application.FloatEqualThreshold && Math.Abs(M33 - other.M33) < Application.FloatEqualThreshold && Math.Abs(M44 - other.M44) < Application.FloatEqualThreshold && // Check diagonal element first for early out.
+                Math.Abs(M12 - other.M12) < Application.FloatEqualThreshold && Math.Abs(M13 - other.M13) < Application.FloatEqualThreshold && Math.Abs(M14 - other.M14) < Application.FloatEqualThreshold &&
+                Math.Abs(M21 - other.M21) < Application.FloatEqualThreshold && Math.Abs(M23 - other.M23) < Application.FloatEqualThreshold && Math.Abs(M24 - other.M24) < Application.FloatEqualThreshold &&
+                Math.Abs(M31 - other.M31) < Application.FloatEqualThreshold && Math.Abs(M32 - other.M32) < Application.FloatEqualThreshold && Math.Abs(M34 - other.M34) < Application.FloatEqualThreshold &&
+                Math.Abs(M41 - other.M41) < Application.FloatEqualThreshold && Math.Abs(M42 - other.M42) < Application.FloatEqualThreshold && Math.Abs(M43 - other.M43) < Application.FloatEqualThreshold);
     }
 
     /// <summary>

--- a/Prowl.Runtime/Math/Plane.cs
+++ b/Prowl.Runtime/Math/Plane.cs
@@ -155,7 +155,7 @@ public struct Plane : IEquatable<Plane>
 
     public override bool Equals(object? other) => (other is Plane plane) ? Equals(plane) : false;
 
-    public bool Equals(Plane other) => ((normal == other.normal) && (distance == other.distance));
+    public bool Equals(Plane other) => ((normal == other.normal) && (Math.Abs(distance - other.distance) < Application.FloatEqualThreshold));
 
     public override int GetHashCode() => normal.GetHashCode() ^ distance.GetHashCode();
 

--- a/Prowl.Runtime/Math/Plane.cs
+++ b/Prowl.Runtime/Math/Plane.cs
@@ -155,7 +155,7 @@ public struct Plane : IEquatable<Plane>
 
     public override bool Equals(object? other) => (other is Plane plane) ? Equals(plane) : false;
 
-    public bool Equals(Plane other) => ((normal == other.normal) && (Math.Abs(distance - other.distance) < Application.FloatEqualThreshold));
+    public bool Equals(Plane other) => ((normal == other.normal) && (MathD.ApproximatelyEquals(distance, other.distance)));
 
     public override int GetHashCode() => normal.GetHashCode() ^ distance.GetHashCode();
 

--- a/Prowl.Runtime/Math/Quaternion.cs
+++ b/Prowl.Runtime/Math/Quaternion.cs
@@ -114,7 +114,7 @@ public struct Quaternion : IEquatable<Quaternion>
     public static Quaternion NormalizeSafe(Quaternion q)
     {
         double mag = q.Magnitude();
-        if (mag < MathD.Epsilon)
+        if (mag < double.Epsilon)
             return identity;
         else
             return q / mag;
@@ -334,7 +334,7 @@ public struct Quaternion : IEquatable<Quaternion>
 
         double s1, s2;
 
-        if (cosOmega > (1.0 - MathD.Epsilon))
+        if (cosOmega > (1.0 - double.Epsilon))
         {
             // Too close, do straight linear interpolation.
             s1 = 1.0 - t;

--- a/Prowl.Runtime/Math/Quaternion.cs
+++ b/Prowl.Runtime/Math/Quaternion.cs
@@ -319,8 +319,6 @@ public struct Quaternion : IEquatable<Quaternion>
     /// <returns>The interpolated Quaternion.</returns>
     public static Quaternion Slerp(Quaternion quaternion1, Quaternion quaternion2, double amount)
     {
-        const double epsilon = 1e-6;
-
         double t = amount;
 
         double cosOmega = quaternion1.x * quaternion2.x + quaternion1.y * quaternion2.y +
@@ -336,7 +334,7 @@ public struct Quaternion : IEquatable<Quaternion>
 
         double s1, s2;
 
-        if (cosOmega > (1.0 - epsilon))
+        if (cosOmega > (1.0 - MathD.Epsilon))
         {
             // Too close, do straight linear interpolation.
             s1 = 1.0 - t;

--- a/Prowl.Runtime/Math/Quaternion.cs
+++ b/Prowl.Runtime/Math/Quaternion.cs
@@ -220,19 +220,17 @@ public struct Quaternion : IEquatable<Quaternion>
     {
         //  Roll first, about axis the object is facing, then
         //  pitch upward, then yaw to face into the new heading
-        double sr, cr, sp, cp, sy, cy;
-
         double halfRoll = roll * 0.5;
-        sr = Math.Sin(halfRoll);
-        cr = Math.Cos(halfRoll);
+        double sr = Math.Sin(halfRoll);
+        double cr = Math.Cos(halfRoll);
 
         double halfPitch = pitch * 0.5;
-        sp = Math.Sin(halfPitch);
-        cp = Math.Cos(halfPitch);
+        double sp = Math.Sin(halfPitch);
+        double cp = Math.Cos(halfPitch);
 
         double halfYaw = yaw * 0.5;
-        sy = Math.Sin(halfYaw);
-        cy = Math.Cos(halfYaw);
+        double sy = Math.Sin(halfYaw);
+        double cy = Math.Cos(halfYaw);
 
         Quaternion result;
 
@@ -779,10 +777,7 @@ public struct Quaternion : IEquatable<Quaternion>
         return ans;
     }
 
-    public static Quaternion operator /(Quaternion q, double v)
-    {
-        return new Quaternion(q.x / v, q.y / v, q.z / v, q.w / v);
-    }
+    public static Quaternion operator /(Quaternion q, double v) => new(q.x / v, q.y / v, q.z / v, q.w / v);
 
     /// <summary>
     /// Returns a boolean indicating whether the two given Quaternions are equal.
@@ -790,13 +785,7 @@ public struct Quaternion : IEquatable<Quaternion>
     /// <param name="value1">The first Quaternion to compare.</param>
     /// <param name="value2">The second Quaternion to compare.</param>
     /// <returns>True if the Quaternions are equal; False otherwise.</returns>
-    public static bool operator ==(Quaternion value1, Quaternion value2)
-    {
-        return (Math.Abs(value1.x - value2.x) < Application.FloatEqualThreshold &&
-                Math.Abs(value1.y - value2.y) < Application.FloatEqualThreshold &&
-                Math.Abs(value1.z - value2.z) < Application.FloatEqualThreshold &&
-                Math.Abs(value1.w - value2.w) < Application.FloatEqualThreshold);
-    }
+    public static bool operator ==(Quaternion value1, Quaternion value2) => value1.Equals(value2);
 
     /// <summary>
     /// Returns a boolean indicating whether the two given Quaternions are not equal.
@@ -804,50 +793,29 @@ public struct Quaternion : IEquatable<Quaternion>
     /// <param name="value1">The first Quaternion to compare.</param>
     /// <param name="value2">The second Quaternion to compare.</param>
     /// <returns>True if the Quaternions are not equal; False if they are equal.</returns>
-    public static bool operator !=(Quaternion value1, Quaternion value2)
-    {
-        return (Math.Abs(value1.x - value2.x) > Application.FloatEqualThreshold ||
-                Math.Abs(value1.y - value2.y) > Application.FloatEqualThreshold ||
-                Math.Abs(value1.z - value2.z) > Application.FloatEqualThreshold ||
-                Math.Abs(value1.w - value2.w) > Application.FloatEqualThreshold);
-    }
+    public static bool operator !=(Quaternion value1, Quaternion value2) => !value1.Equals(value2);
 
-    public static implicit operator System.Numerics.Quaternion(Quaternion value)
-    {
-        return new System.Numerics.Quaternion((float)value.x, (float)value.y, (float)value.z, (float)value.w);
-    }
+    public static implicit operator System.Numerics.Quaternion(Quaternion value) => new((float)value.x, (float)value.y, (float)value.z, (float)value.w);
 
-    public static implicit operator Quaternion(System.Numerics.Quaternion value)
-    {
-        return new Quaternion(value.X, value.Y, value.Z, value.W);
-    }
+    public static implicit operator Quaternion(System.Numerics.Quaternion value) => new(value.X, value.Y, value.Z, value.W);
+
     /// <summary>
     /// Returns a boolean indicating whether the given Quaternion is equal to this Quaternion instance.
     /// </summary>
     /// <param name="other">The Quaternion to compare this instance to.</param>
     /// <returns>True if the other Quaternion is equal to this instance; False otherwise.</returns>
-    public bool Equals(Quaternion other)
-    {
-        return (Math.Abs(x - other.x) < Application.FloatEqualThreshold &&
-                Math.Abs(y - other.y) < Application.FloatEqualThreshold &&
-                Math.Abs(z - other.z) < Application.FloatEqualThreshold &&
-                Math.Abs(w - other.w) < Application.FloatEqualThreshold);
-    }
+    public bool Equals(Quaternion other) =>
+        (MathD.ApproximatelyEquals(x, other.x) &&
+         MathD.ApproximatelyEquals(y, other.y) &&
+         MathD.ApproximatelyEquals(z, other.z) &&
+         MathD.ApproximatelyEquals(w, other.w));
 
     /// <summary>
     /// Returns a boolean indicating whether the given Object is equal to this Quaternion instance.
     /// </summary>
     /// <param name="obj">The Object to compare against.</param>
     /// <returns>True if the Object is equal to this Quaternion; False otherwise.</returns>
-    public override bool Equals(object? obj)
-    {
-        if (obj is Quaternion quaternion)
-        {
-            return Equals(quaternion);
-        }
-
-        return false;
-    }
+    public override bool Equals(object? obj) => obj is Quaternion quaternion && Equals(quaternion);
 
     /// <summary>
     /// Returns a String representing this Quaternion instance.
@@ -857,15 +825,12 @@ public struct Quaternion : IEquatable<Quaternion>
     {
         CultureInfo ci = CultureInfo.CurrentCulture;
 
-        return String.Format(ci, "{{X:{0} Y:{1} Z:{2} W:{3}}}", x.ToString(ci), y.ToString(ci), z.ToString(ci), w.ToString(ci));
+        return string.Format(ci, "{{X:{0} Y:{1} Z:{2} W:{3}}}", x.ToString(ci), y.ToString(ci), z.ToString(ci), w.ToString(ci));
     }
 
     /// <summary>
     /// Returns the hash code for this instance.
     /// </summary>
     /// <returns>The hash code.</returns>
-    public override int GetHashCode()
-    {
-        return x.GetHashCode() + y.GetHashCode() + z.GetHashCode() + w.GetHashCode();
-    }
+    public override int GetHashCode() => x.GetHashCode() + y.GetHashCode() + z.GetHashCode() + w.GetHashCode();
 }

--- a/Prowl.Runtime/Math/Quaternion.cs
+++ b/Prowl.Runtime/Math/Quaternion.cs
@@ -792,10 +792,10 @@ public struct Quaternion : IEquatable<Quaternion>
     /// <returns>True if the Quaternions are equal; False otherwise.</returns>
     public static bool operator ==(Quaternion value1, Quaternion value2)
     {
-        return (value1.x == value2.x &&
-                value1.y == value2.y &&
-                value1.z == value2.z &&
-                value1.w == value2.w);
+        return (Math.Abs(value1.x - value2.x) < Application.FloatEqualThreshold &&
+                Math.Abs(value1.y - value2.y) < Application.FloatEqualThreshold &&
+                Math.Abs(value1.z - value2.z) < Application.FloatEqualThreshold &&
+                Math.Abs(value1.w - value2.w) < Application.FloatEqualThreshold);
     }
 
     /// <summary>
@@ -806,10 +806,10 @@ public struct Quaternion : IEquatable<Quaternion>
     /// <returns>True if the Quaternions are not equal; False if they are equal.</returns>
     public static bool operator !=(Quaternion value1, Quaternion value2)
     {
-        return (value1.x != value2.x ||
-                value1.y != value2.y ||
-                value1.z != value2.z ||
-                value1.w != value2.w);
+        return (Math.Abs(value1.x - value2.x) > Application.FloatEqualThreshold ||
+                Math.Abs(value1.y - value2.y) > Application.FloatEqualThreshold ||
+                Math.Abs(value1.z - value2.z) > Application.FloatEqualThreshold ||
+                Math.Abs(value1.w - value2.w) > Application.FloatEqualThreshold);
     }
 
     public static implicit operator System.Numerics.Quaternion(Quaternion value)
@@ -828,10 +828,10 @@ public struct Quaternion : IEquatable<Quaternion>
     /// <returns>True if the other Quaternion is equal to this instance; False otherwise.</returns>
     public bool Equals(Quaternion other)
     {
-        return (x == other.x &&
-                y == other.y &&
-                z == other.z &&
-                w == other.w);
+        return (Math.Abs(x - other.x) < Application.FloatEqualThreshold &&
+                Math.Abs(y - other.y) < Application.FloatEqualThreshold &&
+                Math.Abs(z - other.z) < Application.FloatEqualThreshold &&
+                Math.Abs(w - other.w) < Application.FloatEqualThreshold);
     }
 
     /// <summary>

--- a/Prowl.Runtime/Math/Ray.cs
+++ b/Prowl.Runtime/Math/Ray.cs
@@ -79,11 +79,9 @@ public struct Ray : IEquatable<Ray>
     // adapted from http://www.scratchapixel.com/lessons/3d-basic-lessons/lesson-7-intersecting-simple-shapes/ray-box-intersection/
     public double? Intersects(Bounds box)
     {
-        const double Epsilon = 1e-6;
-
         double? tMin = null, tMax = null;
 
-        if (Math.Abs(direction.x) < Epsilon)
+        if (Math.Abs(direction.x) < MathD.Epsilon)
         {
             if (origin.x < box.min.x || origin.x > box.max.x)
                 return null;
@@ -101,7 +99,7 @@ public struct Ray : IEquatable<Ray>
             }
         }
 
-        if (Math.Abs(direction.y) < Epsilon)
+        if (Math.Abs(direction.y) < MathD.Epsilon)
         {
             if (origin.y < box.min.y || origin.y > box.max.y)
                 return null;
@@ -125,7 +123,7 @@ public struct Ray : IEquatable<Ray>
             if (!tMax.HasValue || tMaxY < tMax) tMax = tMaxY;
         }
 
-        if (Math.Abs(direction.z) < Epsilon)
+        if (Math.Abs(direction.z) < MathD.Epsilon)
         {
             if (origin.z < box.min.z || origin.z > box.max.z)
                 return null;

--- a/Prowl.Runtime/Math/Ray.cs
+++ b/Prowl.Runtime/Math/Ray.cs
@@ -81,7 +81,7 @@ public struct Ray : IEquatable<Ray>
     {
         double? tMin = null, tMax = null;
 
-        if (Math.Abs(direction.x) < MathD.Epsilon)
+        if (Math.Abs(direction.x) < double.Epsilon)
         {
             if (origin.x < box.min.x || origin.x > box.max.x)
                 return null;
@@ -99,7 +99,7 @@ public struct Ray : IEquatable<Ray>
             }
         }
 
-        if (Math.Abs(direction.y) < MathD.Epsilon)
+        if (Math.Abs(direction.y) < double.Epsilon)
         {
             if (origin.y < box.min.y || origin.y > box.max.y)
                 return null;
@@ -123,7 +123,7 @@ public struct Ray : IEquatable<Ray>
             if (!tMax.HasValue || tMaxY < tMax) tMax = tMaxY;
         }
 
-        if (Math.Abs(direction.z) < MathD.Epsilon)
+        if (Math.Abs(direction.z) < double.Epsilon)
         {
             if (origin.z < box.min.z || origin.z > box.max.z)
                 return null;

--- a/Prowl.Runtime/Math/Transform.cs
+++ b/Prowl.Runtime/Math/Transform.cs
@@ -276,7 +276,7 @@ public class Transform
     internal void RotateAroundInternal(Vector3 worldAxis, double rad)
     {
         Vector3 localAxis = InverseTransformDirection(worldAxis);
-        if (localAxis.sqrMagnitude > MathD.Epsilon)
+        if (localAxis.sqrMagnitude > double.Epsilon)
         {
             localAxis.Normalize();
             Quaternion q = Quaternion.AngleAxis(rad, localAxis);
@@ -356,6 +356,6 @@ public class Transform
         return ret;
     }
 
-    static double InverseSafe(double f) => MathD.Abs(f) > MathD.Epsilon ? 1.0F / f : 0.0F;
+    static double InverseSafe(double f) => MathD.Abs(f) > double.Epsilon ? 1.0F / f : 0.0F;
     static Vector3 InverseSafe(Vector3 v) => new Vector3(InverseSafe(v.x), InverseSafe(v.y), InverseSafe(v.z));
 }

--- a/Prowl.Runtime/Math/Vector2.cs
+++ b/Prowl.Runtime/Math/Vector2.cs
@@ -108,7 +108,7 @@ public struct Vector2 : IEquatable<Vector2>, IFormattable
     /// <returns>True if the other Vector2 is equal to this instance; False otherwise.</returns>
     public bool Equals(Vector2 other)
     {
-        return x == other.x && y == other.y;
+        return Math.Abs(x - other.x) < Application.FloatEqualThreshold && Math.Abs(y - other.y) < Application.FloatEqualThreshold;
     }
 
 

--- a/Prowl.Runtime/Math/Vector2.cs
+++ b/Prowl.Runtime/Math/Vector2.cs
@@ -108,7 +108,7 @@ public struct Vector2 : IEquatable<Vector2>, IFormattable
     /// <returns>True if the other Vector2 is equal to this instance; False otherwise.</returns>
     public bool Equals(Vector2 other)
     {
-        return Math.Abs(x - other.x) < Application.FloatEqualThreshold && Math.Abs(y - other.y) < Application.FloatEqualThreshold;
+        return MathD.ApproximatelyEquals(x, other.x) && MathD.ApproximatelyEquals(y, other.y);
     }
 
 

--- a/Prowl.Runtime/Math/Vector3.cs
+++ b/Prowl.Runtime/Math/Vector3.cs
@@ -121,9 +121,9 @@ public struct Vector3 : IEquatable<Vector3>, IFormattable
     /// <returns>True if the other Vector3 is equal to this instance; False otherwise.</returns>
     public bool Equals(Vector3 other)
     {
-        return x == other.x &&
-               y == other.y &&
-               z == other.z;
+        return Math.Abs(x - other.x) < Application.FloatEqualThreshold &&
+               Math.Abs(y - other.y) < Application.FloatEqualThreshold &&
+               Math.Abs(z - other.z) < Application.FloatEqualThreshold;
     }
 
     /// <summary>
@@ -585,9 +585,9 @@ public struct Vector3 : IEquatable<Vector3>, IFormattable
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static bool operator ==(Vector3 left, Vector3 right)
     {
-        return (left.x == right.x &&
-                left.y == right.y &&
-                left.z == right.z);
+        return (Math.Abs(left.x - right.x) < Application.FloatEqualThreshold &&
+                Math.Abs(left.y - right.y) < Application.FloatEqualThreshold &&
+                Math.Abs(left.z - right.z) < Application.FloatEqualThreshold);
     }
 
     /// <summary>
@@ -599,9 +599,9 @@ public struct Vector3 : IEquatable<Vector3>, IFormattable
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static bool operator !=(Vector3 left, Vector3 right)
     {
-        return (left.x != right.x ||
-                left.y != right.y ||
-                left.z != right.z);
+        return (Math.Abs(left.x - right.x) > Application.FloatEqualThreshold ||
+                Math.Abs(left.y - right.y) > Application.FloatEqualThreshold ||
+                Math.Abs(left.z - right.z) > Application.FloatEqualThreshold);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/Prowl.Runtime/Math/Vector3.cs
+++ b/Prowl.Runtime/Math/Vector3.cs
@@ -107,12 +107,7 @@ public struct Vector3 : IEquatable<Vector3>, IFormattable
     /// <param name="obj">The Object to compare against.</param>
     /// <returns>True if the Object is equal to this Vector3; False otherwise.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public override bool Equals(object? obj)
-    {
-        if (obj is not Vector3)
-            return false;
-        return Equals((Vector3)obj);
-    }
+    public override bool Equals(object? obj) => obj is Vector3 vector3 && Equals(vector3);
 
     /// <summary>
     /// Returns a boolean indicating whether the given Vector3 is equal to this Vector3 instance.
@@ -121,9 +116,9 @@ public struct Vector3 : IEquatable<Vector3>, IFormattable
     /// <returns>True if the other Vector3 is equal to this instance; False otherwise.</returns>
     public bool Equals(Vector3 other)
     {
-        return Math.Abs(x - other.x) < Application.FloatEqualThreshold &&
-               Math.Abs(y - other.y) < Application.FloatEqualThreshold &&
-               Math.Abs(z - other.z) < Application.FloatEqualThreshold;
+        return MathD.ApproximatelyEquals(x, other.x) &&
+               MathD.ApproximatelyEquals(y, other.y) &&
+               MathD.ApproximatelyEquals(z, other.z);
     }
 
     /// <summary>
@@ -585,9 +580,7 @@ public struct Vector3 : IEquatable<Vector3>, IFormattable
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static bool operator ==(Vector3 left, Vector3 right)
     {
-        return (Math.Abs(left.x - right.x) < Application.FloatEqualThreshold &&
-                Math.Abs(left.y - right.y) < Application.FloatEqualThreshold &&
-                Math.Abs(left.z - right.z) < Application.FloatEqualThreshold);
+        return left.Equals(right);
     }
 
     /// <summary>
@@ -599,9 +592,7 @@ public struct Vector3 : IEquatable<Vector3>, IFormattable
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static bool operator !=(Vector3 left, Vector3 right)
     {
-        return (Math.Abs(left.x - right.x) > Application.FloatEqualThreshold ||
-                Math.Abs(left.y - right.y) > Application.FloatEqualThreshold ||
-                Math.Abs(left.z - right.z) > Application.FloatEqualThreshold);
+        return !left.Equals(right);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/Prowl.Runtime/Math/Vector4.cs
+++ b/Prowl.Runtime/Math/Vector4.cs
@@ -158,10 +158,10 @@ public struct Vector4 : IEquatable<Vector4>, IFormattable
     /// <returns>True if the other Vector4 is equal to this instance; False otherwise.</returns>
     public bool Equals(Vector4 other)
     {
-        return x == other.x
-               && y == other.y
-               && z == other.z
-               && w == other.w;
+        return Math.Abs(x - other.x) < Application.FloatEqualThreshold
+               && Math.Abs(y - other.y) < Application.FloatEqualThreshold
+               && Math.Abs(z - other.z) < Application.FloatEqualThreshold
+               && Math.Abs(w - other.w) < Application.FloatEqualThreshold;
     }
 
     /// <summary>

--- a/Prowl.Runtime/Math/Vector4.cs
+++ b/Prowl.Runtime/Math/Vector4.cs
@@ -158,10 +158,10 @@ public struct Vector4 : IEquatable<Vector4>, IFormattable
     /// <returns>True if the other Vector4 is equal to this instance; False otherwise.</returns>
     public bool Equals(Vector4 other)
     {
-        return Math.Abs(x - other.x) < Application.FloatEqualThreshold
-               && Math.Abs(y - other.y) < Application.FloatEqualThreshold
-               && Math.Abs(z - other.z) < Application.FloatEqualThreshold
-               && Math.Abs(w - other.w) < Application.FloatEqualThreshold;
+        return MathD.ApproximatelyEquals(x, other.x)
+               && MathD.ApproximatelyEquals(y, other.y)
+               && MathD.ApproximatelyEquals(z, other.z)
+               && MathD.ApproximatelyEquals(w, other.w);
     }
 
     /// <summary>

--- a/Prowl.Runtime/Physics.cs
+++ b/Prowl.Runtime/Physics.cs
@@ -36,7 +36,7 @@ public class PhysicsSetting : ScriptableSingleton<PhysicsSetting>
 
 public static class Physics
 {
-    public static bool IsReady => isInitialized && Application.isPlaying;
+    public static bool IsReady => isInitialized && Application.IsPlaying;
 
     public static Simulation? Sim { get; private set; }
     public static BufferPool? Pool { get; private set; }

--- a/Prowl.Runtime/SceneManager.cs
+++ b/Prowl.Runtime/SceneManager.cs
@@ -113,7 +113,7 @@ public static class SceneManager
             if (_gameObjects[i].enabledInHierarchy)
                 _gameObjects[i].PreUpdate();
 
-        if (Application.isPlaying)
+        if (Application.IsPlaying)
             Physics.Update();
 
         ForeachComponent((x) =>

--- a/Prowl.Runtime/Screen.cs
+++ b/Prowl.Runtime/Screen.cs
@@ -55,7 +55,7 @@ public static class Screen
     public static float FramesPerSecond
     {
         get => InternalWindow.PollIntervalInMs / 1000.0f;
-        set { InternalWindow.LimitPollRate = value != 0 && value != double.MaxValue; InternalWindow.PollIntervalInMs = value * 1000.0f; }
+        set { InternalWindow.LimitPollRate = value != 0 && Math.Abs(value - double.MaxValue) > Application.FloatEqualThreshold; InternalWindow.PollIntervalInMs = value * 1000.0f; }
     }
 
     public static bool IsVisible

--- a/Prowl.Runtime/Screen.cs
+++ b/Prowl.Runtime/Screen.cs
@@ -55,7 +55,7 @@ public static class Screen
     public static float FramesPerSecond
     {
         get => InternalWindow.PollIntervalInMs / 1000.0f;
-        set { InternalWindow.LimitPollRate = value != 0 && Math.Abs(value - double.MaxValue) > Application.FloatEqualThreshold; InternalWindow.PollIntervalInMs = value * 1000.0f; }
+        set { InternalWindow.LimitPollRate = value != 0 && MathD.ApproximatelyEquals(value , double.MaxValue); InternalWindow.PollIntervalInMs = value * 1000.0f; }
     }
 
     public static bool IsVisible

--- a/Prowl.Runtime/Utils/NodeSystem/Nodes/Operations/Double Nodes.cs
+++ b/Prowl.Runtime/Utils/NodeSystem/Nodes/Operations/Double Nodes.cs
@@ -1,6 +1,8 @@
 ﻿// This file is part of the Prowl Game Engine
 // Licensed under the MIT License. See the LICENSE file in the project root for details.
 
+using System;
+
 namespace Prowl.Runtime.NodeSystem;
 
 [Node("Operations/Double/Add")]
@@ -99,9 +101,9 @@ public class DoubleCompareNode : InFlowNode
         var a = GetInputValue("A", A);
         var b = GetInputValue("B", B);
 
-        if (a == b)
+        if (Math.Abs(a - b) < Application.FloatEqualThreshold)
             ExecuteNext("OnEquals");
-        else if (a != b)
+        else if (Math.Abs(a - b) > Application.FloatEqualThreshold)
             ExecuteNext("OnNotEquals");
         else if (a > b)
             ExecuteNext("OnGreaterThan");

--- a/Prowl.Runtime/Utils/NodeSystem/Nodes/Operations/Double Nodes.cs
+++ b/Prowl.Runtime/Utils/NodeSystem/Nodes/Operations/Double Nodes.cs
@@ -101,9 +101,9 @@ public class DoubleCompareNode : InFlowNode
         var a = GetInputValue("A", A);
         var b = GetInputValue("B", B);
 
-        if (Math.Abs(a - b) < Application.FloatEqualThreshold)
+        if (MathD.ApproximatelyEquals(a, b))
             ExecuteNext("OnEquals");
-        else if (Math.Abs(a - b) > Application.FloatEqualThreshold)
+        else if (MathD.ApproximatelyEquals(a , b))
             ExecuteNext("OnNotEquals");
         else if (a > b)
             ExecuteNext("OnGreaterThan");

--- a/Prowl.Runtime/Utils/ScriptableSingleton.cs
+++ b/Prowl.Runtime/Utils/ScriptableSingleton.cs
@@ -72,14 +72,14 @@ public abstract class ScriptableSingleton<T> where T : ScriptableSingleton<T>, n
                     ArgumentNullException.ThrowIfNull(dataPath);
 
                     // Persistent across sessions for a single project
-                    if (Application.isEditor == false)
+                    if (Application.IsEditor == false)
                         throw new InvalidOperationException("Editor Settings are only available in the editor");
                     directory = Path.Combine(dataPath, "ProjectSettings", "Editor");
                     break;
                 case FilePathAttribute.Location.EditorPreference:
                     // Persistent across all projects
                     // TODO: !Application.isRunning is just a hack to allow CLI operations that do not depend on the editor
-                    if (!Application.isRunning || Application.isEditor == false)
+                    if (!Application.IsRunning || Application.IsEditor == false)
                         throw new InvalidOperationException("Preferences are only available in the editor");
                     directory = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "Prowl", "Editor");
                     break;


### PR DESCRIPTION
`single` and `double` floats use an especial arithmetic that uses a trade-off of being super big/small, but not very precise.

Eventually, 100f - 10f might result in `90.000000001` instead of pure `90f`, so when comparing if 2 floats are the same, we need actually to check if they are close enough. Doing the pure comparison might result in weird behaviors.

- [ ] decide a max difference that will still be considered the same numbers (the code uses `0.0001f`)
- [ ] create a threshold number (Application.FloatEqualThreshold ?)
- [ ] convert all float number tests to use this constant (generally, get the absolute difference and check if is smaller)
