### PR TITLE
Fix: Cameras that are a child object are being rendered multiple times in Game View

### DIFF
--- a/Prowl.Editor/GUI/Panels/GameViewPanel.cs
+++ b/Prowl.Editor/GUI/Panels/GameViewPanel.cs
@@ -136,8 +136,13 @@ public class GameViewPanel : DockPanel
             EnsureRT(rtW, rtH);
 
             // Render all cameras
+            // ActiveObjects is a flat list, so GetComponentsInChildren (which recurses) collects a
+            // nested camera once per active ancestor - Distinct() prevents rendering it multiple
+            // times (matches Scene.Render). Without it, a parented camera renders N times, doubling
+            // every stat and doing a full duplicate color + shadow pass.
             var cameras = scene.ActiveObjects
                 .SelectMany(go => go.GetComponentsInChildren<Camera>())
+                .Distinct()
                 .Where(c => !c.GameObject.HideFlags.HasFlag(HideFlags.HideAndDontSave))
                 .OrderBy(c => c.Depth)
                 .ToList();


### PR DESCRIPTION
I wired up a stats panel and noticed it said two cameras and two directional lights were being rendered despite me only having one. Turned out its because my camera is a child object of another, and digging found this is unique to the Game View. 

Scene.Render already accounts for this exact scenario (which is also what's used for actual builds) by calling Distinct on the fetch for explicitly this reason, but Game View did not replicate it. In theory, this scales for every ancestor the camera has.

Just copied over the tweak and the same comment explaining it.