### PR TITLE
Fix collider DrawGizmo incorrecly placed the shape's Center offset through the combined rotation, leading to mismatch between actual physics shape and debugging

### DIFF
--- a/Prowl.Runtime/Components/Physics/Colliders/BoxCollider.cs
+++ b/Prowl.Runtime/Components/Physics/Colliders/BoxCollider.cs
@@ -30,9 +30,8 @@ public sealed class BoxCollider : Collider
 
     public override void DrawGizmos()
     {
-        Float4x4 matrix = Float4x4.CreateTRS(Transform.Position, Transform.Rotation * Quaternion.FromEuler(Rotation), Transform.LossyScale);
-        Debug.PushMatrix(matrix);
-        Debug.DrawWireCube(Center, size * 0.5f, Color.Green);
+        Debug.PushMatrix(GizmoMatrix);
+        Debug.DrawWireCube(Float3.Zero, size * 0.5f, Color.Green);
         Debug.PopMatrix();
     }
 }

--- a/Prowl.Runtime/Components/Physics/Colliders/CapsuleCollider.cs
+++ b/Prowl.Runtime/Components/Physics/Colliders/CapsuleCollider.cs
@@ -39,9 +39,8 @@ public sealed class CapsuleCollider : Collider
 
     public override void DrawGizmos()
     {
-        Float4x4 matrix = Float4x4.CreateTRS(Transform.Position, Transform.Rotation * Quaternion.FromEuler(Rotation), Transform.LossyScale);
-        Debug.PushMatrix(matrix);
-        Debug.DrawWireCapsule(Center + new Float3(0, -height * 0.5f, 0), Center + new Float3(0, height * 0.5f, 0), radius, Color.Green);
+        Debug.PushMatrix(GizmoMatrix);
+        Debug.DrawWireCapsule(new Float3(0, -height * 0.5f, 0), new Float3(0, height * 0.5f, 0), radius, Color.Green);
         Debug.PopMatrix();
     }
 }

--- a/Prowl.Runtime/Components/Physics/Colliders/Collider.cs
+++ b/Prowl.Runtime/Components/Physics/Colliders/Collider.cs
@@ -16,6 +16,12 @@ public abstract class Collider : MonoBehaviour
     public Float3 Center;
     public Float3 Rotation;
 
+    protected Float4x4 GizmoMatrix =>
+        Float4x4.CreateTRS(
+            Float4x4.TransformPoint(Center, Float4x4.CreateTRS(Transform.Position, Transform.Rotation, Transform.LossyScale)),
+            Transform.Rotation * Quaternion.FromEuler(Rotation),
+            Transform.LossyScale);
+
     /// <summary>
     /// The Jitter2 rigidbody this collider is currently attached to.
     /// This could be either a Rigidbody3D's body or the PhysicsWorld's static rigidbody.

--- a/Prowl.Runtime/Components/Physics/Colliders/ConeCollider.cs
+++ b/Prowl.Runtime/Components/Physics/Colliders/ConeCollider.cs
@@ -39,9 +39,8 @@ public sealed class ConeCollider : Collider
 
     public override void DrawGizmos()
     {
-        Float4x4 matrix = Float4x4.CreateTRS(Transform.Position, Transform.Rotation * Quaternion.FromEuler(Rotation), Transform.LossyScale);
-        Debug.PushMatrix(matrix);
-        Debug.DrawWireCone(Center + new Float3(0, -height * 0.5f, 0), new Float3(0, height, 0), radius, Color.Green);
+        Debug.PushMatrix(GizmoMatrix);
+        Debug.DrawWireCone(new Float3(0, -height * 0.5f, 0), new Float3(0, height, 0), radius, Color.Green);
         Debug.PopMatrix();
     }
 }

--- a/Prowl.Runtime/Components/Physics/Colliders/CylinderCollider.cs
+++ b/Prowl.Runtime/Components/Physics/Colliders/CylinderCollider.cs
@@ -39,9 +39,8 @@ public sealed class CylinderCollider : Collider
 
     public override void DrawGizmos()
     {
-        Float4x4 matrix = Float4x4.CreateTRS(Transform.Position, Transform.Rotation * Quaternion.FromEuler(Rotation), Transform.LossyScale);
-        Debug.PushMatrix(matrix);
-        Debug.DrawWireCylinder(Center, Quaternion.Identity, radius, height, Color.Green);
+        Debug.PushMatrix(GizmoMatrix);
+        Debug.DrawWireCylinder(Float3.Zero, Quaternion.Identity, radius, height, Color.Green);
         Debug.PopMatrix();
     }
 }

--- a/Prowl.Runtime/Components/Physics/Colliders/SphereCollider.cs
+++ b/Prowl.Runtime/Components/Physics/Colliders/SphereCollider.cs
@@ -28,9 +28,8 @@ public sealed class SphereCollider : Collider
 
     public override void DrawGizmos()
     {
-        Float4x4 matrix = Float4x4.CreateTRS(Transform.Position, Transform.Rotation * Quaternion.FromEuler(Rotation), Transform.LossyScale);
-        Debug.PushMatrix(matrix);
-        Debug.DrawWireSphere(Center, radius, Color.Green);
+        Debug.PushMatrix(GizmoMatrix);
+        Debug.DrawWireSphere(Float3.Zero, radius, Color.Green);
         Debug.PopMatrix();
     }
 }


### PR DESCRIPTION
# Summary

Collider 'DrawGizmos' was placing the shape's Center offset through the combined rotation ((Transform.Rotation * FromEuler(Rotation))) so that when a collider had both an offset Center and a non-zero Rotation, the green gizmo box orbited away from where the physics shape actually is. The actual physics shape itself in the engine code was in the proper place (as demonstrated in gifs), but the debugging Gizmo was not.

# Screenshots

Pre-fix: Note that the gizmo is to the left of the second cube, so hitting play you would *think* that's where the collision would occur, but you can see that it actually colliders on the cube itself.

<img width="941" height="772" alt="IncorrectGizmos" src="https://github.com/user-attachments/assets/d17cab97-9b55-4d97-be7c-bd7d16cb85e5" />

Post-fix: The gizmo now matches where the collision actually happens

<img width="941" height="772" alt="FixedGizmos" src="https://github.com/user-attachments/assets/299ad1ac-46e8-4282-9f8f-4ef9a3051613" />
