### PR TITLE
Fix custom asset editors for user-assembly EngineObject types (allow for custom editors)

### DIFF
--- a/Prowl.Editor/AssetsDatabase/AssetEntry.cs
+++ b/Prowl.Editor/AssetsDatabase/AssetEntry.cs
@@ -3,6 +3,7 @@ using System.Security.Cryptography;
 using System.Text;
 
 using Prowl.Echo;
+using Prowl.Runtime;
 
 namespace Prowl.Editor;
 
@@ -19,7 +20,7 @@ public class SubAssetEntry
 
     public Type? Type
     {
-        get => !string.IsNullOrEmpty(TypeName) ? System.Type.GetType(TypeName) : null;
+        get => !string.IsNullOrEmpty(TypeName) ? RuntimeUtils.ResolveType(TypeName) : null;
         set => TypeName = value?.AssemblyQualifiedName ?? "";
     }
 }
@@ -45,7 +46,7 @@ public class AssetEntry
 
     public Type? MainAssetType
     {
-        get => MainAssetTypeName != null ? Type.GetType(MainAssetTypeName) : null;
+        get => MainAssetTypeName != null ? RuntimeUtils.ResolveType(MainAssetTypeName) : null;
         set => MainAssetTypeName = value?.AssemblyQualifiedName;
     }
 

--- a/Prowl.Runtime.Test/RuntimeUtilsTests.cs
+++ b/Prowl.Runtime.Test/RuntimeUtilsTests.cs
@@ -1,0 +1,122 @@
+// This file is part of the Prowl Game Engine
+// Licensed under the MIT License. See the LICENSE file in the project root for details.
+
+using System.Reflection;
+using System.Reflection.Emit;
+using System.Runtime.CompilerServices;
+
+using Xunit;
+
+namespace Prowl.Runtime.Test;
+
+/// <summary>Tests for <see cref="RuntimeUtils.ResolveType"/> assembly-qualified name binding.</summary>
+public class RuntimeUtilsTests
+{
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void ResolveType_NullOrBlank_ReturnsNull(string? name)
+    {
+        Assert.Null(RuntimeUtils.ResolveType(name!));
+    }
+
+    [Fact]
+    public void ResolveType_DefaultContextType_RoundTrips()
+    {
+        Assert.Equal(typeof(RuntimeUtils), RuntimeUtils.ResolveType(typeof(RuntimeUtils).AssemblyQualifiedName!));
+        Assert.Equal(typeof(int), RuntimeUtils.ResolveType(typeof(int).AssemblyQualifiedName!));
+        Assert.Equal(typeof(List<string>), RuntimeUtils.ResolveType(typeof(List<string>).AssemblyQualifiedName!));
+    }
+
+    [Fact]
+    public void ResolveType_WithoutAssemblyQualifier_ResolvesByFullName()
+    {
+        Assert.Equal(typeof(int), RuntimeUtils.ResolveType("System.Int32"));
+        Assert.Equal(typeof(RuntimeUtils), RuntimeUtils.ResolveType("Prowl.Runtime.RuntimeUtils"));
+    }
+
+    // These names reach the editor from a persisted asset database, so a corrupt or truncated entry
+    // must degrade to "unresolved" rather than throw out of a property getter inside a draw loop.
+    [Theory]
+    [InlineData("Foo,")]                                                                    // empty assembly name
+    [InlineData("Foo, ==")]                                                                 // invalid assembly name
+    [InlineData("Prowl.Runtime.RuntimeUtils[")]                                             // truncated
+    [InlineData("Ns.T, Missing.Asm, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null")] // assembly not loaded
+    public void ResolveType_MalformedOrUnloadable_ReturnsNullWithoutThrowing(string name)
+    {
+        Assert.Null(RuntimeUtils.ResolveType(name));
+    }
+
+    // Must not degrade into a loose simple-name search: the assembly recorded in the name is honored,
+    // so two assemblies declaring the same type name can never be confused for one another.
+    [Fact]
+    public void ResolveType_TypeNameQualifiedWithWrongAssembly_ReturnsNull()
+    {
+        string wrong = $"Prowl.Runtime.RuntimeUtils, {typeof(int).Assembly.GetName().Name}";
+        Assert.Null(RuntimeUtils.ResolveType(wrong));
+    }
+
+    [Fact]
+    public void ResolveType_SurvivesCacheClear()
+    {
+        string aqn = typeof(RuntimeUtils).AssemblyQualifiedName!;
+
+        Assert.Equal(typeof(RuntimeUtils), RuntimeUtils.ResolveType(aqn));
+        RuntimeUtils.ClearCache();
+        Assert.Equal(typeof(RuntimeUtils), RuntimeUtils.ResolveType(aqn));
+    }
+
+    // The reason ResolveType exists: user scripts (and their EngineObject/asset types) live in a
+    // separate, collectible load context, which Type.GetType is not permitted to bind into. A dynamic
+    // assembly stands in for that context here - it is reachable by reflection but not by Type.GetType.
+    [Fact]
+    public void ResolveType_TypeOutsideDefaultContext_ResolvesWhereTypeGetTypeCannot()
+    {
+        if (!RuntimeFeature.IsDynamicCodeSupported)
+            return;
+
+        Type outOfContext = DefineOutOfContextType();
+        string aqn = outOfContext.AssemblyQualifiedName!;
+
+        Assert.Null(Type.GetType(aqn, throwOnError: false));
+        Assert.Same(outOfContext, RuntimeUtils.ResolveType(aqn));
+    }
+
+    // Generic arguments and array element types carry their own assembly qualifiers, so they have to
+    // be bound out-of-context too - a naive "split on the first comma" never gets this right.
+    [Fact]
+    public void ResolveType_GenericArgumentAndArrayOfOutOfContextType_Resolve()
+    {
+        if (!RuntimeFeature.IsDynamicCodeSupported)
+            return;
+
+        Type outOfContext = DefineOutOfContextType();
+
+        Type list = typeof(List<>).MakeGenericType(outOfContext);
+        Type resolvedList = RuntimeUtils.ResolveType(list.AssemblyQualifiedName!)!;
+        Assert.NotNull(resolvedList);
+        Assert.Same(outOfContext, resolvedList.GetGenericArguments()[0]);
+
+        Type array = outOfContext.MakeArrayType();
+        Type resolvedArray = RuntimeUtils.ResolveType(array.AssemblyQualifiedName!)!;
+        Assert.NotNull(resolvedArray);
+        Assert.Same(outOfContext, resolvedArray.GetElementType());
+    }
+
+    private static Type? s_outOfContextType;
+
+    private static Type DefineOutOfContextType()
+    {
+        // Cached: an assembly name can only be defined once per process.
+        if (s_outOfContextType != null)
+            return s_outOfContextType;
+
+        AssemblyBuilder asm = AssemblyBuilder.DefineDynamicAssembly(
+            new AssemblyName("Prowl.Runtime.Test.OutOfContext"), AssemblyBuilderAccess.Run);
+        ModuleBuilder module = asm.DefineDynamicModule("Main");
+        TypeBuilder type = module.DefineType("Prowl.Runtime.Test.OutOfContextAsset", TypeAttributes.Public | TypeAttributes.Class);
+
+        return s_outOfContextType = type.CreateType();
+    }
+}

--- a/Prowl.Runtime/Utils/RuntimeUtils.cs
+++ b/Prowl.Runtime/Utils/RuntimeUtils.cs
@@ -2,8 +2,10 @@
 // Licensed under the MIT License. See the LICENSE file in the project root for details.
 
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.CompilerServices;
@@ -44,11 +46,18 @@ public static class RuntimeUtils
     private static readonly Dictionary<TypeInfo, bool> s_deepCopyByAssignmentCache = [];
     private static readonly Dictionary<Type, int> s_executionOrderCache = [];
 
+    // Concurrent because assets (and therefore their type names) are resolved on background
+    // load threads as well as the main thread. Only successful lookups are stored, so a name
+    // that isn't resolvable yet stays resolvable once its assembly finishes loading.
+    private static readonly ConcurrentDictionary<string, Type> s_resolvedTypeCache = new(StringComparer.Ordinal);
+
     [OnAssemblyUnload]
     public static void ClearCache()
     {
         s_deepCopyByAssignmentCache.Clear();
         s_executionOrderCache.Clear();
+        // Must be cleared before the script ALC unloads - a cached Type would pin it alive.
+        s_resolvedTypeCache.Clear();
     }
 
     public static bool IsARM() =>
@@ -102,6 +111,78 @@ public static class RuntimeUtils
             if (t != null)
                 return t;
         }
+        return null;
+    }
+
+    /// <summary>
+    /// Resolves a type from an assembly-qualified name across ALL loaded assembly load contexts,
+    /// including the collectible context user scripts are loaded into. <see cref="Type.GetType(string)"/>
+    /// can only bind names into the default context by CLR rule, so it returns null for any type
+    /// declared in a user assembly - which is why persisted type names (asset entries, and anything
+    /// else round-tripped through <see cref="Type.AssemblyQualifiedName"/>) need this instead.
+    /// </summary>
+    /// <remarks>
+    /// Unlike <see cref="FindType"/>, this honors the assembly recorded in the name and never falls
+    /// back to a loose simple-name match, so it cannot return the wrong type when two assemblies
+    /// declare types that share a name. Assemblies are matched on simple name only: a script assembly
+    /// keeps its name but gets a fresh version and load context on every hot-reload, so matching full
+    /// identity would miss it. Returns null rather than throwing for malformed or unloadable names.
+    /// </remarks>
+    public static Type? ResolveType(string assemblyQualifiedName)
+    {
+        if (string.IsNullOrWhiteSpace(assemblyQualifiedName))
+            return null;
+
+        if (s_resolvedTypeCache.TryGetValue(assemblyQualifiedName, out Type? cached))
+            return cached;
+
+        Type? resolved;
+        try
+        {
+            // Fast path: already resolvable in the default context.
+            resolved = Type.GetType(assemblyQualifiedName, throwOnError: false);
+
+            // Slow path: bind against every loaded assembly. The resolver overload is applied
+            // recursively to generic arguments and array element types, so it also handles names
+            // like List<UserType> whose inner assembly qualifier is a collectible-context one.
+            resolved ??= Type.GetType(assemblyQualifiedName, ResolveLoadedAssembly, ResolveTypeInAssembly, throwOnError: false);
+        }
+        catch (Exception ex) when (ex is FileLoadException or BadImageFormatException or ArgumentException or TypeLoadException)
+        {
+            // A malformed or unloadable name persisted in the asset database must not tear down the
+            // caller - these getters run inside editor draw loops. Treat it as simply unresolved.
+            return null;
+        }
+
+        // Only successful resolutions are cached; a miss may just mean the assembly isn't loaded yet.
+        if (resolved != null)
+            s_resolvedTypeCache[assemblyQualifiedName] = resolved;
+
+        return resolved;
+    }
+
+    private static Assembly? ResolveLoadedAssembly(AssemblyName name)
+    {
+        foreach (Assembly asm in AppDomain.CurrentDomain.GetAssemblies())
+            if (string.Equals(asm.GetName().Name, name.Name, StringComparison.OrdinalIgnoreCase))
+                return asm;
+
+        return null;
+    }
+
+    private static Type? ResolveTypeInAssembly(Assembly? asm, string typeName, bool ignoreCase)
+    {
+        if (asm != null)
+            return asm.GetType(typeName, throwOnError: false, ignoreCase);
+
+        // No assembly qualifier on this portion of the name - search every loaded assembly.
+        foreach (Assembly candidate in AppDomain.CurrentDomain.GetAssemblies())
+        {
+            Type? t = candidate.GetType(typeName, throwOnError: false, ignoreCase);
+            if (t != null)
+                return t;
+        }
+
         return null;
     }
 


### PR DESCRIPTION
### Issue

While experimenting with porting a Unity project over, I was attempting to use a "Data Asset" script (inherits from EngineObject, documentation mentions it is similar to a Scriptable Object), however, I was unable to create a custom editor to view or edit the serialized fields. 

All that would show is the meta data of the asset:

<img width="351" height="314" alt="Screenshot 2026-07-21 145345" src="https://github.com/user-attachments/assets/e8a1bd43-8d87-43c1-851e-5645e2cba808" />

After some debugging, the issue is that AssetEntry used Type.GetType, which is only permitted to bind into the default assembly load context. Prowl loads compiled user scripts into a separate, collectible AssemblyLoadContext named "ProwlScripts" so it can be hot-reloaded and unloaded. So for any EngineObject subclass defined in a game assembly, Type.GetType returns null by CLR rule and because it comes back as null, GetAssetEditor always fails to find an editor and we fall back to the generic view.

If we try to persist a null resolving type name into metadata.db, we cause a crash in the editor (generally).

Notably, this _only_ seems to affect the asset-editor / Importer path, as CustomPropertyEditor resolves off a live object.

### Fix

Originally, I opted to change Type.GetType with RuntimeUtils.FindType, which **does** solve the issue as well. I had Claude code review the changes for any scenarios that I might be missing, and/or introducing, and it pointed out that just using FindType could cause an ambiguous lookup issue if you had the same type across multiple assemblies. The suggestion was to add a new helper that tries to resolve based on assembly identity first (by simple name since a recompiled script assembly keeps its name but changes version/context), and only searches inside assemblies that actually match. It also uses the resolver-overload form of Type.GetType, which recurses into generic arguments and array element types, that FindType's manual comma-split does not do, since the first comma in a generic AQN sits inside the type's own bracketed arguments, not at the assembly boundary.

I had it generate some unit tests to go with this to hopefully help catch it in the future. 

That said, if desired since it's less new code, I can adjust the fix to just use the existing FindType and accept the ambiguous reference may just be a local project issue.

With fix (and custom importer + editor)

<img width="724" height="763" alt="Screenshot 2026-07-21 171751" src="https://github.com/user-attachments/assets/a94e08d6-a108-4453-80d6-1a38de43cb2b" />