### PR TITLE
Add a + button to the Hierarchy and Unity's Create Empty Child/Parent

### DIFF
--- a/Prowl.Editor/Core/EditorApplication.cs
+++ b/Prowl.Editor/Core/EditorApplication.cs
@@ -716,7 +716,14 @@ public class EditorApplication : Game
             var bar = Origami.MenuBar(paper, "menubar").Height(barH);
             foreach (var root in MenuRegistry.RootMenus)
                 if (root.HasSubItems)
-                    bar.Menu(root.Label, ctx => BuildMenu(ctx, root.SubItems));
+                    bar.Menu(root.Label, ctx =>
+                    {
+                        // A menu-bar dropdown has no object of its own to act on, so drop any pin a
+                        // panel's right-click menu left behind; GameObject/... then creates under the
+                        // active selection instead of wherever that menu was last opened.
+                        MenuContext.Clear();
+                        BuildMenu(ctx, root.SubItems);
+                    });
             bar.Show();
 
             // Quick-access to Preferences > Theme (theming is a big part of the editor now).

--- a/Prowl.Editor/Core/MenuItem.cs
+++ b/Prowl.Editor/Core/MenuItem.cs
@@ -12,8 +12,33 @@ namespace Prowl.Editor;
 
 public static class MenuContext
 {
-    public static GameObject? ActiveGameObject { get; private set; }
-    public static void Set(GameObject? go) => ActiveGameObject = go;
+    private static GameObject? _pinned;
+    private static bool _isPinned;
+
+    /// <summary>
+    /// The GameObject that a "GameObject/..." menu action parents its result to. Menus that carry a
+    /// context of their own - the hierarchy's row and background menus - pin it explicitly; every
+    /// other entry point (the main menu bar, the hierarchy's + button) leaves it unpinned so new
+    /// objects land under the active selection, which is what the equivalent menu does in Unity.
+    /// A pin to a since-destroyed object falls back to the scene root.
+    /// </summary>
+    public static GameObject? ActiveGameObject => _isPinned
+        ? (_pinned.IsValid() ? _pinned : null)
+        : Selection.GetSelected<GameObject>().FirstOrDefault();
+
+    /// <summary>Pin the context to <paramref name="go"/>, or to the scene root when it is null.</summary>
+    public static void Set(GameObject? go)
+    {
+        _pinned = go;
+        _isPinned = true;
+    }
+
+    /// <summary>Drop the pin so the context follows the active selection again.</summary>
+    public static void Clear()
+    {
+        _pinned = null;
+        _isPinned = false;
+    }
 }
 
 [AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]

--- a/Prowl.Editor/Core/ShortcutManager.cs
+++ b/Prowl.Editor/Core/ShortcutManager.cs
@@ -308,6 +308,8 @@ internal static class BuiltInShortcuts
         ShortcutManager.Register("Hierarchy/Copy", "Copy Selected", KeyCode.C, ctrl: true);
         ShortcutManager.Register("Hierarchy/Paste", "Paste", KeyCode.V, ctrl: true);
         ShortcutManager.Register("Hierarchy/Rename", "Rename Selected", KeyCode.F2);
+        ShortcutManager.Register("Hierarchy/CreateEmptyChild", "Create Empty Child", KeyCode.N, shift: true, alt: true);
+        ShortcutManager.Register("Hierarchy/CreateEmptyParent", "Create Empty Parent", KeyCode.G, ctrl: true, shift: true);
 
         // Project
         ShortcutManager.Register("Project/Delete", "Delete Selected", KeyCode.Delete);

--- a/Prowl.Editor/Core/Undo.cs
+++ b/Prowl.Editor/Core/Undo.cs
@@ -321,13 +321,27 @@ public static class Undo
 
     private static void FlushCreatedObject(GameObject go, string description)
     {
-        // Now serialize all components have been added by this point
+        var (undo, redo) = CaptureCreatedObject(go);
+        _pendingActions.Add((description, new ActionRecord(undo, redo)));
+    }
+
+    /// <summary>
+    /// Build the undo/redo pair for a just-created GameObject without pushing it as its own step,
+    /// so a compound operation can hand it to <see cref="RegisterActionGroup"/> together with the
+    /// follow-up actions that depend on it (e.g. "Create Empty Parent" = new object + reparenting).
+    /// Splitting those across two steps would let the object be destroyed while the objects moved
+    /// under it still live there, taking them down with it.
+    /// Unlike <see cref="RegisterCreatedObject"/> this serializes immediately, so call it while the
+    /// object is still in the state redo should restore it to - before the follow-up actions run.
+    /// </summary>
+    public static (Action undo, Action redo) CaptureCreatedObject(GameObject go)
+    {
         var serialized = Serializer.Serialize(typeof(object), go);
         var goId = go.Identifier;
         var parentId = go.Parent?.Identifier ?? Guid.Empty;
         var siblingIndex = go.Parent != null ? go.Parent.Children.IndexOf(go) : -1;
 
-        _pendingActions.Add((description, new ActionRecord(
+        return (
             undo: () =>
             {
                 var scene = Scene.Current;
@@ -366,7 +380,7 @@ public static class Undo
 
                 Selection.Select(restored);
                 EditorSceneManager.MarkDirty();
-            })));
+            });
     }
 
     /// <summary>

--- a/Prowl.Editor/GUI/DefaultGameObjectCreators.cs
+++ b/Prowl.Editor/GUI/DefaultGameObjectCreators.cs
@@ -1,3 +1,6 @@
+using System.Linq;
+
+using Prowl.Editor.Core;
 using Prowl.Editor.GUI.Panels;
 using Prowl.Editor.Projects;
 using Prowl.Editor.Theming;
@@ -18,6 +21,25 @@ internal static class DefaultGameObjectCreators
     {
         HierarchyPanel.CreateGameObject("GameObject", MenuContext.ActiveGameObject);
     }
+
+    [MenuItem("GameObject/Empty Child", priority: 1, Icon = EditorIcons.Sitemap)]
+    static void CreateEmptyChild()
+    {
+        var parent = MenuContext.ActiveGameObject;
+        if (parent == null) return;
+        HierarchyPanel.CreateGameObject("GameObject", parent);
+    }
+
+    // Nothing to parent to from the scene-root menu, or with an empty selection.
+    [MenuItem("GameObject/Empty Child", isValidate: true)]
+    static bool ValidateCreateEmptyChild() => MenuContext.ActiveGameObject != null;
+
+    [MenuItem("GameObject/Empty Parent", priority: 2, Icon = EditorIcons.ObjectGroup)]
+    static void CreateEmptyParent() => HierarchyPanel.CreateEmptyParent();
+
+    // Wrapping is defined by what's selected, not by where the menu was opened.
+    [MenuItem("GameObject/Empty Parent", isValidate: true)]
+    static bool ValidateCreateEmptyParent() => Selection.GetSelected<GameObject>().Any();
 
     [MenuItem("GameObject/3D Object/Cube", priority: 10, Icon = EditorIcons.Cube, Separator = true)]
     static void CreateCube() => CreatePrimitive("Cube", DefaultModel.Cube);

--- a/Prowl.Editor/GUI/Panels/HierarchyPanel.cs
+++ b/Prowl.Editor/GUI/Panels/HierarchyPanel.cs
@@ -177,6 +177,27 @@ public class HierarchyPanel : DockPanel
                     .TextColor(EditorTheme.Ink500)
                     .FontSize(EditorTheme.FontSizeSmall)
                     .Alignment(TextAlignment.MiddleLeft);
+
+                // Create menu without having to hunt for empty space to right-click. It fills the
+                // header row bar a pixel each side, so its hover fill sits inside the row instead of
+                // against the border, and the glyph is sized to the button so the plus reads at a
+                // glance. Stops propagation so clicking it doesn't also collapse the scene section.
+                float addSize = EditorTheme.RowHeight - 2f;
+                paper.Box("hier_scene_add")
+                    .Width(addSize).Height(addSize).Rounded(6)
+                    .Margin(0, 0, UnitValue.StretchOne, UnitValue.StretchOne)
+                    .Hovered.BackgroundColor(EditorTheme.Hover).End()
+                    .Text(EditorIcons.Plus, font)
+                    .TextColor(EditorTheme.Ink400)
+                    .Hovered.TextColor(EditorTheme.Ink500).End()
+                    .FontSize(addSize).Alignment(TextAlignment.MiddleCenter)
+                    .Tooltip(Loc.Get("hierarchy.create"))
+                    .StopEventPropagation()
+                    .OnClick(0, (_, _) => Origami.ContextMenu((float)paper.PointerPos.X, (float)paper.PointerPos.Y, b =>
+                    {
+                        b.Header(Loc.Get("hierarchy.create"));
+                        BuildCreateMenuForSelection(b);
+                    }));
             }
 
             if (!_sceneExpanded)
@@ -219,6 +240,16 @@ public class HierarchyPanel : DockPanel
                         var first = Selection.GetSelected<GameObject>().FirstOrDefault();
                         if (first != null)
                             StartRenameGO(first, Selection.GetSelected<GameObject>());
+                    }
+                    else if (ShortcutManager.IsPressed("Hierarchy/CreateEmptyChild"))
+                    {
+                        // A shortcut has no menu behind it, so it acts on the selection directly.
+                        // With nothing selected the new object lands at the scene root.
+                        CreateGameObject("GameObject", Selection.GetSelected<GameObject>().FirstOrDefault());
+                    }
+                    else if (ShortcutManager.IsPressed("Hierarchy/CreateEmptyParent"))
+                    {
+                        CreateEmptyParent();
                     }
                 }
 
@@ -543,14 +574,10 @@ public class HierarchyPanel : DockPanel
                 continue;
 
             // Block moving a prefab child out of its parent
-            if (dragged.Parent != null && dragged.Parent.IsPrefabInstance && dragged.Parent.PrefabChildCount >= 0)
+            if (IsPrefabStructuralChild(dragged))
             {
-                int dragChildIdx = dragged.Parent.Children.IndexOf(dragged);
-                if (dragChildIdx >= 0 && dragChildIdx < dragged.Parent.PrefabChildCount)
-                {
-                    Toasts.Show(Loc.Get("toast.prefab_structure"), Loc.Get("toast.prefab_cant_move"), ToastType.Warning, 3f);
-                    continue;
-                }
+                Toasts.Show(Loc.Get("toast.prefab_structure"), Loc.Get("toast.prefab_cant_move"), ToastType.Warning, 3f);
+                continue;
             }
 
             // Capture state for undo (BEFORE the move)
@@ -702,8 +729,8 @@ public class HierarchyPanel : DockPanel
     {
         Origami.RightClickMenu(paper, "hier_bg_ctx", builder =>
         {
-            builder.Header("Create");
-            BuildCreateMenu(builder, null);
+            builder.Header(Loc.Get("hierarchy.create"));
+            BuildCreateMenuFor(builder, null);
         });
     }
 
@@ -720,7 +747,7 @@ public class HierarchyPanel : DockPanel
             builder.Title(multiSelect ? Loc.Get("project.item_count", new { count = Selection.Count }) : firstSelected.Name, iconDraw: GetGoStyle(firstSelected).icon);
 
             // Create parent to first selected
-            builder.Submenu("Create", (b) => { BuildCreateMenu(b, firstSelected); }, EditorIcons.Plus);
+            builder.Submenu(Loc.Get("hierarchy.create"), (b) => { BuildCreateMenuFor(b, firstSelected); }, EditorIcons.Plus);
 
             builder.Separator();
 
@@ -866,9 +893,19 @@ public class HierarchyPanel : DockPanel
     //  Create Menu
     // ================================================================
 
-    private void BuildCreateMenu(ContextBuilder builder, GameObject? parent)
+    /// <summary>Create menu for a menu that knows what it was opened over: <paramref name="parent"/>
+    /// for a GameObject row, null for empty space (meaning the scene root).</summary>
+    private static void BuildCreateMenuFor(ContextBuilder builder, GameObject? parent)
     {
         MenuContext.Set(parent);
+        MenuItemAttribute.BuildContextMenu(builder, "GameObject");
+    }
+
+    /// <summary>Create menu with no object of its own - new objects land under the active selection,
+    /// matching the main menu bar's GameObject menu.</summary>
+    private static void BuildCreateMenuForSelection(ContextBuilder builder)
+    {
+        MenuContext.Clear();
         MenuItemAttribute.BuildContextMenu(builder, "GameObject");
     }
 
@@ -894,23 +931,140 @@ public class HierarchyPanel : DockPanel
         Undo.RegisterCreatedObject(go, "Create GameObject");
 
         if (beginRename)
-        {
-            Selection.FastPing(go.Identifier);
-            // Enter rename via global overlay
-            string goIdStr = go.Identifier.ToString();
-            var goGuid = go.Identifier;
-            RenameOverlay.Begin(goIdStr, go.Name, newName =>
-            {
-                var oldName = go.Name;
-                Undo.RegisterAction("Rename",
-                    () => { var r = Undo.FindGO(goGuid); if (r != null) r.Name = oldName; },
-                    () => { var r = Undo.FindGO(goGuid); if (r != null) r.Name = newName; });
-                go.Name = newName;
-                EditorSceneManager.MarkDirty();
-            });
-        }
+            BeginRenameNewGameObject(go);
 
         return go;
+    }
+
+    /// <summary>Ping a freshly created GameObject and open the inline rename overlay on it, so the
+    /// user can type the name straight away.</summary>
+    private static void BeginRenameNewGameObject(GameObject go)
+    {
+        Selection.FastPing(go.Identifier);
+        // Enter rename via global overlay
+        string goIdStr = go.Identifier.ToString();
+        var goGuid = go.Identifier;
+        RenameOverlay.Begin(goIdStr, go.Name, newName =>
+        {
+            var oldName = go.Name;
+            Undo.RegisterAction("Rename",
+                () => { var r = Undo.FindGO(goGuid); if (r != null) r.Name = oldName; },
+                () => { var r = Undo.FindGO(goGuid); if (r != null) r.Name = newName; });
+            go.Name = newName;
+            EditorSceneManager.MarkDirty();
+        });
+    }
+
+    /// <summary>
+    /// Wraps the current selection in a new empty GameObject, Unity's "Create Empty Parent". The new
+    /// parent takes over the first selected object's slot - same parent, same sibling index - and
+    /// sits at the centre of the selection so the group's pivot lands among the objects rather than
+    /// at the world origin. Children keep their world transforms.
+    /// </summary>
+    internal static void CreateEmptyParent()
+    {
+        var scene = Scene.Current;
+        if (scene == null) return;
+
+        // Only the top-level selection moves: an object whose ancestor is also selected already
+        // travels with that ancestor, and reparenting it too would flatten it out of its own parent.
+        var targets = ExcludeNestedSelections(Selection.GetSelected<GameObject>().ToList());
+        if (targets.Count == 0) return;
+
+        foreach (var target in targets)
+        {
+            if (IsPrefabStructuralChild(target))
+            {
+                Toasts.Show(Loc.Get("toast.prefab_structure"), Loc.Get("toast.prefab_cant_move"), ToastType.Warning, 3f);
+                return;
+            }
+        }
+
+        // The first selected object anchors the group: the new parent drops into its place in the
+        // hierarchy, so the wrapped objects stay where they were in the tree.
+        var anchor = targets[0];
+        var anchorParent = anchor.Parent.IsValid() ? anchor.Parent : null;
+        int anchorIndex = anchorParent != null ? (anchor.GetSiblingIndex() ?? -1) : scene.GetRootIndex(anchor);
+
+        Float3 centre = Float3.Zero;
+        foreach (var target in targets)
+            centre += target.Transform.Position;
+        centre /= targets.Count;
+
+        var newParent = new GameObject("GameObject");
+        scene.Add(newParent);
+        if (anchorParent != null)
+        {
+            newParent.SetParent(anchorParent);
+            if (anchorIndex >= 0) newParent.SetSiblingIndex(anchorIndex);
+        }
+        else if (anchorIndex >= 0)
+        {
+            scene.SetRootIndex(newParent, anchorIndex);
+        }
+        newParent.Transform.Position = centre;
+
+        // Capture the new parent while it is still empty, then move the selection into it. Undo runs
+        // the records in reverse, so the objects leave before the parent is destroyed instead of
+        // being deleted along with it.
+        var actions = new List<(Action undo, Action redo)> { Undo.CaptureCreatedObject(newParent) };
+        foreach (var target in targets)
+            actions.Add(ReparentWithUndo(target, newParent));
+        Undo.RegisterActionGroup("Create Empty Parent", actions);
+
+        Selection.Select(newParent);
+        BeginRenameNewGameObject(newParent);
+        EditorSceneManager.MarkDirty();
+    }
+
+    /// <summary>Move <paramref name="go"/> under <paramref name="newParent"/> and return the
+    /// undo/redo pair that replays the move, resolving both objects by identifier so the records
+    /// survive destroy/recreate cycles.</summary>
+    private static (Action undo, Action redo) ReparentWithUndo(GameObject go, GameObject newParent)
+    {
+        Guid goId = go.Identifier;
+        Guid newParentId = newParent.Identifier;
+        var oldParent = go.Parent.IsValid() ? go.Parent : null;
+        Guid oldParentId = oldParent?.Identifier ?? Guid.Empty;
+        int oldIndex = oldParent != null ? (go.GetSiblingIndex() ?? -1) : (Scene.Current?.GetRootIndex(go) ?? -1);
+
+        go.SetParent(newParent);
+
+        return (
+            undo: () =>
+            {
+                var scene = Scene.Current;
+                var g = Undo.FindGO(goId);
+                if (scene == null || g == null) return;
+                if (oldParentId == Guid.Empty)
+                {
+                    g.SetParent(default);
+                    if (oldIndex >= 0) scene.SetRootIndex(g, oldIndex);
+                }
+                else
+                {
+                    var p = Undo.FindGO(oldParentId);
+                    if (p == null) return;
+                    g.SetParent(p);
+                    if (oldIndex >= 0) g.SetSiblingIndex(oldIndex);
+                }
+            },
+            redo: () =>
+            {
+                var g = Undo.FindGO(goId);
+                var p = Undo.FindGO(newParentId);
+                if (g != null && p != null) g.SetParent(p);
+            });
+    }
+
+    /// <summary>True when the GameObject is part of its parent prefab instance's fixed structure.
+    /// Those children can't be deleted or reparented without breaking the link to the prefab.</summary>
+    private static bool IsPrefabStructuralChild(GameObject go)
+    {
+        var parent = go.Parent;
+        if (!parent.IsValid() || !parent!.IsPrefabInstance || parent.PrefabChildCount < 0) return false;
+        int index = parent.Children.IndexOf(go);
+        return index >= 0 && index < parent.PrefabChildCount;
     }
 
     private void StartRenameGO(GameObject primary, IEnumerable<GameObject> allTargets)
@@ -935,14 +1089,10 @@ public class HierarchyPanel : DockPanel
     internal static void DeleteGameObject(GameObject go)
     {
         // Block deleting prefab children that are part of the prefab structure
-        if (go.Parent != null && go.Parent.IsPrefabInstance && go.Parent.PrefabChildCount >= 0)
+        if (IsPrefabStructuralChild(go))
         {
-            int childIdx = go.Parent.Children.IndexOf(go);
-            if (childIdx >= 0 && childIdx < go.Parent.PrefabChildCount)
-            {
-                Toasts.Show(Loc.Get("toast.prefab_structure"), Loc.Get("toast.prefab_cant_delete"), ToastType.Warning, 3f);
-                return;
-            }
+            Toasts.Show(Loc.Get("toast.prefab_structure"), Loc.Get("toast.prefab_cant_delete"), ToastType.Warning, 3f);
+            return;
         }
 
         var scene = Scene.Current;

--- a/Prowl.Editor/Resources/Locale/de.json
+++ b/Prowl.Editor/Resources/Locale/de.json
@@ -150,6 +150,7 @@
   "hierarchy.save_and_exit": "Speichern & Beenden",
   "hierarchy.no_scene_loaded": "Keine Szene geladen",
   "hierarchy.new_scene": "Neue Szene",
+  "hierarchy.create": "Erstellen",
   "hierarchy.drop_to_spawn": "Hier ablegen zum Erstellen",
   "hierarchy.scene_empty": "Szene ist leer",
   "hierarchy.move_to_view": "Zur Ansicht bewegen",

--- a/Prowl.Editor/Resources/Locale/en.json
+++ b/Prowl.Editor/Resources/Locale/en.json
@@ -151,6 +151,7 @@
   "hierarchy.save_and_exit": "Save & Exit",
   "hierarchy.no_scene_loaded": "No Scene Loaded",
   "hierarchy.new_scene": "New Scene",
+  "hierarchy.create": "Create",
   "hierarchy.drop_to_spawn": "Drop to spawn here",
   "hierarchy.scene_empty": "Scene is empty",
   "hierarchy.move_to_view": "Move to View",

--- a/Prowl.Editor/Resources/Locale/es.json
+++ b/Prowl.Editor/Resources/Locale/es.json
@@ -150,6 +150,7 @@
   "hierarchy.save_and_exit": "Guardar y Salir",
   "hierarchy.no_scene_loaded": "Sin escena cargada",
   "hierarchy.new_scene": "Nueva escena",
+  "hierarchy.create": "Crear",
   "hierarchy.drop_to_spawn": "Soltar para crear aqui",
   "hierarchy.scene_empty": "La escena esta vacia",
   "hierarchy.move_to_view": "Mover a la vista",

--- a/Prowl.Editor/Resources/Locale/fr.json
+++ b/Prowl.Editor/Resources/Locale/fr.json
@@ -150,6 +150,7 @@
   "hierarchy.save_and_exit": "Enregistrer & Quitter",
   "hierarchy.no_scene_loaded": "Aucune scene chargee",
   "hierarchy.new_scene": "Nouvelle scene",
+  "hierarchy.create": "Creer",
   "hierarchy.drop_to_spawn": "Deposer pour creer ici",
   "hierarchy.scene_empty": "La scene est vide",
   "hierarchy.move_to_view": "Deplacer vers la vue",

--- a/Prowl.Editor/Resources/Locale/it.json
+++ b/Prowl.Editor/Resources/Locale/it.json
@@ -173,6 +173,7 @@
   "hierarchy.save_and_exit": "Salva ed Esci",
   "hierarchy.no_scene_loaded": "Nessuna scena caricata",
   "hierarchy.new_scene": "Nuova scena",
+  "hierarchy.create": "Crea",
   "hierarchy.drop_to_spawn": "Rilascia per creare qui",
   "hierarchy.scene_empty": "La scena e vuota",
   "hierarchy.move_to_view": "Sposta alla vista",

--- a/Prowl.Editor/Resources/Locale/ja.json
+++ b/Prowl.Editor/Resources/Locale/ja.json
@@ -150,6 +150,7 @@
   "hierarchy.save_and_exit": "保存して終了",
   "hierarchy.no_scene_loaded": "シーンが読み込まれていません",
   "hierarchy.new_scene": "新しいシーン",
+  "hierarchy.create": "作成",
   "hierarchy.drop_to_spawn": "ここにドロップして生成",
   "hierarchy.scene_empty": "シーンは空です",
   "hierarchy.move_to_view": "ビューに移動",

--- a/Prowl.Editor/Resources/Locale/ko.json
+++ b/Prowl.Editor/Resources/Locale/ko.json
@@ -173,6 +173,7 @@
   "hierarchy.save_and_exit": "저장 후 종료",
   "hierarchy.no_scene_loaded": "로드된 씬 없음",
   "hierarchy.new_scene": "새 씬",
+  "hierarchy.create": "만들기",
   "hierarchy.drop_to_spawn": "여기에 놓아서 생성",
   "hierarchy.scene_empty": "씬이 비어 있습니다",
   "hierarchy.move_to_view": "뷰로 이동",

--- a/Prowl.Editor/Resources/Locale/pl.json
+++ b/Prowl.Editor/Resources/Locale/pl.json
@@ -173,6 +173,7 @@
   "hierarchy.save_and_exit": "Zapisz i wyjdz",
   "hierarchy.no_scene_loaded": "Brak zaladowanej sceny",
   "hierarchy.new_scene": "Nowa scena",
+  "hierarchy.create": "Utworz",
   "hierarchy.drop_to_spawn": "Upusc aby utworzyc tutaj",
   "hierarchy.scene_empty": "Scena jest pusta",
   "hierarchy.move_to_view": "Przenies do widoku",

--- a/Prowl.Editor/Resources/Locale/pt.json
+++ b/Prowl.Editor/Resources/Locale/pt.json
@@ -173,6 +173,7 @@
   "hierarchy.save_and_exit": "Salvar e Sair",
   "hierarchy.no_scene_loaded": "Nenhuma cena carregada",
   "hierarchy.new_scene": "Nova cena",
+  "hierarchy.create": "Criar",
   "hierarchy.drop_to_spawn": "Solte para criar aqui",
   "hierarchy.scene_empty": "A cena esta vazia",
   "hierarchy.move_to_view": "Mover para a vista",

--- a/Prowl.Editor/Resources/Locale/ru.json
+++ b/Prowl.Editor/Resources/Locale/ru.json
@@ -173,6 +173,7 @@
   "hierarchy.save_and_exit": "Сохранить и выйти",
   "hierarchy.no_scene_loaded": "Сцена не загружена",
   "hierarchy.new_scene": "Новая сцена",
+  "hierarchy.create": "Создать",
   "hierarchy.drop_to_spawn": "Перетащите для создания",
   "hierarchy.scene_empty": "Сцена пуста",
   "hierarchy.move_to_view": "Переместить к виду",

--- a/Prowl.Editor/Resources/Locale/tr.json
+++ b/Prowl.Editor/Resources/Locale/tr.json
@@ -173,6 +173,7 @@
   "hierarchy.save_and_exit": "Kaydet ve Cik",
   "hierarchy.no_scene_loaded": "Sahne yuklenmedi",
   "hierarchy.new_scene": "Yeni sahne",
+  "hierarchy.create": "Olustur",
   "hierarchy.drop_to_spawn": "Olusturmak icin birakin",
   "hierarchy.scene_empty": "Sahne bos",
   "hierarchy.move_to_view": "Gorunume tasi",

--- a/Prowl.Editor/Resources/Locale/zh.json
+++ b/Prowl.Editor/Resources/Locale/zh.json
@@ -173,6 +173,7 @@
   "hierarchy.save_and_exit": "保存并退出",
   "hierarchy.no_scene_loaded": "未加载场景",
   "hierarchy.new_scene": "新建场景",
+  "hierarchy.create": "创建",
   "hierarchy.drop_to_spawn": "拖放到此处生成",
   "hierarchy.scene_empty": "场景为空",
   "hierarchy.move_to_view": "移动到视图",


### PR DESCRIPTION
Closes #319.

### + button

The Create menu was only reachable by right-clicking, and you had to find empty space first to create anything at the scene root. The scene header row now carries a `+` that opens the same menu, where the issue asks for it.

### Creation follows the selection

Creation had no notion of the selection. `MenuContext` only ever held whatever the hierarchy's last right-click menu pinned into it, so the main menu bar's **GameObject** menu created under a stale object — or at the root before any right-click had happened.

It now falls back to the active selection when nothing pinned it, which is the case for the `+` button and the menu bar, while the hierarchy's row and background menus keep pinning explicitly (a row pins its object, the background pins the scene root). Menu-bar dropdowns drop the pin as they build, so a previous right-click can't leak into them, and a pin to a since-destroyed object falls back to the root.

`Empty Object` is deliberately unchanged: it still creates under the menu's context object like every other creator in that menu. (Unity's *Create Empty* creates a *sibling* instead — happy to follow that too if you'd prefer, but it seemed out of scope for this issue.)

### Two new commands

- **Empty Child** (`Alt+Shift+N`) — an empty GameObject under the active object; disabled when there isn't one.
- **Empty Parent** (`Ctrl+Shift+G`) — wraps the selection in a new empty GameObject. It takes over the first selected object's slot (same parent, same sibling index) and sits at the centre of the selection, so the group's pivot lands among the objects instead of at the origin. Children keep their world transforms, prefab-structural children are refused the same way a drag-reparent refuses them, and only the top-level selection moves so a selected descendant isn't flattened out of its own parent.

Both are registered in `ShortcutManager`, so they're rebindable alongside the other Hierarchy shortcuts, and like those they fire while the Hierarchy is hovered.

### Undo

Create Empty Parent has to be a single undo step: undoing the reparenting separately from the creation would let the new parent be destroyed while the wrapped objects still lived under it, deleting them along with it. `Undo` gains `CaptureCreatedObject`, which builds a created-object record without pushing it as its own step — and serializes immediately rather than at frame end, so redo restores the parent as it was *before* the children moved in. The whole operation then goes through `RegisterActionGroup`, which undoes its records in reverse: the objects leave first, then the parent goes.

### Misc

`hierarchy.create` added to all 12 locale files; it also replaces the hardcoded `"Create"` on the two existing create menus. The prefab-structural-child check that was duplicated between the drag-reparent and delete paths is now one helper, shared with the new code.

### Testing

Exercised by hand in the editor: the `+` button, creating from the menu bar with and without a selection, both new commands from the menu and from their shortcuts, and undo/redo of Create Empty Parent (one step, the wrapped objects come back with it).

`dotnet build` clean and the full suite passes (`Prowl.Editor.Test` 179/179, `Prowl.Runtime.Test` 385/386 — the one failure is `ColorTests.ToString_Returns_Correct_Value`, which is culture-dependent and fails on my `tr-TR` machine on `main` too).
