### PR TITLE
Fixed SLN not including Analyzer project, fixed HierarchyPanel's null analyzer errors

### DIFF
--- a/Prowl.Editor/GUI/Panels/HierarchyPanel.cs
+++ b/Prowl.Editor/GUI/Panels/HierarchyPanel.cs
@@ -1025,8 +1025,8 @@ public class HierarchyPanel : DockPanel
         Guid goId = go.Identifier;
         Guid newParentId = newParent.Identifier;
         var oldParent = go.Parent.IsValid() ? go.Parent : null;
-        Guid oldParentId = oldParent?.Identifier ?? Guid.Empty;
-        int oldIndex = oldParent != null ? (go.GetSiblingIndex() ?? -1) : (Scene.Current?.GetRootIndex(go) ?? -1);
+        Guid oldParentId = oldParent.IsValid() ? oldParent.Identifier : Guid.Empty;
+        int oldIndex = oldParent != null ? (go.GetSiblingIndex() ?? -1) : (Scene.Current.IsValid() ? Scene.Current.GetRootIndex(go) : -1);
 
         go.SetParent(newParent);
 

--- a/Prowl.sln
+++ b/Prowl.sln
@@ -33,6 +33,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Prowl.Editor", "Prowl.Edito
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Prowl.Editor.Test", "Prowl.Editor.Test\Prowl.Editor.Test.csproj", "{E322A63A-8D99-4D4E-ABDA-61813172418F}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Prowl.Analyzers", "Prowl.Analyzers\Prowl.Analyzers.csproj", "{85602794-3399-4FC1-B19E-7D41C14B2FE4}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -211,6 +213,18 @@ Global
 		{E322A63A-8D99-4D4E-ABDA-61813172418F}.Release|x64.Build.0 = Release|Any CPU
 		{E322A63A-8D99-4D4E-ABDA-61813172418F}.Release|x86.ActiveCfg = Release|Any CPU
 		{E322A63A-8D99-4D4E-ABDA-61813172418F}.Release|x86.Build.0 = Release|Any CPU
+		{85602794-3399-4FC1-B19E-7D41C14B2FE4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{85602794-3399-4FC1-B19E-7D41C14B2FE4}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{85602794-3399-4FC1-B19E-7D41C14B2FE4}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{85602794-3399-4FC1-B19E-7D41C14B2FE4}.Debug|x64.Build.0 = Debug|Any CPU
+		{85602794-3399-4FC1-B19E-7D41C14B2FE4}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{85602794-3399-4FC1-B19E-7D41C14B2FE4}.Debug|x86.Build.0 = Debug|Any CPU
+		{85602794-3399-4FC1-B19E-7D41C14B2FE4}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{85602794-3399-4FC1-B19E-7D41C14B2FE4}.Release|Any CPU.Build.0 = Release|Any CPU
+		{85602794-3399-4FC1-B19E-7D41C14B2FE4}.Release|x64.ActiveCfg = Release|Any CPU
+		{85602794-3399-4FC1-B19E-7D41C14B2FE4}.Release|x64.Build.0 = Release|Any CPU
+		{85602794-3399-4FC1-B19E-7D41C14B2FE4}.Release|x86.ActiveCfg = Release|Any CPU
+		{85602794-3399-4FC1-B19E-7D41C14B2FE4}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
As stated in the title, made it so that the Analyzer project is included in the SLN file of the editor, as well as fixed two Hierarchy null errors raised by the Analyzer.