### PR TITLE
Add Align With View to the hierarchy context menu

### DIFF
--- a/Prowl.Editor/GUI/Panels/HierarchyPanel.cs
+++ b/Prowl.Editor/GUI/Panels/HierarchyPanel.cs
@@ -786,19 +786,34 @@ public class HierarchyPanel : DockPanel, IScriptReloadCleanup
 
             builder.Separator();
 
-            // Move to View / Move View To
+            // Move to View / Align With View / Move View To
             var cam = SceneViewPanel.ActiveCamera;
             if (cam != null)
             {
+                // Pose writes go to the top-level selection only: a GameObject whose ancestor is
+                // also selected already travels with that ancestor, so writing its world pose
+                // separately would fight the parent's write (order-dependent) and bloat the undo step.
+                var poseTargets = ExcludeNestedSelections(selectedGOs);
+
+                // Position only, at the centre of the view - rotation is deliberately untouched.
                 builder.Item(Loc.Get("hierarchy.move_to_view"), () =>
                 {
-                    foreach (var go in selectedGOs)
-                    {
-                        go.Transform.Position = cam.Position;
-                        go.Transform.LocalEulerAngles = new Float3(cam.Pitch, cam.Yaw, 0);
-                    }
+                    Undo.ApplyGameObjectChanges(poseTargets, "Move to View",
+                        g => g.Transform.Position,
+                        (g, position) => g.Transform.Position = position,
+                        cam.ViewFocusPoint);
                     EditorSceneManager.MarkDirty();
                 }, icon: EditorIcons.ArrowRight);
+
+                // Position *and* rotation, so the object looks exactly where the view looks.
+                builder.Item(Loc.Get("hierarchy.align_with_view"), () =>
+                {
+                    Undo.ApplyGameObjectChanges<(Float3 Position, Quaternion Rotation)>(poseTargets, "Align With View",
+                        g => (g.Transform.Position, g.Transform.Rotation),
+                        (g, pose) => g.Transform.SetPositionAndRotation(pose.Position, pose.Rotation),
+                        (cam.Position, cam.Rotation));
+                    EditorSceneManager.MarkDirty();
+                }, icon: EditorIcons.ArrowsToEye);
 
                 builder.Item(Loc.Get("hierarchy.move_view_to"), () =>
                 {

--- a/Prowl.Editor/GUI/SceneView/EditorCamera.cs
+++ b/Prowl.Editor/GUI/SceneView/EditorCamera.cs
@@ -76,6 +76,16 @@ public class EditorCamera
     public float Pitch => _pitch;
     public Float3 Forward => _cameraObject.Transform.Forward;
 
+    /// <summary>World rotation matching the camera's current yaw/pitch.</summary>
+    public Quaternion Rotation => _cameraObject.Transform.Rotation;
+
+    /// <summary>
+    /// The point the view is centred on: straight ahead of the camera at the current orbit/zoom
+    /// distance. "Move to View" drops objects here so they land in front of the camera instead of
+    /// inside it (where they'd be clipped away by the near plane).
+    /// </summary>
+    public Float3 ViewFocusPoint => _position + _cameraObject.Transform.Forward * _orbitDistance;
+
     /// <summary>Set the camera position directly.</summary>
     public void SetPosition(Float3 position)
     {

--- a/Prowl.Editor/Resources/Locale/de.json
+++ b/Prowl.Editor/Resources/Locale/de.json
@@ -153,6 +153,7 @@
   "hierarchy.drop_to_spawn": "Hier ablegen zum Erstellen",
   "hierarchy.scene_empty": "Szene ist leer",
   "hierarchy.move_to_view": "Zur Ansicht bewegen",
+  "hierarchy.align_with_view": "An Ansicht ausrichten",
   "hierarchy.move_view_to": "Ansicht bewegen zu",
   "hierarchy.select_prefab_asset": "Prefab-Asset auswaehlen",
   "hierarchy.apply_prefab_overrides": "Prefab-Aenderungen anwenden",

--- a/Prowl.Editor/Resources/Locale/en.json
+++ b/Prowl.Editor/Resources/Locale/en.json
@@ -154,6 +154,7 @@
   "hierarchy.drop_to_spawn": "Drop to spawn here",
   "hierarchy.scene_empty": "Scene is empty",
   "hierarchy.move_to_view": "Move to View",
+  "hierarchy.align_with_view": "Align With View",
   "hierarchy.move_view_to": "Move View To",
   "hierarchy.select_prefab_asset": "Select Prefab Asset",
   "hierarchy.apply_prefab_overrides": "Apply Prefab Overrides",

--- a/Prowl.Editor/Resources/Locale/es.json
+++ b/Prowl.Editor/Resources/Locale/es.json
@@ -153,6 +153,7 @@
   "hierarchy.drop_to_spawn": "Soltar para crear aqui",
   "hierarchy.scene_empty": "La escena esta vacia",
   "hierarchy.move_to_view": "Mover a la vista",
+  "hierarchy.align_with_view": "Alinear con la vista",
   "hierarchy.move_view_to": "Mover vista hacia",
   "hierarchy.select_prefab_asset": "Seleccionar asset Prefab",
   "hierarchy.apply_prefab_overrides": "Aplicar cambios de Prefab",

--- a/Prowl.Editor/Resources/Locale/fr.json
+++ b/Prowl.Editor/Resources/Locale/fr.json
@@ -153,6 +153,7 @@
   "hierarchy.drop_to_spawn": "Deposer pour creer ici",
   "hierarchy.scene_empty": "La scene est vide",
   "hierarchy.move_to_view": "Deplacer vers la vue",
+  "hierarchy.align_with_view": "Aligner sur la vue",
   "hierarchy.move_view_to": "Deplacer la vue vers",
   "hierarchy.select_prefab_asset": "Selectionner l'asset Prefab",
   "hierarchy.apply_prefab_overrides": "Appliquer les modifications Prefab",

--- a/Prowl.Editor/Resources/Locale/it.json
+++ b/Prowl.Editor/Resources/Locale/it.json
@@ -175,6 +175,7 @@
   "hierarchy.drop_to_spawn": "Rilascia per creare qui",
   "hierarchy.scene_empty": "La scena e vuota",
   "hierarchy.move_to_view": "Sposta alla vista",
+  "hierarchy.align_with_view": "Allinea alla vista",
   "hierarchy.move_view_to": "Sposta vista verso",
   "hierarchy.select_prefab_asset": "Seleziona asset Prefab",
   "hierarchy.apply_prefab_overrides": "Applica modifiche Prefab",

--- a/Prowl.Editor/Resources/Locale/ja.json
+++ b/Prowl.Editor/Resources/Locale/ja.json
@@ -153,6 +153,7 @@
   "hierarchy.drop_to_spawn": "ここにドロップして生成",
   "hierarchy.scene_empty": "シーンは空です",
   "hierarchy.move_to_view": "ビューに移動",
+  "hierarchy.align_with_view": "ビューに合わせる",
   "hierarchy.move_view_to": "ビューを移動",
   "hierarchy.select_prefab_asset": "プレハブアセットを選択",
   "hierarchy.apply_prefab_overrides": "プレハブの変更を適用",

--- a/Prowl.Editor/Resources/Locale/ko.json
+++ b/Prowl.Editor/Resources/Locale/ko.json
@@ -175,6 +175,7 @@
   "hierarchy.drop_to_spawn": "여기에 놓아서 생성",
   "hierarchy.scene_empty": "씬이 비어 있습니다",
   "hierarchy.move_to_view": "뷰로 이동",
+  "hierarchy.align_with_view": "뷰에 정렬",
   "hierarchy.move_view_to": "뷰를 이동",
   "hierarchy.select_prefab_asset": "프리팹 에셋 선택",
   "hierarchy.apply_prefab_overrides": "프리팹 변경사항 적용",

--- a/Prowl.Editor/Resources/Locale/pl.json
+++ b/Prowl.Editor/Resources/Locale/pl.json
@@ -175,6 +175,7 @@
   "hierarchy.drop_to_spawn": "Upusc aby utworzyc tutaj",
   "hierarchy.scene_empty": "Scena jest pusta",
   "hierarchy.move_to_view": "Przenies do widoku",
+  "hierarchy.align_with_view": "Wyrownaj do widoku",
   "hierarchy.move_view_to": "Przenies widok do",
   "hierarchy.select_prefab_asset": "Wybierz asset Prefab",
   "hierarchy.apply_prefab_overrides": "Zastosuj zmiany Prefab",

--- a/Prowl.Editor/Resources/Locale/pt.json
+++ b/Prowl.Editor/Resources/Locale/pt.json
@@ -175,6 +175,7 @@
   "hierarchy.drop_to_spawn": "Solte para criar aqui",
   "hierarchy.scene_empty": "A cena esta vazia",
   "hierarchy.move_to_view": "Mover para a vista",
+  "hierarchy.align_with_view": "Alinhar com a vista",
   "hierarchy.move_view_to": "Mover vista para",
   "hierarchy.select_prefab_asset": "Selecionar asset Prefab",
   "hierarchy.apply_prefab_overrides": "Aplicar alteracoes do Prefab",

--- a/Prowl.Editor/Resources/Locale/ru.json
+++ b/Prowl.Editor/Resources/Locale/ru.json
@@ -175,6 +175,7 @@
   "hierarchy.drop_to_spawn": "Перетащите для создания",
   "hierarchy.scene_empty": "Сцена пуста",
   "hierarchy.move_to_view": "Переместить к виду",
+  "hierarchy.align_with_view": "Выровнять по виду",
   "hierarchy.move_view_to": "Переместить вид к",
   "hierarchy.select_prefab_asset": "Выбрать ассет префаба",
   "hierarchy.apply_prefab_overrides": "Применить изменения префаба",

--- a/Prowl.Editor/Resources/Locale/tr.json
+++ b/Prowl.Editor/Resources/Locale/tr.json
@@ -175,6 +175,7 @@
   "hierarchy.drop_to_spawn": "Olusturmak icin birakin",
   "hierarchy.scene_empty": "Sahne bos",
   "hierarchy.move_to_view": "Gorunume tasi",
+  "hierarchy.align_with_view": "Gorunumle hizala",
   "hierarchy.move_view_to": "Gorunumu tasi",
   "hierarchy.select_prefab_asset": "Prefab varligini sec",
   "hierarchy.apply_prefab_overrides": "Prefab degisikliklerini uygula",

--- a/Prowl.Editor/Resources/Locale/zh.json
+++ b/Prowl.Editor/Resources/Locale/zh.json
@@ -175,6 +175,7 @@
   "hierarchy.drop_to_spawn": "拖放到此处生成",
   "hierarchy.scene_empty": "场景为空",
   "hierarchy.move_to_view": "移动到视图",
+  "hierarchy.align_with_view": "对齐到视图",
   "hierarchy.move_view_to": "将视图移动到",
   "hierarchy.select_prefab_asset": "选择预制体资源",
   "hierarchy.apply_prefab_overrides": "应用预制体修改",


### PR DESCRIPTION
Adds Unity's **Align With View** to the GameObject context menu in the Hierarchy: it moves the selected object(s) to the scene view camera's position *and* rotation, so the object ends up looking exactly where the view looks. Handy for placing cameras and spotlights — fly the view to the shot you want, then align.

### Why "Move to View" changed too

The existing `Move to View` already applied position **and** rotation, which is exactly what Align With View means — so adding Align With View on its own would have produced two menu entries doing the same thing, and nothing doing Unity's actual Move to View.

`Move to View` now moves objects to the centre of the view and leaves rotation untouched, matching Unity. The two commands are distinct:

| Command | Position | Rotation |
| --- | --- | --- |
| Move to View | centre of the view | unchanged |
| **Align With View** (new) | camera position | camera rotation |
| Move View To | — | moves the camera to the object |

### Other fixes in the touched code

Both commands now:

- **Register a single undo step.** `Move to View` previously recorded no undo at all, so a misclick permanently lost the object's old transform.
- **Write world-space rotation** via `SetPositionAndRotation` instead of assigning the camera's *world* angles to `LocalEulerAngles`, which produced the wrong orientation for a child of a rotated parent.
- **Apply to the top-level selection only** (`ExcludeNestedSelections`), matching Unity's `Selection.transforms`. A child whose parent is also selected already travels with the parent, so writing its world pose separately fought the parent's write and made the outcome depend on iteration order.

`EditorCamera` gains two members: `Rotation` (world rotation from the current yaw/pitch) and `ViewFocusPoint` (the point the view is centred on). `Move to View` drops objects at the focus point rather than at the camera itself, where the near plane would clip them out of sight.

`hierarchy.align_with_view` is added to all 12 locale files, following each file's existing convention (fr/pl/tr are ASCII-only).

### Testing

Built clean and verified in the editor: align on a root object and on a child of a rotated parent, undo/redo for both commands, multi-selection including a parent + child pair, and that `Move to View` no longer disturbs rotation.
