### PR TITLE
Auto focus on Viewport when leaving Play Mode.

### DIFF
--- a/Prowl.Editor/PlayMode.cs
+++ b/Prowl.Editor/PlayMode.cs
@@ -55,5 +55,10 @@ public static class PlayMode
 
         SceneManager.RestoreScene();
         SceneManager.ClearStoredScene();
+
+        // Focus SceneViewWindow
+        var sceneView = EditorGuiManager.Windows.FirstOrDefault(w => w is SceneViewWindow);
+        if (sceneView != null && GeneralPreferences.Instance.AutoFocusGameView)
+            EditorGuiManager.FocusWindow(sceneView);
     }
 }


### PR DESCRIPTION
Match the logic for auto focusing on `GameWindow` when entering Play Mode by auto focusing on the first found `SceneViewWindow` when exiting Play Mode.