### PR TITLE
Normalize separators in Show in Explorer

### DIFF
--- a/Prowl.Editor/Utils/EditorUtils.cs
+++ b/Prowl.Editor/Utils/EditorUtils.cs
@@ -89,6 +89,9 @@ public static class EditorUtils
     {
         try
         {
+            // Normalize separators to the platform's native form
+            absPath = Path.GetFullPath(absPath);
+
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
                 if (Directory.Exists(absPath))


### PR DESCRIPTION
Fixes issue #315 

The problem is item.RelativePath stores asset paths with forward slashes (Scripts/foo.cs). Path.Combine doesn't normalize existing separators inside a string, so combining it with the Windows AssetsPath produced a mixed path like C:\Project\Assets\Scripts/foo.cs and explorer just doesn't bother with it so it kicks us to Home path.

Could instead change it so that the call path is responsible for it and not here, but given all 3 call sites are Show In Explorer anyways, figured it was better for one place as the source of truth.

Another approach is string replace if preferred.