### PR TITLE
Adjust active camera fetch in Scene and GameViewPanel to prevent generating extra garbage

### DIFF
--- a/Prowl.Editor/GUI/Panels/GameViewPanel.cs
+++ b/Prowl.Editor/GUI/Panels/GameViewPanel.cs
@@ -135,17 +135,9 @@ public class GameViewPanel : DockPanel
 
             EnsureRT(rtW, rtH);
 
-            // Render all cameras
-            // ActiveObjects is a flat list, so GetComponentsInChildren (which recurses) collects a
-            // nested camera once per active ancestor - Distinct() prevents rendering it multiple
-            // times (matches Scene.Render). Without it, a parented camera renders N times, doubling
-            // every stat and doing a full duplicate color + shadow pass.
-            var cameras = scene.ActiveObjects
-                .SelectMany(go => go.GetComponentsInChildren<Camera>())
-                .Distinct()
-                .Where(c => !c.GameObject.HideFlags.HasFlag(HideFlags.HideAndDontSave))
-                .OrderBy(c => c.Depth)
-                .ToList();
+            // Render all cameras.
+            var cameras = scene.GatherActiveCameras();
+            cameras.RemoveAll(c => c.GameObject.HideFlags.HasFlag(HideFlags.HideAndDontSave));
 
             RenderStats.BeginFrame();
             foreach (var cam in cameras)

--- a/Prowl.Runtime.Test/SceneCameraGatherTests.cs
+++ b/Prowl.Runtime.Test/SceneCameraGatherTests.cs
@@ -1,0 +1,234 @@
+// This file is part of the Prowl Game Engine
+// Licensed under the MIT License. See the LICENSE file in the project root for details.
+
+using Prowl.Runtime.Resources;
+
+using Xunit;
+
+namespace Prowl.Runtime.Test;
+
+/// <summary>
+/// Guards <see cref="Scene.GatherActiveCameras"/>, which replaced a per-object
+/// <c>GetComponentsInChildren</c> recursion in Scene.Render. The flat scan must return exactly what
+/// the old recursive-plus-Distinct expression returned, for every hierarchy shape.
+/// </summary>
+public class SceneCameraGatherTests : RuntimeTestBase
+{
+    /// <summary>The exact expression Scene.Render used before the flat scan replaced it.</summary>
+    private static List<Camera> LegacyGather(Scene scene)
+    {
+        var cameras = scene.ActiveObjects
+            .SelectMany(x => x.GetComponentsInChildren<Camera>())
+            .Distinct()
+            .ToList();
+        cameras.Sort((a, b) => a.Depth.CompareTo(b.Depth));
+        return cameras;
+    }
+
+    private static void AssertMatchesLegacy(Scene scene)
+    {
+        List<Camera> expected = LegacyGather(scene);
+        List<Camera> actual = scene.GatherActiveCameras();
+
+        Assert.Equal(expected.Count, actual.Count);
+        // Same set, and same depth ordering.
+        Assert.Equal(expected.OrderBy(c => c.InstanceID), actual.OrderBy(c => c.InstanceID));
+        Assert.Equal(expected.Select(c => c.Depth), actual.Select(c => c.Depth));
+    }
+
+    [Fact]
+    public void EmptyScene_ReturnsNoCameras()
+    {
+        Scene scene = CreateScene(enable: true);
+        Assert.Empty(scene.GatherActiveCameras());
+        AssertMatchesLegacy(scene);
+    }
+
+    [Fact]
+    public void RootCamera_IsFound()
+    {
+        Scene scene = CreateScene(enable: true);
+        GameObject go = CreateGameObject("Cam");
+        go.AddComponent<Camera>();
+        scene.Add(go);
+
+        Assert.Single(scene.GatherActiveCameras());
+        AssertMatchesLegacy(scene);
+    }
+
+    [Fact]
+    public void NestedCamera_IsCountedExactlyOnce()
+    {
+        // The bug the old Distinct() existed to paper over: a camera nested under N active
+        // ancestors was collected N+1 times by the recursion.
+        Scene scene = CreateScene(enable: true);
+        GameObject root = CreateGameObject("Root");
+        GameObject mid = CreateGameObject("Mid");
+        GameObject leaf = CreateGameObject("Leaf");
+
+        mid.SetParent(root);
+        leaf.SetParent(mid);
+        leaf.AddComponent<Camera>();
+        scene.Add(root);
+
+        Assert.Single(scene.GatherActiveCameras());
+        AssertMatchesLegacy(scene);
+    }
+
+    [Fact]
+    public void DisabledGameObject_IsSkipped()
+    {
+        Scene scene = CreateScene(enable: true);
+        GameObject go = CreateGameObject("Cam");
+        go.AddComponent<Camera>();
+        scene.Add(go);
+        go.Enabled = false;
+
+        Assert.Empty(scene.GatherActiveCameras());
+        AssertMatchesLegacy(scene);
+    }
+
+    [Fact]
+    public void CameraUnderDisabledParent_IsSkipped()
+    {
+        Scene scene = CreateScene(enable: true);
+        GameObject parent = CreateGameObject("Parent");
+        GameObject child = CreateGameObject("Child");
+        child.SetParent(parent);
+        child.AddComponent<Camera>();
+        scene.Add(parent);
+
+        parent.Enabled = false;
+
+        Assert.Empty(scene.GatherActiveCameras());
+        AssertMatchesLegacy(scene);
+    }
+
+    [Fact]
+    public void MultipleCamerasOnOneGameObject_AreAllReturned()
+    {
+        Scene scene = CreateScene(enable: true);
+        GameObject go = CreateGameObject("Rig");
+        go.AddComponent<Camera>();
+        go.AddComponent<Camera>();
+        scene.Add(go);
+
+        Assert.Equal(2, scene.GatherActiveCameras().Count);
+        AssertMatchesLegacy(scene);
+    }
+
+    [Fact]
+    public void CamerasAreSortedByDepth()
+    {
+        Scene scene = CreateScene(enable: true);
+        GameObject a = CreateGameObject("A");
+        GameObject b = CreateGameObject("B");
+        GameObject c = CreateGameObject("C");
+
+        a.AddComponent<Camera>().Depth = 5;
+        b.AddComponent<Camera>().Depth = -3;
+        c.AddComponent<Camera>().Depth = 1;
+
+        scene.Add(a);
+        scene.Add(b);
+        scene.Add(c);
+
+        List<Camera> cameras = scene.GatherActiveCameras();
+        Assert.Equal([-3, 1, 5], cameras.Select(x => x.Depth));
+        AssertMatchesLegacy(scene);
+    }
+
+    [Fact]
+    public void DisabledCameraComponent_IsStillReturned()
+    {
+        // Preserved from the old expression: GetComponentsInChildren ignores the component's own
+        // Enabled flag, so Camera.Enabled = false did NOT exclude it here. Camera.Render is what
+        // honours it downstream. Locking this in so the rewrite doesn't silently change behaviour.
+        Scene scene = CreateScene(enable: true);
+        GameObject go = CreateGameObject("Cam");
+        Camera cam = go.AddComponent<Camera>();
+        scene.Add(go);
+        cam.Enabled = false;
+
+        Assert.Single(scene.GatherActiveCameras());
+        AssertMatchesLegacy(scene);
+    }
+
+    [Fact]
+    public void GatherCost_DoesNotScaleWithSceneSize()
+    {
+        // The regression this guards: Scene.Render's camera gather used to allocate O(sum of subtree
+        // sizes) worth of LINQ/iterator garbage EVERY frame - ~6 MB on a 10k-object tilemap, which
+        // dominated the engine's gen0 churn. A flat scan allocates only the result list, so cost must
+        // stay flat as the scene grows.
+        static long MeasureGather(Scene scene)
+        {
+            scene.GatherActiveCameras(); // warm up
+            long before = GC.GetAllocatedBytesForCurrentThread();
+            for (int i = 0; i < 10; i++)
+                scene.GatherActiveCameras();
+            return (GC.GetAllocatedBytesForCurrentThread() - before) / 10;
+        }
+
+        Scene small = BuildTileMap(5, 5);     // 31 objects
+        Scene large = BuildTileMap(60, 60);   // 3661 objects
+
+        long smallBytes = MeasureGather(small);
+        long largeBytes = MeasureGather(large);
+
+        // A 118x bigger scene must not cost meaningfully more. Allow generous slack for list growth.
+        Assert.True(largeBytes <= smallBytes + 256,
+            $"Camera gather scaled with scene size: {smallBytes} B at 31 objects vs {largeBytes} B at 3661 objects. " +
+            "Something reintroduced a per-object walk.");
+    }
+
+    private Scene BuildTileMap(int rows, int cols)
+    {
+        Scene scene = CreateScene(enable: true);
+        GameObject map = CreateGameObject("Map");
+
+        for (int r = 0; r < rows; r++)
+        {
+            var row = new GameObject($"Row{r}");
+            for (int c = 0; c < cols; c++)
+                new GameObject($"Tile{r}_{c}").SetParent(row);
+            row.SetParent(map);
+        }
+
+        GameObject cam = CreateGameObject("MainCamera");
+        cam.AddComponent<Camera>();
+
+        scene.Add(map);
+        scene.Add(cam);
+        return scene;
+    }
+
+    [Fact]
+    public void MixedHierarchy_MatchesLegacyExactly()
+    {
+        Scene scene = CreateScene(enable: true);
+
+        GameObject map = CreateGameObject("Map");
+        for (int r = 0; r < 5; r++)
+        {
+            var row = new GameObject($"Row{r}");
+            for (int t = 0; t < 5; t++)
+            {
+                var tile = new GameObject($"Tile{r}_{t}");
+                if (t == 2)
+                    tile.AddComponent<Camera>().Depth = r;
+                tile.SetParent(row);
+            }
+            row.SetParent(map);
+        }
+
+        GameObject loose = CreateGameObject("LooseCam");
+        loose.AddComponent<Camera>().Depth = 99;
+
+        scene.Add(map);
+        scene.Add(loose);
+
+        Assert.Equal(6, scene.GatherActiveCameras().Count);
+        AssertMatchesLegacy(scene);
+    }
+}

--- a/Prowl.Runtime/Resources/Scene.cs
+++ b/Prowl.Runtime/Resources/Scene.cs
@@ -717,6 +717,31 @@ public class Scene : EngineObject, ISerializationCallbackReceiver
     }
 
     /// <summary>
+    /// Collects every Camera on an enabled-in-hierarchy GameObject, sorted by Camera.Depth.
+    /// </summary>
+    internal List<Camera> GatherActiveCameras()
+    {
+        var cameras = new List<Camera>();
+
+        for (int i = 0; i < _allObj.Count; i++)
+        {
+            GameObject go = _allObj[i];
+            if (go.IsDisposed || !go.EnabledInHierarchy) continue;
+
+            foreach (MonoBehaviour component in go._components)
+            {
+                if (component is Camera camera)
+                {
+                    cameras.Add(camera);
+                }
+            }
+        }
+
+        cameras.Sort(static (a, b) => a.Depth.CompareTo(b.Depth));
+        return cameras;
+    }
+
+    /// <summary>
     /// Renders all cameras in this scene, sorted by depth.
     /// </summary>
     /// <param name="target">Optional render target to render into</param>
@@ -726,11 +751,7 @@ public class Scene : EngineObject, ISerializationCallbackReceiver
         EnsureNotDisposed();
         // Renderables are now collected per-camera inside pipeline.Render()
 
-        // ActiveObjects is a flat list, so GetComponentsInChildren (which recurses) would collect a
-        // child camera once per active ancestor - Distinct() prevents rendering it multiple times.
-        var Cameras = ActiveObjects.SelectMany(x => x.GetComponentsInChildren<Camera>()).Distinct().ToList();
-
-        Cameras.Sort((a, b) => a.Depth.CompareTo(b.Depth));
+        List<Camera> Cameras = GatherActiveCameras();
 
         if (Cameras.Count == 0)
             return false;


### PR DESCRIPTION
## Summary

While testing my local project for performance (it moves at a brisk walk now instead of a crawl), I noticed a very high chunk of garbage being generated leading to constant GC spikes. After some digging, it's actually related to the last PR (https://github.com/ProwlEngine/Prowl/pull/325) which ended up being a band-aid and something I should have looked into a little further than just the surface level issue.

The GetComponentsInChildren was indeed duplicating the Cameras in the Game View, but that was a symptom of a larger issue in that the LINQ calls were being run every frame, and since it recursively looped over an already flat list (_allObj), we just generated a chunk of garbage that scaled up the more objects we had, because it had more recursive searches to make.

Since Scene and GameViewPanel did the same thing, I just moved it into a single internal method to make sure this time the code is shared.  

Note: These are run with the Hierarchy disabled. There is another potential performance hiccup with the Hierarchy specifically around drawing *all rows* even if the parent is folded, but I think this may be worth a separate PR / discussions. Maybe some changes on the Anthology side (no idea where) might allow us to do some kind of virtualization like from a scroll view and only draw the rows actually visible? 

Allocation test - play mode, 600 frames per row after 200 warmup frames

## Tests

## 111 objects

| Version | Scene | Objects | Frames | Alloc/frame | Peak/frame | Total alloc | GC g0/g1/g2 |
| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: |
| Preview 2 | empty scene | 0 | 600 | 900.7 KB | 934.1 KB | 527.8 MB | 21/15/15 |
| Preview 2 | 10x10 grid | 111 | 600 | 993.2 KB | 1.0 MB | 581.9 MB | 23/17/17 |
| Fix | empty scene | 0 | 600 | 882.0 KB | 950.5 KB | 516.8 MB | 15/9/9 |
| Fix | 10x10 grid | 111 | 600 | 918.0 KB | 952.7 KB | 537.9 MB | 14/9/9 |

Grid cost — Preview 2: +92.5 KB/frame (900.7 KB -> 993.2 KB, 1.1x), +2/2/2 collections.
Grid cost — Fix: +36.0 KB/frame (882.0 KB -> 918.0 KB, 1.0x), -1/0/0 collections.

## 10,101 objects

| Version | Scene | Objects | Frames | Alloc/frame | Peak/frame | Total alloc | GC g0/g1/g2 |
| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: |
| Preview 2 | empty scene | 0 | 600 | 953.1 KB | 1022.7 KB | 558.5 MB | 25/19/19 |
| Preview 2 | 100x100 grid | 10,101 | 600 | 6.8 MB | 6.9 MB | 3.98 GB | 100/27/21 |
| Fix | empty scene | 0 | 600 | 940.5 KB | 975.0 KB | 551.1 MB | 15/10/10 |
| Fix | 100x100 grid | 10,101 | 600 | 962.4 KB | 1.0 MB | 563.9 MB | 16/10/10 |

Grid cost — Preview 2: +5.9 MB/frame (953.1 KB -> 6.8 MB, 7.3x), +75/8/2 collections.
Grid cost — Fix: +21.9 KB/frame (940.5 KB -> 962.4 KB, 1.0x), +1/0/0 collections.

## 90,301 objects

| Version | Scene | Objects | Frames | Alloc/frame | Peak/frame | Total alloc | GC g0/g1/g2 |
| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: |
| Preview 2 | empty scene | 0 | 600 | 998.8 KB | 1.0 MB | 585.3 MB | 26/21/20 |
| Preview 2 | 300x300 grid | 90,301 | 600 | 53.3 MB | 53.4 MB | 31.24 GB | 668/140/7 |
| Fix | empty scene | 0 | 600 | 982.7 KB | 1014.4 KB | 575.8 MB | 19/14/14 |
| Fix | 300x300 grid | 90,301 | 600 | 1004.8 KB | 1.0 MB | 588.7 MB | 13/11/8 |

Grid cost — Preview 2: +52.3 MB/frame (998.8 KB -> 53.3 MB, 54.7x), +642/119/-13 collections.
Grid cost — Fix: +22.1 KB/frame (982.7 KB -> 1004.8 KB, 1.0x), -6/-3/-6 collections.


Testing Component (generated by Claude) if you're interested in running locally. Just throw it on a game object and press Run Allocation Test when running. Disabling the component will delete the generated objects.
https://pastebin.com/hf6jzHkX