### PR TITLE
[Feature] MSAA (Hardware Multisample Anti-Aliasing)

### DIFF
--- a/Prowl.Editor/GUI/SceneView/EditorCamera.cs
+++ b/Prowl.Editor/GUI/SceneView/EditorCamera.cs
@@ -267,6 +267,7 @@ public class EditorCamera
         _camera.Effects.Clear();
         _camera.Effects.AddRange(_clonedEffects);
         _camera.HDR = sceneCamera.HDR;
+        _camera.MSAA = sceneCamera.MSAA;
     }
 
     /// <summary>

--- a/Prowl.Runtime.Test/MSAATests.cs
+++ b/Prowl.Runtime.Test/MSAATests.cs
@@ -1,0 +1,194 @@
+// This file is part of the Prowl Game Engine
+// Licensed under the MIT License. See the LICENSE file in the project root for details.
+
+using System;
+using System.Linq;
+
+using Prowl.Runtime.Resources;
+
+using Xunit;
+
+namespace Prowl.Runtime.Test;
+
+/// <summary>
+/// Headless tests for MSAA render-target plumbing: the temporary-RT pool discriminates on sample
+/// count, multisampled targets construct without a device, and the constructors that
+/// <c>Deserialize</c> resolves reflectively still exist. GPU behaviour (multisample allocation,
+/// framebuffer completeness, the resolve blit) is not exercised here - the test process is
+/// headless, so that is verified by running the editor.
+/// </summary>
+public class MSAATests
+{
+    private static readonly TextureImageFormat[] Color = [TextureImageFormat.Color4b];
+
+    [Fact]
+    public void MaxSamples_DefaultsToGLMinimum_PreDevice()
+    {
+        // GL 4.1 guarantees MAX_SAMPLES >= 4, so the pre-device default must not be lower or
+        // clamping would silently disable MSAA levels the hardware actually supports.
+        Assert.True(Graphics.MaxSamples >= 4);
+    }
+
+    [Fact]
+    public void MSAASamples_ValuesAreLiteralSampleCounts()
+    {
+        // The pipeline casts the enum straight to a GL sample count.
+        Assert.Equal(1, (int)MSAASamples.None);
+        Assert.Equal(2, (int)MSAASamples.X2);
+        Assert.Equal(4, (int)MSAASamples.X4);
+        Assert.Equal(8, (int)MSAASamples.X8);
+    }
+
+    [Fact]
+    public void Camera_DefaultsToNoMSAA()
+    {
+        // MSAA must be opt-in: existing projects should render exactly as before.
+        Assert.Equal(MSAASamples.None, new Camera().MSAA);
+    }
+
+    [Fact]
+    public void RenderTexture_MultisampledConstructsHeadless()
+    {
+        var rt = new RenderTexture(64, 64, true, Color, 4);
+
+        Assert.Equal(4, rt.SampleCount);
+        Assert.True(rt.IsMultisampled);
+        // Every attachment, depth included, must carry the sample count or the framebuffer
+        // would come back FRAMEBUFFER_INCOMPLETE_MULTISAMPLE on a real device.
+        Assert.Equal(4, rt.MainTexture.Samples);
+        Assert.Equal(4, rt.InternalDepth.Samples);
+        Assert.True(rt.InternalDepth.IsMultisampled);
+    }
+
+    [Fact]
+    public void RenderTexture_SingleSampledIsNotMultisampled()
+    {
+        var rt = new RenderTexture(64, 64, true, Color);
+
+        Assert.Equal(1, rt.SampleCount);
+        Assert.False(rt.IsMultisampled);
+        Assert.False(rt.MainTexture.IsMultisampled);
+        Assert.Equal(TextureType.Texture2D, rt.MainTexture.Type);
+    }
+
+    [Fact]
+    public void RenderTexture_RejectsZeroSampleCount()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => new RenderTexture(64, 64, true, Color, 0));
+    }
+
+    [Fact]
+    public void Texture2D_MultisampleCtor_RejectsSingleSample()
+    {
+        // A sample count of 1 would produce a TEXTURE_2D_MULTISAMPLE with no sampler state
+        // rather than a normal sampleable texture, which is never what a caller wants.
+        Assert.Throws<ArgumentOutOfRangeException>(() => new Texture2D(64, 64, 1, TextureImageFormat.Color4b));
+    }
+
+    [Fact]
+    public void Pool_DoesNotAliasAcrossSampleCounts()
+    {
+        // The highest-value test here. ReleaseTemporaryRT rebuilds the pool key from the
+        // instance rather than remembering it, so if either the key struct or the rebuild drops
+        // SampleCount, a released single-sampled RT gets handed back to a request for a
+        // multisampled one and rendering breaks in a way no compiler catches.
+        RenderTexture single = RenderTexture.GetTemporaryRT(32, 32, true, Color);
+        RenderTexture.ReleaseTemporaryRT(single);
+
+        RenderTexture multi = RenderTexture.GetTemporaryRT(32, 32, true, Color, 4);
+
+        Assert.NotSame(single, multi);
+        Assert.Equal(4, multi.SampleCount);
+
+        RenderTexture.ReleaseTemporaryRT(multi);
+    }
+
+    [Fact]
+    public void Pool_ReusesTargetsOfMatchingSampleCount()
+    {
+        // The flip side: SampleCount must survive the key rebuild in ReleaseTemporaryRT, or a
+        // multisampled RT would be filed under the wrong key and never reused.
+        RenderTexture first = RenderTexture.GetTemporaryRT(32, 32, true, Color, 4);
+        RenderTexture.ReleaseTemporaryRT(first);
+
+        RenderTexture second = RenderTexture.GetTemporaryRT(32, 32, true, Color, 4);
+
+        Assert.Same(first, second);
+
+        RenderTexture.ReleaseTemporaryRT(second);
+    }
+
+    [Fact]
+    public void RenderTexture_DeserializeConstructor_IsResolvableByReflection()
+    {
+        // RenderTexture.Deserialize invokes this constructor reflectively by exact signature, so
+        // changing its parameter list breaks deserialization at runtime with no compile error.
+        Assert.NotNull(typeof(RenderTexture).GetConstructor(
+            [typeof(int), typeof(int), typeof(bool), typeof(TextureImageFormat[]), typeof(int)]));
+    }
+
+    [Fact]
+    public void RenderTexture_FourArgConstructor_StillExists()
+    {
+        // Retained for the many direct callers that predate MSAA.
+        Assert.NotNull(typeof(RenderTexture).GetConstructor(
+            [typeof(int), typeof(int), typeof(bool), typeof(TextureImageFormat[])]));
+    }
+
+    [Fact]
+    public void Texture2D_DeserializeConstructor_IsResolvableByReflection()
+    {
+        // Same reflective-invoke hazard as RenderTexture: the multisample overload must not have
+        // displaced the signature Texture2D.Deserialize looks up.
+        Assert.NotNull(typeof(Texture2D).GetConstructor(
+            [typeof(uint), typeof(uint), typeof(bool), typeof(TextureImageFormat)]));
+    }
+
+    [Fact]
+    public void Texture2DMultisample_IsNotMipmappable()
+    {
+        Assert.True(Enum.IsDefined(typeof(TextureType), TextureType.Texture2DMultisample));
+        Assert.False(Texture.IsTextureTypeMipmappable(TextureType.Texture2DMultisample));
+    }
+
+    [Fact]
+    public void BlitShader_HasBlendOffCopyPass()
+    {
+        // The pipeline copies into multisampled targets with pass 1, which must be the Blend Off
+        // pass. If pass order changed, copies would silently alpha-blend instead of replace.
+        Shader blit = Shader.LoadDefault(DefaultShader.Blit);
+
+        string[] passNames = blit.Passes.Select(p => p.Name).ToArray();
+        Assert.Equal(2, passNames.Length);
+        Assert.Equal("Copy", passNames[1]);
+        Assert.False(blit.GetPass(1).State.DoBlend);
+
+        // ZWrite Off matters: copying into a multisampled target must not disturb its depth.
+        Assert.False(blit.GetPass(1).State.DepthWrite);
+        Assert.False(blit.GetPass(1).State.DepthTest);
+    }
+
+    [Fact]
+    public void Blit_FromMultisampledSource_Throws()
+    {
+        // MainTexture is a Texture2D either way, so without this guard a multisampled attachment
+        // would bind to a sampler2D and render garbage rather than fail.
+        var ms = new RenderTexture(32, 32, true, Color, 4);
+        var dst = new RenderTexture(32, 32, true, Color);
+
+        using var cmd = Graphics.GetCommandBuffer("test");
+        Assert.Throws<InvalidOperationException>(() => cmd.Blit(ms, dst));
+    }
+
+    [Fact]
+    public void ResolveMultisample_RejectsMismatchedSizes()
+    {
+        // GL forbids scaling on any blit touching a multisampled framebuffer; catching it here
+        // beats an INVALID_OPERATION surfacing later on the render thread.
+        var src = new RenderTexture(64, 64, true, Color, 4);
+        var dst = new RenderTexture(32, 32, true, Color);
+
+        using var cmd = Graphics.GetCommandBuffer("test");
+        Assert.Throws<ArgumentException>(() => cmd.ResolveMultisample(src, dst));
+    }
+}

--- a/Prowl.Runtime/Assets/Defaults/Blit.shader
+++ b/Prowl.Runtime/Assets/Defaults/Blit.shader
@@ -46,3 +46,49 @@ Pass "Gizmos"
 
 	ENDGLSL
 }
+
+// Same as above but Blend Off, so the source replaces the destination instead of
+// alpha-blending against it. Used to copy into a multisampled target, where the
+// destination's existing samples must not survive and HDR scene color carries no
+// alpha=1 guarantee. ZWrite Off keeps the multisampled depth buffer intact.
+Pass "Copy"
+{
+    Tags { "RenderOrder" = "Opaque" }
+
+    Blend Off
+    Cull None
+    ZTest Off
+    ZWrite Off
+
+	GLSLPROGRAM
+
+	Vertex
+	{
+		layout (location = 0) in vec3 vertexPosition;
+		layout (location = 1) in vec2 vertexTexCoord;
+
+		out vec2 TexCoords;
+
+		void main()
+		{
+			TexCoords = vertexTexCoord;
+		    gl_Position = vec4(vertexPosition, 1.0);
+		}
+	}
+
+	Fragment
+	{
+		layout (location = 0) out vec4 finalColor;
+
+		in vec2 TexCoords;
+
+		uniform sampler2D _MainTex;
+
+		void main()
+		{
+			finalColor = texture(_MainTex, TexCoords).rgba;
+		}
+	}
+
+	ENDGLSL
+}

--- a/Prowl.Runtime/Components/Camera.cs
+++ b/Prowl.Runtime/Components/Camera.cs
@@ -85,6 +85,13 @@ public class Camera : MonoBehaviour
     public bool HDR = false;
     public float RenderScale = 1.0f;
 
+    /// <summary>Hardware multisample anti-aliasing for the geometry passes. Unlike the
+    /// post-process AA effects (FXAA/SMAA/TAA) this antialiases at rasterization time, so it
+    /// costs memory and bandwidth rather than a fullscreen pass, and it does nothing for
+    /// shading or texture aliasing. Clamped to <see cref="Graphics.MaxSamples"/> at render
+    /// time. <see cref="Target"/> stays single-sampled MSAA is internal to the pipeline.</summary>
+    public MSAASamples MSAA = MSAASamples.None;
+
     public bool IsOrthographic => ProjectionMode == ProjectionType.Orthographic;
 
     private float _aspect;

--- a/Prowl.Runtime/Graphics/Commands/CommandBuffer.cs
+++ b/Prowl.Runtime/Graphics/Commands/CommandBuffer.cs
@@ -173,6 +173,28 @@ public sealed class CommandBuffer : IDisposable
         Write((byte)filter);
     }
 
+    /// <summary>Resolve a multisampled <see cref="RenderTexture"/> down to a single-sampled
+    /// one so it can be sampled by a shader. GL forbids scaling on any blit involving a
+    /// multisampled framebuffer, so mismatched sizes are rejected here rather than left to
+    /// raise INVALID_OPERATION on the render thread. Depth is resolved too when both sides
+    /// carry it (GL picks a single sample, which is what depth-testing gizmos expect).</summary>
+    public void ResolveMultisample(RenderTexture source, RenderTexture destination)
+    {
+        if (source.Width != destination.Width || source.Height != destination.Height)
+            throw new ArgumentException(
+                $"Multisample resolve requires identical dimensions, got {source.Width}x{source.Height} -> {destination.Width}x{destination.Height}.");
+
+        SetRenderTargets(destination.frameBuffer, source.frameBuffer);
+        BlitFramebuffer(0, 0, source.Width, source.Height,
+                        0, 0, destination.Width, destination.Height,
+                        ClearFlags.Color, BlitFilter.Nearest);
+
+        if (source.InternalDepth != null && destination.InternalDepth != null)
+            BlitFramebuffer(0, 0, source.Width, source.Height,
+                            0, 0, destination.Width, destination.Height,
+                            ClearFlags.Depth, BlitFilter.Nearest);
+    }
+
     // ─────────────────────── Pipeline state ───────────────────────
 
     public void SetRasterState(in RasterizerState state)
@@ -568,7 +590,13 @@ public sealed class CommandBuffer : IDisposable
     {
         material ??= Rendering.RenderPipeline.GetBlitMaterial();
         if (source != null)
+        {
+            // MainTexture is typed Texture2D either way, so nothing else would stop a
+            // multisampled attachment being bound to a sampler2D and rendering garbage.
+            if (source.IsMultisampled)
+                throw new InvalidOperationException("Cannot Blit from a multisampled RenderTexture; resolve it first with ResolveMultisample.");
             material.SetTexture("_MainTex", source.MainTexture);
+        }
 
         if (destination != null && destination.IsValid())
         {
@@ -674,6 +702,17 @@ public sealed class CommandBuffer : IDisposable
         Write(border);
         var r = _store.Park(data);
         Write(in r);
+    }
+
+    /// <summary>Allocate multisampled storage for a 2D texture. No data blob is parked
+    /// multisampled textures cannot be uploaded to, only rendered into.</summary>
+    internal void EncodeAllocateTexture2DMultisample(GraphicsTexture tex, uint width, uint height, int samples)
+    {
+        WriteHeader(CommandOpcode.AllocateTexture2DMultisample);
+        Write(PushObject(tex));
+        Write(width);
+        Write(height);
+        Write(samples);
     }
 
     /// <summary>Allocate (and optionally upload) one face of a cubemap at a mip level.

--- a/Prowl.Runtime/Graphics/Commands/CommandExecutor.cs
+++ b/Prowl.Runtime/Graphics/Commands/CommandExecutor.cs
@@ -497,6 +497,15 @@ internal sealed class CommandExecutor
                     }
                     break;
                 }
+                case CommandOpcode.AllocateTexture2DMultisample:
+                {
+                    var tex = (GraphicsTexture)objects[ReadU16(stream, ref pos)]!;
+                    uint w = ReadU32(stream, ref pos);
+                    uint h = ReadU32(stream, ref pos);
+                    int samples = ReadI32(stream, ref pos);
+                    tex.TexImage2DMultisample(w, h, samples);
+                    break;
+                }
                 case CommandOpcode.AllocateTextureCubeFace:
                 {
                     var tex = (GraphicsTexture)objects[ReadU16(stream, ref pos)]!;

--- a/Prowl.Runtime/Graphics/Commands/CommandOpcode.cs
+++ b/Prowl.Runtime/Graphics/Commands/CommandOpcode.cs
@@ -86,6 +86,7 @@ internal enum CommandOpcode : ushort
     DisposeBuffer,
     CreateTexture,
     AllocateTexture2D,
+    AllocateTexture2DMultisample,
     AllocateTexture3D,
     AllocateTextureCubeFace,
     UpdateTexture3D,

--- a/Prowl.Runtime/Graphics/Graphics.cs
+++ b/Prowl.Runtime/Graphics/Graphics.cs
@@ -27,6 +27,10 @@ public static unsafe class Graphics
     public static int MaxArrayTextureLayers { get; internal set; } = 2048;
     public static int MaxFramebufferColorAttachments { get; internal set; } = 8;
 
+    /// <summary>Highest MSAA sample count usable for both color and depth render target
+    /// attachments. GL 4.1 guarantees at least 4.</summary>
+    public static int MaxSamples { get; internal set; } = 4;
+
     public static GL GL;
 
     /// <summary>
@@ -153,10 +157,20 @@ public static unsafe class Graphics
         // and prefiltered-environment sampling.
         GL.Enable(EnableCap.TextureCubeMapSeamless);
 
+        // Only has any effect while the bound draw framebuffer is multisampled, so this
+        // cannot alter single-sampled rendering. Enabled by default per spec; explicit here.
+        GL.Enable(EnableCap.Multisample);
+
         MaxTextureSize = GL.GetInteger(GLEnum.MaxTextureSize);
         MaxCubeMapTextureSize = GL.GetInteger(GLEnum.MaxCubeMapTextureSize);
         MaxArrayTextureLayers = GL.GetInteger(GLEnum.MaxArrayTextureLayers);
         MaxFramebufferColorAttachments = GL.GetInteger(GLEnum.MaxColorAttachments);
+
+        // A render target needs its color and depth attachments to agree on sample count,
+        // and float color formats can cap lower than MAX_SAMPLES, so take the floor of all three.
+        MaxSamples = Math.Min(GL.GetInteger(GLEnum.MaxSamples),
+                     Math.Min(GL.GetInteger(GLEnum.MaxColorTextureSamples),
+                              GL.GetInteger(GLEnum.MaxDepthTextureSamples)));
     }
 
     public static void StartRenderThread()
@@ -286,8 +300,8 @@ public static unsafe class Graphics
     public static GraphicsFrameBuffer CreateFramebuffer(GraphicsFrameBuffer.Attachment[] attachments, uint width, uint height)
         => new GraphicsFrameBuffer(attachments, width, height);
 
-    public static GraphicsTexture CreateTexture(TextureType type, TextureImageFormat format)
-        => new GraphicsTexture(type, format);
+    public static GraphicsTexture CreateTexture(TextureType type, TextureImageFormat format, int samples = 1)
+        => new GraphicsTexture(type, format, samples);
 
     public static GraphicsProgram CompileProgram(string fragment, string vertex, string geometry)
         => new GraphicsProgram(fragment, vertex, geometry);
@@ -347,6 +361,15 @@ public static unsafe class Graphics
         ReadOnlySpan<byte> span = data != null ? new ReadOnlySpan<byte>(data, size) : ReadOnlySpan<byte>.Empty;
         using var cmd = GetCommandBuffer("Texture.TexImage2D");
         cmd.EncodeAllocateTexture2D(texture, mip, width, height, border, span);
+        Submit(cmd);
+    }
+
+    /// <summary>Allocate multisampled storage for a render-target attachment. There is no
+    /// data parameter multisampled textures can only be rendered into.</summary>
+    public static void TexImage2DMultisample(GraphicsTexture texture, uint width, uint height, int samples)
+    {
+        using var cmd = GetCommandBuffer("Texture.TexImage2DMultisample");
+        cmd.EncodeAllocateTexture2DMultisample(texture, width, height, samples);
         Submit(cmd);
     }
 

--- a/Prowl.Runtime/Graphics/GraphicsFrameBuffer.cs
+++ b/Prowl.Runtime/Graphics/GraphicsFrameBuffer.cs
@@ -93,7 +93,8 @@ public unsafe class GraphicsFrameBuffer
                 }
                 else
                 {
-                    Graphics.GL.FramebufferTexture2D(FramebufferTarget.Framebuffer, FramebufferAttachment.DepthAttachment, TextureTarget.Texture2D, a.Texture!.Handle, a.MipLevel);
+                    // Use the texture's own target so multisampled depth attaches correctly.
+                    Graphics.GL.FramebufferTexture2D(FramebufferTarget.Framebuffer, FramebufferAttachment.DepthAttachment, a.Texture!.Target, a.Texture!.Handle, a.MipLevel);
                 }
             }
             Graphics.GL.DrawBuffers((uint)numTextures, buffers);

--- a/Prowl.Runtime/Graphics/GraphicsTexture.cs
+++ b/Prowl.Runtime/Graphics/GraphicsTexture.cs
@@ -25,7 +25,14 @@ public unsafe class GraphicsTexture : IDisposable
     /// <summary>The format of the pixel data.</summary>
     public readonly PixelFormat PixelFormat;
 
-    public GraphicsTexture(TextureType type, TextureImageFormat format)
+    /// <summary>GL sample count. 1 means a normal single-sampled texture.</summary>
+    public readonly int Samples;
+
+    /// <summary>Multisampled textures have no sampler state and cannot be read by a
+    /// <c>sampler2D</c> they exist only to be rendered into and resolved via a blit.</summary>
+    public bool IsMultisampled => Samples > 1;
+
+    public GraphicsTexture(TextureType type, TextureImageFormat format, int samples = 1)
     {
         Type = type;
         Target = type switch
@@ -33,8 +40,10 @@ public unsafe class GraphicsTexture : IDisposable
             TextureType.Texture2D => TextureTarget.Texture2D,
             TextureType.Texture3D => TextureTarget.Texture3D,
             TextureType.TextureCubeMap => TextureTarget.TextureCubeMap,
+            TextureType.Texture2DMultisample => TextureTarget.Texture2DMultisample,
             _ => throw new ArgumentOutOfRangeException(nameof(type), type, null),
         };
+        Samples = samples;
         GetTextureFormatEnums(format, out PixelInternalFormat, out PixelType, out PixelFormat);
         Handle = 0;
 
@@ -50,12 +59,14 @@ public unsafe class GraphicsTexture : IDisposable
 
     public void GenerateMipmap()
     {
+        if (IsMultisampled) return;
         Bind(false);
         Graphics.GL.GenerateMipmap(Target);
     }
 
     public void SetWrapS(TextureWrap wrap)
     {
+        if (IsMultisampled) return;
         Bind(false);
         GLEnum wrapMode = wrap switch
         {
@@ -70,6 +81,7 @@ public unsafe class GraphicsTexture : IDisposable
 
     public void SetWrapT(TextureWrap wrap)
     {
+        if (IsMultisampled) return;
         Bind(false);
         GLEnum wrapMode = wrap switch
         {
@@ -84,6 +96,7 @@ public unsafe class GraphicsTexture : IDisposable
 
     public void SetWrapR(TextureWrap wrap)
     {
+        if (IsMultisampled) return;
         Bind(false);
         GLEnum wrapMode = wrap switch
         {
@@ -98,6 +111,7 @@ public unsafe class GraphicsTexture : IDisposable
 
     public void SetTextureFilters(TextureMin min, TextureMag mag)
     {
+        if (IsMultisampled) return;
         Bind(false);
         GLEnum minFilter = min switch
         {
@@ -126,6 +140,7 @@ public unsafe class GraphicsTexture : IDisposable
     /// </summary>
     public void SetCompareMode(bool enabled)
     {
+        if (IsMultisampled) return;
         Bind(false);
         if (enabled)
         {
@@ -174,6 +189,16 @@ public unsafe class GraphicsTexture : IDisposable
     {
         Bind(false);
         Graphics.GL.TexImage2D(type, mip, PixelInternalFormat, width, height, v2, PixelFormat, PixelType, data);
+    }
+
+    /// <summary>Allocate multisampled storage. There is no data pointer multisampled
+    /// textures cannot be uploaded to, only rendered into. <c>fixedsamplelocations</c> is
+    /// true because every attachment of one framebuffer must agree on it.</summary>
+    public void TexImage2DMultisample(uint width, uint height, int samples)
+    {
+        Bind(false);
+        Graphics.GL.TexImage2DMultisample(TextureTarget.Texture2DMultisample, (uint)samples,
+            PixelInternalFormat, width, height, true);
     }
 
     public void TexImage3D(TextureTarget type, int level, uint width, uint height, uint depth, void* data)

--- a/Prowl.Runtime/Graphics/Primitives.cs
+++ b/Prowl.Runtime/Graphics/Primitives.cs
@@ -5,7 +5,11 @@ using System;
 namespace Prowl.Runtime;
 
 public enum TextureWrap { Repeat, ClampToBorder, ClampToEdge, MirroredRepeat }
-public enum TextureType { Texture2D, Texture3D, TextureCubeMap, }
+public enum TextureType { Texture2D, Texture3D, TextureCubeMap, Texture2DMultisample, }
+
+/// <summary>Multisample anti-aliasing rate for a <see cref="Camera"/>. Values are the
+/// literal GL sample count, so casting to int gives the number to allocate with.</summary>
+public enum MSAASamples { None = 1, X2 = 2, X4 = 4, X8 = 8 }
 public enum TextureParameter { WrapS, WrapT, WrapR, MinFilter, MagFilter }
 public enum TextureMin { Nearest, Linear, NearestMipmapNearest, LinearMipmapNearest, NearestMipmapLinear, LinearMipmapLinear }
 public enum TextureMag { Nearest, Linear }

--- a/Prowl.Runtime/Rendering/DefaultRenderPipeline.cs
+++ b/Prowl.Runtime/Rendering/DefaultRenderPipeline.cs
@@ -255,15 +255,26 @@ public class DefaultRenderPipeline : RenderPipeline
         UploadFogUniforms(css.Scene);
         UploadAmbientUniforms(css.Scene);
 
+        // MSAA applies to the geometry passes only. The target is resolved back down to a
+        // normal single-sampled RT before any image effect can sample it, so everything from
+        // PostProcess onward is identical to the non-MSAA path.
+        int samples = Math.Min((int)camera.MSAA, Graphics.MaxSamples);
+        bool msaa = samples > 1;
+
+        TextureImageFormat colorFormat = isHDR ? TextureImageFormat.Short4 : TextureImageFormat.Color4b;
+
         // Main color render target
         RenderTexture colorRT = RenderTexture.GetTemporaryRT((int)css.PixelWidth, (int)css.PixelHeight, true, [
-            isHDR ? TextureImageFormat.Short4 : TextureImageFormat.Color4b,
-        ]);
+            colorFormat,
+        ], samples);
 
         // Unified prepass RT. One MRT pass writes everything depth-based effects need:
         //   depth attachment      = scene depth
         //   color 0 (Color4b)     = view-space normals
         //   color 1 (Short4)      = motion vectors (.rg) + roughness (.b) + metallic (.a)
+        // Stays single-sampled even under MSAA: these are sampled as plain sampler2D by
+        // GTAO/SSR/TAA, and resolving three attachments per frame would cost more than the
+        // per-sample depth is worth to effects that are screen-space approximations anyway.
         RenderTexture prepass = RenderTexture.GetTemporaryRT((int)css.PixelWidth, (int)css.PixelHeight, true, [
             TextureImageFormat.Color4b,
             TextureImageFormat.Short4,
@@ -290,14 +301,28 @@ public class DefaultRenderPipeline : RenderPipeline
         mainCmd.SetGlobalTexture("_CameraMotionVectorsTexture", prepass.InternalTextures[1]);
 
         // Copy depth from prepass into colorRT so the opaque pass can ZTest LEqual against it.
-        mainCmd.SetRenderTargets(colorRT.frameBuffer, prepass.frameBuffer);
-        mainCmd.BlitFramebuffer(0, 0, prepass.Width, prepass.Height,
-                                 0, 0, colorRT.Width, colorRT.Height,
-                                 ClearFlags.Depth, BlitFilter.Nearest);
+        // Skipped under MSAA: the prepass is single-sampled, and replicating its per-pixel depth
+        // to every sample would defeat the coverage MSAA exists to capture. Opaques regenerate
+        // correct per-sample depth on their own (RasterizerState defaults to ZWrite On / LEqual),
+        // so this blit is only an early-Z optimization. The skybox does not need it either it
+        // is ZTest Off / ZWrite Off and is simply overdrawn by the opaques.
+        if (!msaa)
+        {
+            mainCmd.SetRenderTargets(colorRT.frameBuffer, prepass.frameBuffer);
+            mainCmd.BlitFramebuffer(0, 0, prepass.Width, prepass.Height,
+                                     0, 0, colorRT.Width, colorRT.Height,
+                                     ClearFlags.Depth, BlitFilter.Nearest);
+        }
 
         // Switch back to colorRT for the opaque draws.
         mainCmd.SetRenderTarget(colorRT.frameBuffer);
         mainCmd.SetViewport(0, 0, (uint)colorRT.Width, (uint)colorRT.Height);
+
+        // With the depth blit skipped, nothing else initializes depth. This has to sit outside
+        // the switch below: the Depth and Nothing branches never clear at all, and colorRT is
+        // pooled, so they would otherwise inherit stale depth from last frame's tenant.
+        if (msaa)
+            mainCmd.ClearRenderTarget(ClearFlags.Depth, default);
 
         // Camera clear flags
         switch (camera.ClearFlags)
@@ -314,22 +339,25 @@ public class DefaultRenderPipeline : RenderPipeline
                 mainCmd.ClearRenderTarget(ClearFlags.Color, camera.ClearColor);
                 break;
             case CameraClearFlags.Depth:
-                if (target.IsValid())
-                {
-                    mainCmd.SetRenderTargets(colorRT.frameBuffer, target.frameBuffer);
-                    mainCmd.BlitFramebuffer(0, 0, target.Width, target.Height,
-                                            0, 0, colorRT.Width, colorRT.Height,
-                                            ClearFlags.Color, BlitFilter.Nearest);
-                    mainCmd.SetRenderTarget(colorRT.frameBuffer);
-                }
-                break;
             case CameraClearFlags.Nothing:
                 if (target.IsValid())
                 {
-                    mainCmd.SetRenderTargets(colorRT.frameBuffer, target.frameBuffer);
-                    mainCmd.BlitFramebuffer(0, 0, target.Width, target.Height,
-                                            0, 0, colorRT.Width, colorRT.Height,
-                                            ClearFlags.Color, BlitFilter.Nearest);
+                    if (msaa)
+                    {
+                        // A framebuffer blit involving a multisampled target cannot scale, and
+                        // RenderScale routinely makes target and colorRT different sizes. Copy
+                        // with a fullscreen quad instead pass 1 of the blit shader is Blend Off,
+                        // so target's color replaces rather than blends, and it is ZWrite Off so
+                        // the depth cleared above survives.
+                        mainCmd.Blit(target, colorRT, GetBlitMaterial(), 1);
+                    }
+                    else
+                    {
+                        mainCmd.SetRenderTargets(colorRT.frameBuffer, target.frameBuffer);
+                        mainCmd.BlitFramebuffer(0, 0, target.Width, target.Height,
+                                                0, 0, colorRT.Width, colorRT.Height,
+                                                ClearFlags.Color, BlitFilter.Nearest);
+                    }
                     mainCmd.SetRenderTarget(colorRT.frameBuffer);
                 }
                 break;
@@ -349,17 +377,43 @@ public class DefaultRenderPipeline : RenderPipeline
         RenderStats.BeginPostFx();
         if (effectsByStage[RenderStage.AfterOpaques].Count > 0)
         {
+            // These effects read and write SceneColor through a sampler2D, which a multisampled
+            // buffer cannot be. Resolve a copy for them to work on, then put the result back into
+            // the multisampled target so the transparents below still rasterize with real coverage
+            // against the live multisampled depth buffer. Replicating the resolved average across
+            // every sample does not lose the opaque edge AA already baked into it resolving
+            // uniform samples again is a no-op.
+            RenderTexture effectRT = colorRT;
+            if (msaa)
+            {
+                effectRT = RenderTexture.GetTemporaryRT((int)css.PixelWidth, (int)css.PixelHeight, true, [colorFormat]);
+                using var resolveCmd = Graphics.GetCommandBuffer("MSAAResolveAfterOpaques");
+                resolveCmd.ResolveMultisample(colorRT, effectRT);
+                Graphics.Submit(resolveCmd);
+            }
+
             var afterContext = new RenderContext
             {
                 DepthNormals = prepass,
                 MotionVectors = prepass.InternalTextures[1],
-                SceneColor = colorRT,
+                SceneColor = effectRT,
                 Camera = camera,
                 Width = (int)css.PixelWidth,
                 Height = (int)css.PixelHeight,
                 CurrentStage = RenderStage.AfterOpaques
             };
             ExecuteImageEffects(afterContext, effectsByStage[RenderStage.AfterOpaques]);
+
+            if (msaa)
+            {
+                using (var restoreCmd = Graphics.GetCommandBuffer("MSAARestoreAfterOpaques"))
+                {
+                    // Pass 1 is Blend Off / ZWrite Off: replaces color, leaves MS depth alone.
+                    restoreCmd.Blit(effectRT, colorRT, GetBlitMaterial(), 1);
+                    Graphics.Submit(restoreCmd);
+                }
+                RenderTexture.ReleaseTemporaryRT(effectRT);
+            }
         }
         RenderStats.EndPostFx();
 
@@ -375,6 +429,23 @@ public class DefaultRenderPipeline : RenderPipeline
         RenderUIQueue(css, colorRT, UISurface.World, data);
 
         RenderStats.EndColorPass();
+
+        // ─── MSAA resolve ───
+        // Placed after the last geometry (transparents + world-space UI) so all of it is
+        // antialiased, and before anything samples the scene color. Everything downstream
+        // post-process effects, gizmos, the final blit then sees an ordinary single-sampled
+        // target and behaves exactly as it does with MSAA off.
+        if (msaa)
+        {
+            RenderTexture resolved = RenderTexture.GetTemporaryRT((int)css.PixelWidth, (int)css.PixelHeight, true, [colorFormat]);
+            using (var resolveCmd = Graphics.GetCommandBuffer("MSAAResolve"))
+            {
+                resolveCmd.ResolveMultisample(colorRT, resolved);
+                Graphics.Submit(resolveCmd);
+            }
+            RenderTexture.ReleaseTemporaryRT(colorRT);
+            colorRT = resolved;
+        }
 
         // ─── PostProcess image effects ───
         RenderStats.BeginPostFx();

--- a/Prowl.Runtime/Rendering/RenderPipeline.cs
+++ b/Prowl.Runtime/Rendering/RenderPipeline.cs
@@ -635,7 +635,9 @@ public abstract class RenderPipeline : EngineObject
                 int fbWidth = currentRT.Width;
                 int fbHeight = currentRT.Height;
                 bool wantDepth = pass.HasGrabDepth;
-                grabRT = RenderTexture.GetTemporaryRT(fbWidth, fbHeight, wantDepth, [TextureImageFormat.Color4b]);
+                // Match the source format instead of assuming Color4b, otherwise an HDR
+                // scene color (Short4) is truncated to 8bpc on the way into the grab.
+                grabRT = RenderTexture.GetTemporaryRT(fbWidth, fbHeight, wantDepth, [currentRT.MainTexture.ImageFormat]);
 
                 cmd.SetRenderTargets(grabRT.frameBuffer, currentRT.frameBuffer);
                 cmd.BlitFramebuffer(0, 0, fbWidth, fbHeight, 0, 0, fbWidth, fbHeight, ClearFlags.Color, BlitFilter.Nearest);

--- a/Prowl.Runtime/Resources/RenderTexture.cs
+++ b/Prowl.Runtime/Resources/RenderTexture.cs
@@ -18,6 +18,14 @@ public sealed class RenderTexture : EngineObject, ISerializable
 
     public int Width { get; private set; }
     public int Height { get; private set; }
+
+    /// <summary>GL sample count. 1 means a normal single-sampled target.</summary>
+    public int SampleCount { get; private set; }
+
+    /// <summary>When true this target's attachments are multisampled, so they cannot be
+    /// sampled by a shader. Resolve it first with <see cref="CommandBuffer.ResolveMultisample"/>.</summary>
+    public bool IsMultisampled => SampleCount > 1;
+
     private int numTextures;
     private bool hasDepthAttachment;
     private TextureImageFormat[] textureFormats;
@@ -26,36 +34,59 @@ public sealed class RenderTexture : EngineObject, ISerializable
     {
         Width = 0;
         Height = 0;
+        SampleCount = 1;
         numTextures = 0;
         hasDepthAttachment = false;
         textureFormats = [];
     }
 
-    public RenderTexture(int Width, int Height, bool hasDepthAttachment, TextureImageFormat[] formats) : base("RenderTexture")
+    /// <summary>Kept as a distinct 4-argument overload rather than an optional parameter:
+    /// <see cref="Deserialize"/> resolves this constructor reflectively by exact signature.</summary>
+    public RenderTexture(int Width, int Height, bool hasDepthAttachment, TextureImageFormat[] formats)
+        : this(Width, Height, hasDepthAttachment, formats, 1) { }
+
+    public RenderTexture(int Width, int Height, bool hasDepthAttachment, TextureImageFormat[] formats, int sampleCount) : base("RenderTexture")
     {
         this.Width = Width;
         this.Height = Height;
+        SampleCount = sampleCount;
         numTextures = formats?.Length ?? throw new ArgumentNullException(nameof(formats), "Texture formats cannot be null.");
         this.hasDepthAttachment = hasDepthAttachment;
 
         if (numTextures < 0 || numTextures > Graphics.MaxFramebufferColorAttachments)
             throw new Exception("Invalid number of textures! [0-" + Graphics.MaxFramebufferColorAttachments + "]");
 
+        if (sampleCount < 1)
+            throw new ArgumentOutOfRangeException(nameof(sampleCount), sampleCount, "Sample count must be at least 1.");
+
         textureFormats = formats;
+        bool multisampled = sampleCount > 1;
 
         GraphicsFrameBuffer.Attachment[] attachments = new GraphicsFrameBuffer.Attachment[numTextures + (hasDepthAttachment ? 1 : 0)];
         InternalTextures = new Texture2D[numTextures];
         for (int i = 0; i < numTextures; i++)
         {
-            InternalTextures[i] = new Texture2D((uint)Width, (uint)Height, false, textureFormats[i]);
-            InternalTextures[i].SetTextureFilters(TextureMin.Linear, TextureMag.Linear);
-            InternalTextures[i].SetWrapModes(TextureWrap.ClampToEdge, TextureWrap.ClampToEdge);
+            InternalTextures[i] = multisampled
+                ? new Texture2D((uint)Width, (uint)Height, sampleCount, textureFormats[i])
+                : new Texture2D((uint)Width, (uint)Height, false, textureFormats[i]);
+
+            // Multisampled attachments reject all sampler state (INVALID_ENUM).
+            if (!multisampled)
+            {
+                InternalTextures[i].SetTextureFilters(TextureMin.Linear, TextureMag.Linear);
+                InternalTextures[i].SetWrapModes(TextureWrap.ClampToEdge, TextureWrap.ClampToEdge);
+            }
+
             attachments[i] = new GraphicsFrameBuffer.Attachment { Texture = InternalTextures[i].Handle, IsDepth = false };
         }
 
         if (hasDepthAttachment)
         {
-            InternalDepth = new Texture2D((uint)Width, (uint)Height, false, TextureImageFormat.Depth24f);
+            // The depth attachment has to match the color attachments' sample count or the
+            // framebuffer comes back FRAMEBUFFER_INCOMPLETE_MULTISAMPLE.
+            InternalDepth = multisampled
+                ? new Texture2D((uint)Width, (uint)Height, sampleCount, TextureImageFormat.Depth24f)
+                : new Texture2D((uint)Width, (uint)Height, false, TextureImageFormat.Depth24f);
             attachments[numTextures] = new GraphicsFrameBuffer.Attachment { Texture = InternalDepth.Handle, IsDepth = true };
         }
 
@@ -79,6 +110,7 @@ public sealed class RenderTexture : EngineObject, ISerializable
     {
         compoundTag.Add("Width", new(Width));
         compoundTag.Add("Height", new(Height));
+        compoundTag.Add("SampleCount", new(SampleCount));
         compoundTag.Add("NumTextures", new(numTextures));
         compoundTag.Add("HasDepthAttachment", new((byte)(hasDepthAttachment ? 1 : 0)));
         EchoObject textureFormatsTag = EchoObject.NewList();
@@ -91,6 +123,8 @@ public sealed class RenderTexture : EngineObject, ISerializable
     {
         Width = value["Width"].IntValue;
         Height = value["Height"].IntValue;
+        // Assets written before MSAA existed have no SampleCount tag.
+        SampleCount = value.Get("SampleCount")?.IntValue ?? 1;
         numTextures = value["NumTextures"].IntValue;
         hasDepthAttachment = value["HasDepthAttachment"].ByteValue == 1;
         textureFormats = new TextureImageFormat[numTextures];
@@ -99,25 +133,27 @@ public sealed class RenderTexture : EngineObject, ISerializable
             textureFormats[i] = (TextureImageFormat)textureFormatsTag[i].ByteValue;
 
 
-        Type[] param = new[] { typeof(int), typeof(int), typeof(bool), typeof(TextureImageFormat[]) };
-        object[] values = new object[] { Width, Height, hasDepthAttachment, textureFormats };
+        Type[] param = new[] { typeof(int), typeof(int), typeof(bool), typeof(TextureImageFormat[]), typeof(int) };
+        object[] values = new object[] { Width, Height, hasDepthAttachment, textureFormats, SampleCount };
         typeof(RenderTexture).GetConstructor(param).Invoke(this, values);
     }
 
     #region Pool
 
-    private struct RenderTextureKey(int width, int height, bool hasDepth, TextureImageFormat[] format)
+    private struct RenderTextureKey(int width, int height, bool hasDepth, TextureImageFormat[] format, int sampleCount)
     {
         public int Width = width;
         public int Height = height;
         public bool HasDepth = hasDepth;
         public TextureImageFormat[] Format = format;
+        public int SampleCount = sampleCount;
 
         public override bool Equals(object? obj)
         {
             if (obj is RenderTextureKey key)
             {
-                if (Width == key.Width && Height == key.Height && HasDepth == key.HasDepth && Format.Length == key.Format.Length)
+                if (Width == key.Width && Height == key.Height && HasDepth == key.HasDepth
+                    && SampleCount == key.SampleCount && Format.Length == key.Format.Length)
                 {
                     for (int i = 0; i < Format.Length; i++)
                         if (Format[i] != key.Format[i])
@@ -133,6 +169,7 @@ public sealed class RenderTexture : EngineObject, ISerializable
             hash = hash * 23 + Width.GetHashCode();
             hash = hash * 23 + Height.GetHashCode();
             hash = hash * 23 + HasDepth.GetHashCode();
+            hash = hash * 23 + SampleCount.GetHashCode();
             foreach (TextureImageFormat format in Format)
                 hash = hash * 23 + ((int)format).GetHashCode();
             return hash;
@@ -146,9 +183,9 @@ public sealed class RenderTexture : EngineObject, ISerializable
     private const int MaxUnusedFrames = 10;
     private const int MaxActiveFrames = 3; // Warn if held longer than 3 frames
 
-    public static RenderTexture GetTemporaryRT(int width, int height, bool hasDepth, TextureImageFormat[] format)
+    public static RenderTexture GetTemporaryRT(int width, int height, bool hasDepth, TextureImageFormat[] format, int sampleCount = 1)
     {
-        var key = new RenderTextureKey(width, height, hasDepth, format);
+        var key = new RenderTextureKey(width, height, hasDepth, format, sampleCount);
 
         RenderTexture renderTexture;
         if (pool.TryGetValue(key, out List<(RenderTexture, long frameCreated)>? list) && list.Count > 0)
@@ -159,7 +196,7 @@ public sealed class RenderTexture : EngineObject, ISerializable
         }
         else
         {
-            renderTexture = new RenderTexture(width, height, hasDepth, format);
+            renderTexture = new RenderTexture(width, height, hasDepth, format, sampleCount);
         }
 
         // Track in active pool
@@ -175,7 +212,7 @@ public sealed class RenderTexture : EngineObject, ISerializable
 
     public static void ReleaseTemporaryRT(RenderTexture renderTexture)
     {
-        var key = new RenderTextureKey(renderTexture.Width, renderTexture.Height, renderTexture.hasDepthAttachment, [.. renderTexture.InternalTextures.Select(t => t.ImageFormat)]);
+        var key = new RenderTextureKey(renderTexture.Width, renderTexture.Height, renderTexture.hasDepthAttachment, [.. renderTexture.InternalTextures.Select(t => t.ImageFormat)], renderTexture.SampleCount);
 
         // Remove from active pool
         if (active.TryGetValue(key, out List<(RenderTexture, long frameAcquired)>? activeList))

--- a/Prowl.Runtime/Resources/Texture.cs
+++ b/Prowl.Runtime/Resources/Texture.cs
@@ -36,12 +36,19 @@ public abstract class Texture : EngineObject
     /// <summary>Gets whether this <see cref="Texture"/> can be mipmapped (depends on texture type).</summary>
     public bool IsMipmappable => !isNotMipmappable;
 
+    /// <summary>GL sample count. 1 means a normal single-sampled texture.</summary>
+    public readonly int Samples;
+
+    /// <summary>Multisampled textures have no sampler state and cannot be read by a
+    /// <c>sampler2D</c>. They are render-target attachments only, resolved via a blit.</summary>
+    public bool IsMultisampled => Samples > 1;
+
     /// <summary>
     /// Creates a <see cref="Texture"/> with specified <see cref="TextureType"/> and <see cref="TextureImageFormat"/>.
     /// </summary>
     /// <param name="type">The type of texture (or texture target) the texture will be.</param>
     /// <param name="imageFormat">The type of image format this texture will store.</param>
-    internal Texture(TextureType type, TextureImageFormat imageFormat) : base("New Texture")
+    internal Texture(TextureType type, TextureImageFormat imageFormat, int samples = 1) : base("New Texture")
     {
         if (!Enum.IsDefined(typeof(TextureType), type))
             throw new FormatException("Invalid texture target");
@@ -52,8 +59,15 @@ public abstract class Texture : EngineObject
         Type = type;
         ImageFormat = imageFormat;
         IsMipmapped = false;
+        Samples = samples;
         isNotMipmappable = !IsTextureTypeMipmappable(type);
-        Handle = Graphics.CreateTexture(type, imageFormat);
+        Handle = Graphics.CreateTexture(type, imageFormat, samples);
+
+        // glTexParameteri raises INVALID_ENUM for any sampler state on a multisample
+        // target, so multisampled textures skip the default wrap/filter setup entirely.
+        if (IsMultisampled)
+            return;
+
         Graphics.SetWrapS(Handle, TextureWrap.Repeat);
         Graphics.SetWrapT(Handle, TextureWrap.Repeat);
         Graphics.SetTextureFilters(Handle, DefaultMinFilter, DefaultMagFilter);

--- a/Prowl.Runtime/Resources/Texture2D.cs
+++ b/Prowl.Runtime/Resources/Texture2D.cs
@@ -12,7 +12,8 @@ namespace Prowl.Runtime.Resources;
 
 
 /// <summary>
-/// A <see cref="Texture"/> whose image has two dimensions and support for multisampling.
+/// A <see cref="Texture"/> whose image has two dimensions. Single-sampled by default;
+/// the <c>samples</c> constructor makes a multisampled render-target attachment instead.
 /// </summary>
 public sealed class Texture2D : Texture, ISerializable
 {
@@ -42,6 +43,27 @@ public sealed class Texture2D : Texture, ISerializable
         Graphics.SetTextureFilters(Handle, IsMipmapped ? DefaultMipmapMinFilter : DefaultMinFilter, DefaultMagFilter);
         MinFilter = IsMipmapped ? DefaultMipmapMinFilter : DefaultMinFilter;
         MagFilter = DefaultMagFilter;
+    }
+
+    /// <summary>
+    /// Creates a multisampled <see cref="Texture2D"/> for use as a render target attachment.
+    /// It cannot be sampled, uploaded to, mipmapped, or given sampler state it exists only
+    /// to be rendered into and resolved with <see cref="Prowl.Runtime.CommandBuffer.ResolveMultisample"/>.
+    /// </summary>
+    /// <param name="width">The width of the <see cref="Texture2D"/>.</param>
+    /// <param name="height">The height of the <see cref="Texture2D"/>.</param>
+    /// <param name="samples">GL sample count. Must be greater than 1.</param>
+    /// <param name="imageFormat">The image format for this <see cref="Texture2D"/>.</param>
+    public Texture2D(uint width, uint height, int samples, TextureImageFormat imageFormat)
+        : base(TextureType.Texture2DMultisample, imageFormat, samples)
+    {
+        if (samples <= 1)
+            throw new ArgumentOutOfRangeException(nameof(samples), samples, "Use the single-sampled constructor for a sample count of 1.");
+
+        ValidateTextureSize(width, height);
+        Width = width;
+        Height = height;
+        Graphics.TexImage2DMultisample(Handle, width, height, samples);
     }
 
     /// <summary>

--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ Prowl is currently in **1.0-preview**, following a complete rewrite of the Edito
         - Cascaded Shadow Maps for Directional Lights (up to 4 cascades)
         - Cubemap Shadows for Point Lights
         - Shadow Atlas with Dynamic Packing
+    - MSAA (2x/4x/8x hardware multisampling, per-camera)
     - Post Processing
         - HDR Tonemapping (ACES / Reinhard / Uncharted / Filmic / Melon / AgX)
         - Bloom (dual-filter downsample/upsample)


### PR DESCRIPTION
This PR adds **MSAA** as a per-camera rendering option, alongside the existing post-process AA effects (FXAA/SMAA/TAA). It gives Prowl its first anti-aliaser that works at rasterization time rather than reconstructing edges from an already-aliased image.

## MSAA

FXAA, SMAA, and TAA all run at the end of the frame on a finished image: the geometry has already been rasterized with one sample per pixel, so the edge information is gone and has to be inferred. MSAA instead rasterizes coverage and depth at multiple samples per pixel and resolves them, so geometric edges are correct rather than reconstructed — no blurring of fine detail (FXAA), no ghosting or history buffers (TAA). The trade is memory and bandwidth instead of a fullscreen pass, and it only helps geometric aliasing, not shading or texture aliasing, so it composes with the post-process effects rather than replacing them.

Because it lives in the render targets, MSAA cannot be an `ImageEffect` — it has to be part of the pipeline itself.

## How it was implemented

`Camera.MSAA` (`None`/`X2`/`X4`/`X8`, default `None`, clamped to `Graphics.MaxSamples`) makes the forward geometry passes rasterize into a multisampled color+depth target, which is resolved back to an ordinary single-sampled texture before anything samples it. Everything from `PostProcess` onward — effects, gizmos, the final blit — is untouched and behaves exactly as it does with MSAA off. `Camera.Target` stays single-sampled; MSAA is internal to the pipeline.

The resolve goes through `glBlitFramebuffer` and multisampled content is never sampled in a shader, so **no GLSL changes and no `sampler2DMS`** are needed. Being a public field, `MSAA` surfaces in the inspector through the reflective property grid with no editor code.

### Notes on the less obvious parts

- **The prepass stays single-sampled.** It feeds `_CameraDepthTexture`/Normals/Motion, which GTAO/SSR/TAA read as plain `sampler2D`.
- **The prepass → colorRT depth blit is skipped under MSAA.** It only ever provided opaque early-Z: the skybox is `ZTest Off`/`ZWrite Off` and is overdrawn regardless, and opaques regenerate correct per-sample depth themselves. Its replacement depth clear is emitted outside the `ClearFlags` switch, because the `Depth` and `Nothing` branches never clear and `colorRT` is pooled — they would otherwise inherit stale depth.
- **The `Depth`/`Nothing` branches copy the target with a fullscreen quad** rather than a framebuffer blit: `RenderScale` makes target and `colorRT` different sizes, and a scaling blit into a multisampled framebuffer is `INVALID_OPERATION`.
- **`Blit.shader` gains a `Blend Off` "Copy" pass.** The existing pass is `Blend Alpha`, which would blend rather than replace when copying into a multisampled target, and HDR scene color carries no `alpha = 1` guarantee.
- **GTAO/SSR read and write SceneColor**, so under MSAA the target is resolved for them and copied back, leaving the multisampled depth buffer live so transparents still rasterize with real coverage. Only paid when those effects are present.
- **Multisampled textures reject all sampler state** (`INVALID_ENUM`), so the `Texture` base constructor skips its default wrap/filter setup for them.
- **`RenderTexture`'s pool key carries `SampleCount`** in both the key struct and the rebuild in `ReleaseTemporaryRT`; missing either would silently alias multisampled and single-sampled targets.

### Included fix: grab-pass RT format

Also included is a small independent fix that MSAA would have turned into a hard error. The grab-pass temporary RT was always allocated as `Color4b` even when the scene color it copies from is HDR (`Short4`). `glBlitFramebuffer` permits format conversion from a single-sampled read framebuffer, so this silently truncated HDR grab/refraction passes to 8 bits per channel instead of erroring. The grab RT now takes the source RT's own format.

## Usage

```csharp
camera.MSAA = MSAASamples.X4;
```

## Testing

Added `MSAATests` — headless tests covering the enum's literal sample counts, the camera default, multisampled `RenderTexture`/`Texture2D` construction and its invalid-argument cases, pool behavior (no aliasing across sample counts, reuse within one), the `Blend Off` copy pass in `Blit.shader`, and the guards on blitting from a multisampled source and resolving mismatched sizes.

Verified on-device across a matrix of 16 configurations (sample counts, HDR, all four `ClearFlags`, `RenderScale` 0.5/2.0, GTAO/SSR, post-process stacks, and MSAA toggling for pool reuse) under a GL debug context: no GL errors. The check was falsified by temporarily removing the multisample sampler-state guard, which correctly reported `GL_INVALID_ENUM` on `GL_TEXTURE_2D_MULTISAMPLE`.