### PR TITLE
Modify import and asset/scene references to use the actual names, rather than the EngineObject constructor default of New (TypeName)

### DIFF
--- a/Prowl.Editor/AssetsDatabase/Importers/AssemblyDefinitionImporter.cs
+++ b/Prowl.Editor/AssetsDatabase/Importers/AssemblyDefinitionImporter.cs
@@ -35,7 +35,7 @@ public class AssemblyDefinitionImporter : AssetImporter
             ScriptAssemblyManager.RequestRecompile();
 
         // Marker asset so the inspector resolves the editor by type (data stays in the file).
-        ctx.SetMainAsset(new AssemblyDefinitionAsset { Name = Path.GetFileNameWithoutExtension(ctx.AbsolutePath) });
+        ctx.SetMainAsset(new AssemblyDefinitionAsset { Name = ctx.FileName });
         return true;
     }
 

--- a/Prowl.Editor/AssetsDatabase/Importers/AudioImporter.cs
+++ b/Prowl.Editor/AssetsDatabase/Importers/AudioImporter.cs
@@ -1,5 +1,3 @@
-using System.IO;
-
 using Prowl.Runtime;
 using Prowl.Runtime.Resources;
 
@@ -18,7 +16,8 @@ public class AudioImporter : AssetImporter
         try
         {
             var clip = new AudioClip(ctx.AbsolutePath, streamFromDisk: false);
-            clip.ClipName = Path.GetFileNameWithoutExtension(ctx.AbsolutePath);
+            clip.ClipName = ctx.FileName;
+            clip.Name = ctx.FileName;
             ctx.SetMainAsset(clip);
         }
         catch (System.Exception ex)

--- a/Prowl.Editor/AssetsDatabase/Importers/EditorModelImporter.cs
+++ b/Prowl.Editor/AssetsDatabase/Importers/EditorModelImporter.cs
@@ -13,7 +13,7 @@ namespace Prowl.Editor.Importers;
 [ImporterFor(".gltf", ".glb", ".obj", ".fbx")]
 public class EditorModelImporter : AssetImporter
 {
-    private const int BaseVersion = 5;
+    private const int BaseVersion = 6;
     public override int Version => BaseVersion + MeshFeatureRegistry.AggregateVersion;
 
     public override bool Import(ImportContext ctx)

--- a/Prowl.Editor/AssetsDatabase/Importers/EditorModelImporter.cs
+++ b/Prowl.Editor/AssetsDatabase/Importers/EditorModelImporter.cs
@@ -65,7 +65,7 @@ public class EditorModelImporter : AssetImporter
             // 3. Serialize GO hierarchy sub-assets have correct IDs, AssetRefs serialize as GUIDs.
             //    Tracked (matching SceneImporter/PrefabImporter) so the Model's own dependency list
             //    reflects what its GameObject hierarchy actually references.
-            var model = new Model(Path.GetFileNameWithoutExtension(ctx.AbsolutePath));
+            var model = new Model(ctx.FileName);
             if (data.RootGO != null)
             {
                 var goSerCtx = ImportHelper.CreateTrackingContext(out var goDependencies);

--- a/Prowl.Editor/AssetsDatabase/Importers/ImportHelper.cs
+++ b/Prowl.Editor/AssetsDatabase/Importers/ImportHelper.cs
@@ -36,6 +36,7 @@ public static class ImportHelper
             var asset = Serializer.Deserialize<T>(echo, serCtx);
             if (asset != null)
             {
+                asset.Name = ctx.FileName;
                 ctx.SetMainAsset(asset);
                 foreach (var dep in dependencies)
                     ctx.AddDependency(dep);

--- a/Prowl.Editor/AssetsDatabase/Importers/ImportResult.cs
+++ b/Prowl.Editor/AssetsDatabase/Importers/ImportResult.cs
@@ -21,6 +21,10 @@ public class ImportContext
     /// <summary>Importer settings from .meta file.</summary>
     public Echo.EchoObject? Settings { get; }
 
+    /// <summary>The source file's name without its extension - the usual choice for naming the
+    /// main asset (see <see cref="SetMainAsset"/>).</summary>
+    public string FileName => Path.GetFileNameWithoutExtension(AbsolutePath);
+
     /// <summary>The primary imported object.</summary>
     public EngineObject? MainAsset { get; private set; }
 
@@ -37,11 +41,17 @@ public class ImportContext
         Settings = settings;
     }
 
-    /// <summary>Set the main asset. Auto-sets Name from the file path.</summary>
+    /// <summary>Register the primary imported object. Naming is the importer's responsibility (use
+    /// <see cref="FileName"/> for the common case); a null/blank Name is treated as an importer bug
+    /// and throws, since it would otherwise surface as EngineObject's "New{TypeName}" default.</summary>
     public void SetMainAsset(EngineObject asset)
     {
+        if (string.IsNullOrWhiteSpace(asset.Name))
+            throw new InvalidOperationException(
+                $"Importer produced a main asset of type '{asset.GetType().Name}' with no Name. " +
+                $"Assign one (e.g. ctx.{nameof(FileName)}) before calling {nameof(SetMainAsset)}.");
+
         asset.AssetID = AssetGuid;
-        asset.Name = Path.GetFileNameWithoutExtension(AbsolutePath);
         MainAsset = asset;
     }
 
@@ -54,13 +64,18 @@ public class ImportContext
     /// </summary>
     public void AddSubAsset(string name, EngineObject asset)
     {
+        // The name seeds the sub-asset's deterministic GUID and is its display name, so it must be
+        // present and unique - a blank one collides and breaks the asset. Naming is the importer's job.
+        if (string.IsNullOrWhiteSpace(name))
+            throw new InvalidOperationException(
+                $"Importer added a sub-asset of type '{asset.GetType().Name}' with no name. " +
+                "A sub-asset name is required (it seeds the sub-asset's GUID).");
+
         // Ensure unique name; appends _1, _2, etc. if duplicate.
         string uniqueName = Utils.UniqueNames.MakeUnique(name, n => _usedNames.Contains(n),
             openSeparator: "_", closeSeparator: "", stripExistingSuffix: false);
         _usedNames.Add(uniqueName);
-
-        if (string.IsNullOrEmpty(asset.Name))
-            asset.Name = uniqueName;
+        asset.Name = uniqueName;
 
         asset.AssetID = AssetEntry.DeriveSubAssetGuid(AssetGuid, uniqueName);
         SubAssets.Add(asset);

--- a/Prowl.Editor/AssetsDatabase/Importers/ImportResult.cs
+++ b/Prowl.Editor/AssetsDatabase/Importers/ImportResult.cs
@@ -37,12 +37,11 @@ public class ImportContext
         Settings = settings;
     }
 
-    /// <summary>Set the main asset. Auto-sets Name from the file path if it isn't already set.</summary>
+    /// <summary>Set the main asset. Auto-sets Name from the file path.</summary>
     public void SetMainAsset(EngineObject asset)
     {
         asset.AssetID = AssetGuid;
-        if (string.IsNullOrEmpty(asset.Name))
-            asset.Name = Path.GetFileNameWithoutExtension(AbsolutePath);
+        asset.Name = Path.GetFileNameWithoutExtension(AbsolutePath);
         MainAsset = asset;
     }
 

--- a/Prowl.Editor/AssetsDatabase/Importers/InputActionMapImporter.cs
+++ b/Prowl.Editor/AssetsDatabase/Importers/InputActionMapImporter.cs
@@ -23,7 +23,10 @@ public class InputActionMapImporter : AssetImporter
 
             var map = Serializer.Deserialize<InputActionMap>(echo);
             if (map != null)
+            {
+                map.Name = ctx.FileName;
                 ctx.SetMainAsset(map);
+            }
         }
         catch (Exception ex)
         {

--- a/Prowl.Editor/AssetsDatabase/Importers/MeshImporter.cs
+++ b/Prowl.Editor/AssetsDatabase/Importers/MeshImporter.cs
@@ -35,6 +35,7 @@ public class MeshImporter : AssetImporter
                 return false;
             }
 
+            mesh.Name = ctx.FileName;
             ctx.SetMainAsset(mesh);
 
             foreach (var dep in dependencies)

--- a/Prowl.Editor/AssetsDatabase/Importers/MeshImporter.cs
+++ b/Prowl.Editor/AssetsDatabase/Importers/MeshImporter.cs
@@ -15,7 +15,7 @@ namespace Prowl.Editor.Importers;
 [ImporterFor(".mesh")]
 public class MeshImporter : AssetImporter
 {
-    private const int BaseVersion = 1;
+    private const int BaseVersion = 2;
 
     public override int Version => BaseVersion + MeshFeatureRegistry.AggregateVersion;
 

--- a/Prowl.Editor/AssetsDatabase/Importers/PrefabImporter.cs
+++ b/Prowl.Editor/AssetsDatabase/Importers/PrefabImporter.cs
@@ -30,6 +30,7 @@ public class PrefabImporter : AssetImporter
 
             var prefab = new PrefabAsset();
             prefab.GameObjectData = goEcho;
+            prefab.Name = ctx.FileName;
 
             ctx.SetMainAsset(prefab);
             foreach (var dep in dependencies)

--- a/Prowl.Editor/AssetsDatabase/Importers/SceneImporter.cs
+++ b/Prowl.Editor/AssetsDatabase/Importers/SceneImporter.cs
@@ -29,6 +29,7 @@ public class SceneImporter : AssetImporter
             var scene = Serializer.Deserialize<Scene>(echo, serCtx);
             if (scene != null)
             {
+                scene.Name = ctx.FileName;
                 ctx.SetMainAsset(scene);
 
                 // Also walk the raw echo for PrefabAssetId references

--- a/Prowl.Editor/AssetsDatabase/Importers/ShaderImporter.cs
+++ b/Prowl.Editor/AssetsDatabase/Importers/ShaderImporter.cs
@@ -55,7 +55,7 @@ public class ShaderImporter : AssetImporter
             return false;
         }
 
-        shader.Name = Path.GetFileNameWithoutExtension(ctx.AbsolutePath);
+        shader.Name = ctx.FileName;
         ctx.SetMainAsset(shader);
         return true;
     }

--- a/Prowl.Editor/AssetsDatabase/Importers/TextureImporter.cs
+++ b/Prowl.Editor/AssetsDatabase/Importers/TextureImporter.cs
@@ -25,7 +25,7 @@ public class TextureImporter : AssetImporter
 
         // Load texture WITHOUT mipmaps first we'll generate them after applying settings
         var texture = Texture2D.FromFile(ctx.AbsolutePath, false);
-        texture.Name = Path.GetFileNameWithoutExtension(ctx.AbsolutePath);
+        texture.Name = ctx.FileName;
 
         // Read filter/wrap settings (defaults merged by RunImport)
         var minFilter = ctx.Settings?.TryGet("minFilter", out var minTag2) == true

--- a/Prowl.Editor/AssetsDatabase/Importers/TextureImporter.cs
+++ b/Prowl.Editor/AssetsDatabase/Importers/TextureImporter.cs
@@ -16,7 +16,7 @@ namespace Prowl.Editor.Importers;
 [ImporterFor(".png", ".jpg", ".jpeg", ".bmp", ".tga", ".psd", ".hdr", ".dds", ".exr")]
 public class TextureImporter : AssetImporter
 {
-    public override int Version => 3; // Bumped: emits sprite sub-assets from settings["sprite"]
+    public override int Version => 4;
 
     public override bool Import(ImportContext ctx)
     {

--- a/Prowl.Editor/GUI/PropertyEditors/AssetRefPropertyEditor.cs
+++ b/Prowl.Editor/GUI/PropertyEditors/AssetRefPropertyEditor.cs
@@ -36,8 +36,7 @@ public class AssetRefPropertyEditor : PropertyEditor
 
         bool isAsset = instance != null && instance.AssetID != Guid.Empty;
         bool isInstance = instance != null && instance.AssetID == Guid.Empty;
-        string suffix = isAsset ? instance!.GetType().Name : isInstance ? "Instance" : fieldType.Name;
-        string displayName = instance != null ? $"{instance.Name} ({suffix})" : $"None ({fieldType.Name})";
+        string displayName = PropertyGridUtils.DescribeObjectRef(instance, fieldType);
         string icon = isAsset ? EditorIcons.Cube : isInstance ? EditorIcons.CircleDot : EditorIcons.Circle;
         var iconColor = isAsset ? EditorTheme.Purple400 : isInstance ? EditorTheme.Ink500 : EditorTheme.Ink300;
 

--- a/Prowl.Editor/GUI/PropertyEditors/EngineObjectPropertyEditor.cs
+++ b/Prowl.Editor/GUI/PropertyEditors/EngineObjectPropertyEditor.cs
@@ -34,8 +34,7 @@ public class EngineObjectPropertyEditor : PropertyEditor
         _lastFieldType = null; // consume it
 
         bool isAsset = eo != null && eo.AssetID != Guid.Empty;
-        string suffix = eo != null ? (isAsset ? eo.GetType().Name : "Instance") : fieldType.Name;
-        string displayName = eo != null ? $"{eo.Name} ({suffix})" : $"None ({fieldType.Name})";
+        string displayName = PropertyGridUtils.DescribeObjectRef(eo, fieldType);
         string icon = eo != null ? EditorIcons.Cube : EditorIcons.Circle;
 
         using (paper.Row(id).Height(UnitValue.Auto).MinHeight(rh).Padding(m.PaddingLarge, m.PaddingLarge, 0, 0).RowBetween(m.Padding).Enter())

--- a/Prowl.Editor/GUI/PropertyGridUtils.cs
+++ b/Prowl.Editor/GUI/PropertyGridUtils.cs
@@ -5,11 +5,31 @@ using System.Reflection;
 using Prowl.Editor.Core;
 using Prowl.OrigamiUI;
 using Prowl.PaperUI;
+using Prowl.Runtime;
 
 namespace Prowl.Editor.GUI;
 
 public static class PropertyGridUtils
 {
+    /// <summary>
+    /// Build the "Name (Type)" label an object-reference field shows in the property grid. 
+    /// A scene component has no name of its own so it uses the name of the GameObject it lives on and typed
+    /// by the component (e.g. "Player (Rigidbody)"). GameObjects and assets carry a real Name, so they use it.
+    /// Field Type is used as a fallback for empty references.
+    /// </summary>
+    public static string DescribeObjectRef(EngineObject? instance, Type fieldType)
+    {
+        if (instance == null)
+            return $"None ({fieldType.Name})";
+
+        if (instance is MonoBehaviour mb && mb.GameObject != null)
+            return $"{mb.GameObject.Name} ({instance.GetType().Name})";
+
+        bool isAsset = instance.AssetID != Guid.Empty;
+        string suffix = isAsset || instance is GameObject ? instance.GetType().Name : "Instance";
+        return $"{instance.Name} ({suffix})";
+    }
+
     /// <summary>
     /// Set of overridden field names for the current component being drawn.
     /// Set by the inspector before drawing a prefab instance's component.

--- a/Prowl.Runtime/EngineObject.cs
+++ b/Prowl.Runtime/EngineObject.cs
@@ -102,7 +102,7 @@ public abstract class EngineObject : IDisposable
 
     protected void DeserializeHeader(EchoObject value)
     {
-        Name = value.Get("Name")?.StringValue ?? string.Empty;
+        Name = value.Get("Name")?.StringValue ?? Name;
         AssetPath = value.Get("AssetPath")?.StringValue ?? string.Empty;
         if (Guid.TryParse(value.Get("AssetID")?.StringValue, out Guid assetId))
             AssetID = assetId;

--- a/Prowl.Runtime/Resources/AudioClip.cs
+++ b/Prowl.Runtime/Resources/AudioClip.cs
@@ -219,6 +219,8 @@ public sealed class AudioClip : EngineObject, ISerializable
     {
         // Restore the name
         clipName = value["Name"].StringValue;
+        if (!string.IsNullOrEmpty(clipName))
+            Name = clipName;
 
         bool isFileBased = value["IsFileBased"].BoolValue;
 

--- a/Prowl.Runtime/Resources/Cubemap.cs
+++ b/Prowl.Runtime/Resources/Cubemap.cs
@@ -190,6 +190,7 @@ public sealed class Cubemap : Texture, ISerializable
 
     public void Serialize(ref EchoObject compoundTag, SerializationContext ctx)
     {
+        SerializeHeader(compoundTag);
         compoundTag.Add("Size", new(Size));
         compoundTag.Add("MipLevels", new(MipLevels));
         compoundTag.Add("ImageFormat", new((int)ImageFormat));
@@ -222,6 +223,8 @@ public sealed class Cubemap : Texture, ISerializable
         Type[] param = [typeof(uint), typeof(bool), typeof(TextureImageFormat)];
         object[] values = [size, mipLevels > 1, imageFormat];
         typeof(Cubemap).GetConstructor(param)!.Invoke(this, values);
+
+        DeserializeHeader(value);
 
         EchoObject faces = value["Faces"];
         int idx = 0;

--- a/Prowl.Runtime/Resources/Mesh.cs
+++ b/Prowl.Runtime/Resources/Mesh.cs
@@ -1759,6 +1759,7 @@ public class Mesh : EngineObject, ISerializable
                 }
             }
 
+            SerializeHeader(compoundTag);
             compoundTag.Add("MeshData", new EchoObject(memoryStream.ToArray()));
             compoundTag.Add("MeshType", new EchoObject((int)meshTopology));
             compoundTag.Add("MeshIndexFormat", new EchoObject((int)indexFormat));
@@ -1773,6 +1774,8 @@ public class Mesh : EngineObject, ISerializable
 
     public void Deserialize(EchoObject value, SerializationContext ctx)
     {
+        DeserializeHeader(value);
+
         meshTopology = (Topology)value["MeshType"].IntValue;
         indexFormat = (IndexFormat)value["MeshIndexFormat"].IntValue;
         bounds = new AABB(

--- a/Prowl.Runtime/Resources/MeshFeatures/MeshSDF.cs
+++ b/Prowl.Runtime/Resources/MeshFeatures/MeshSDF.cs
@@ -50,6 +50,7 @@ public sealed class MeshSDF : EngineObject, IMeshFeature
 
     public void Serialize(ref EchoObject compoundTag, SerializationContext ctx)
     {
+        SerializeHeader(compoundTag);
         compoundTag.Add("Bounds.Min.X", new(Bounds.Min.X));
         compoundTag.Add("Bounds.Min.Y", new(Bounds.Min.Y));
         compoundTag.Add("Bounds.Min.Z", new(Bounds.Min.Z));
@@ -67,6 +68,7 @@ public sealed class MeshSDF : EngineObject, IMeshFeature
 
     public void Deserialize(EchoObject value, SerializationContext ctx)
     {
+        DeserializeHeader(value);
         Bounds = new AABB(
             new Float3(value["Bounds.Min.X"].FloatValue, value["Bounds.Min.Y"].FloatValue, value["Bounds.Min.Z"].FloatValue),
             new Float3(value["Bounds.Max.X"].FloatValue, value["Bounds.Max.Y"].FloatValue, value["Bounds.Max.Z"].FloatValue));

--- a/Prowl.Runtime/Resources/RenderTexture.cs
+++ b/Prowl.Runtime/Resources/RenderTexture.cs
@@ -84,6 +84,7 @@ public sealed class RenderTexture : EngineObject, ISerializable
 
     public void Serialize(ref EchoObject compoundTag, SerializationContext ctx)
     {
+        SerializeHeader(compoundTag);
         compoundTag.Add("Width", new(Width));
         compoundTag.Add("Height", new(Height));
         compoundTag.Add("NumTextures", new(numTextures));
@@ -109,6 +110,8 @@ public sealed class RenderTexture : EngineObject, ISerializable
         Type[] param = new[] { typeof(int), typeof(int), typeof(bool), typeof(TextureImageFormat[]) };
         object[] values = new object[] { Width, Height, hasDepthAttachment, textureFormats };
         typeof(RenderTexture).GetConstructor(param).Invoke(this, values);
+
+        DeserializeHeader(value);
     }
 
     #region Pool

--- a/Prowl.Runtime/Resources/Texture2D.cs
+++ b/Prowl.Runtime/Resources/Texture2D.cs
@@ -230,6 +230,7 @@ public sealed class Texture2D : Texture, ISerializable
 
     public void Serialize(ref EchoObject compoundTag, SerializationContext ctx)
     {
+        SerializeHeader(compoundTag);
         compoundTag.Add("Width", new(Width));
         compoundTag.Add("Height", new(Height));
         compoundTag.Add("IsMipMapped", new(IsMipmapped));
@@ -255,6 +256,8 @@ public sealed class Texture2D : Texture, ISerializable
         Type[] param = new[] { typeof(uint), typeof(uint), typeof(bool), typeof(TextureImageFormat) };
         object[] values = new object[] { Width, Height, false, imageFormat };
         typeof(Texture2D).GetConstructor(param).Invoke(this, values);
+
+        DeserializeHeader(value);
 
         Memory<byte> memory = value["Data"].ByteArrayValue;
         SetData(memory);

--- a/Prowl.Runtime/Resources/Texture3D.cs
+++ b/Prowl.Runtime/Resources/Texture3D.cs
@@ -256,6 +256,7 @@ public sealed class Texture3D : Texture, ISerializable
 
     public void Serialize(ref EchoObject compoundTag, SerializationContext ctx)
     {
+        SerializeHeader(compoundTag);
         compoundTag.Add("Width", new(Width));
         compoundTag.Add("Height", new(Height));
         compoundTag.Add("Depth", new(Depth));
@@ -283,6 +284,8 @@ public sealed class Texture3D : Texture, ISerializable
         Type[] param = new[] { typeof(uint), typeof(uint), typeof(uint), typeof(bool), typeof(TextureImageFormat) };
         object[] values = new object[] { Width, Height, Depth, false, imageFormat };
         typeof(Texture3D).GetConstructor(param).Invoke(this, values);
+
+        DeserializeHeader(value);
 
         Memory<byte> memory = value["Data"].ByteArrayValue;
         SetData(memory);


### PR DESCRIPTION
# Summary

Two small tweaks to how references display in the Editor. Currently, they always display as "New {TypeName}" or "New {TypeName} (Instance)" which can make it a little difficult to see at a glance what they are referencing. While clicking it does highlight / take to the right spot, that requires action from the user.

# Implementation

Import Result already tried to do this, but the problem was that the code never fired because Name was never null/empty. The EngineObject constructor always set it to be New {TypeName} no matter what.

Similarly, AssetRef and EngineObject just grabbed the Instance.Name, which was the EngineObject constructor default of New {TypeName}.

ImportResult just got rid of the dead guard, while in AssetRef and EngineObjectPropertyEditor I extracted out to a small helper that first checks if it is a component. If so, we use the GameObject's name and the Component's type in the display (this is a small change, previously it would always just be (Instance)). If a gameobject or asset, we use its Name (as now set properly from ImportResult). As a fallback, we use Instance still for the suffix (or None if instance is not true).

# Screenshots

Asset Reference pre-fix:
<img width="781" height="370" alt="Screenshot 2026-07-24 160458" src="https://github.com/user-attachments/assets/6408cfb3-fb17-49bb-88dc-c2f3d11e8397" />

Asset Reference post-fix:
<img width="746" height="384" alt="Screenshot 2026-07-24 160519" src="https://github.com/user-attachments/assets/30a1954f-4191-4acf-87ad-a6c9dbfc325c" />

Scene Reference pre-fix:
<img width="778" height="216" alt="Screenshot 2026-07-24 161827" src="https://github.com/user-attachments/assets/ed6ecacd-e7f7-4e4f-8a87-0a126bf6dc9c" />

Scene Reference post-fix:
<img width="774" height="174" alt="Screenshot 2026-07-24 164306" src="https://github.com/user-attachments/assets/ddad1289-ed84-4e4f-8d40-bfaee6ec66eb" />

# Notes

- This doesn't fix existing references (for assets. Scene Objects should be picked up). If an asset was created and assigned, it will need to be Reimported to be picked up in the inspector with the new name. Changing the name also appears to trigger this for what its worth.  Conveniently, the editor has a reimport all button at the top!