### PR TITLE
Added auto SLNX generation upon script compilation

### DIFF
--- a/Prowl.Editor.Test/DirectoryBuildPropsTests.cs
+++ b/Prowl.Editor.Test/DirectoryBuildPropsTests.cs
@@ -44,6 +44,7 @@ public class DirectoryBuildPropsTests : EditorTestHarness
         Assert.False(result.RequiresReload);
         Assert.True(File.Exists(Project.GameCsprojPath));     // generated so an IDE has something to open
         Assert.True(File.Exists(Project.EditorCsprojPath));
+        Assert.True(File.Exists(Project.ProjectSolutionPath));
         Assert.False(File.Exists(Project.GameAssemblyPath));  // nothing to compile
     }
 

--- a/Prowl.Editor/Projects/Project.cs
+++ b/Prowl.Editor/Projects/Project.cs
@@ -37,6 +37,7 @@ public class Project
     public string EditorAssemblyPath => Path.Combine(ScriptAssemblyPath, $"{Name}.Editor.dll");
     public string GameCsprojPath => Path.Combine(RootPath, $"{Name}.Game.csproj");
     public string EditorCsprojPath => Path.Combine(RootPath, $"{Name}.Editor.csproj");
+    public string ProjectSolutionPath => Path.Combine(RootPath, $"{Name}.slnx");
 
     private Project(string rootPath, string name)
     {
@@ -63,7 +64,7 @@ public class Project
         if (!File.Exists(gitignore))
         {
             File.WriteAllText(gitignore,
-                "Library/\nTemp/\nLogs/\n*.csproj\n*.sln\n.vs/\nbin/\nobj/\n# MacOS\n.DS_Store\n");
+                "Library/\nTemp/\nLogs/\n*.csproj\n*.sln\n*.slnx\n.vs/\nbin/\nobj/\n# MacOS\n.DS_Store\n");
         }
 
         // Non-destructive MSBuild customization surface. The generated .csproj files are rewritten on

--- a/Prowl.Editor/Projects/Scripting/ScriptCompiler.cs
+++ b/Prowl.Editor/Projects/Scripting/ScriptCompiler.cs
@@ -58,8 +58,11 @@ public static class ScriptCompiler
 
         // Generate the default Game/Editor csproj (and any asmdef unit that owns scripts) up front so
         // NuGet packages restore and IDEs resolve references even before the first script exists.
-        foreach (var unit in units.Where(u => u.Source == null || u.Scripts.Count > 0))
+        var generated = units.Where(u => u.Source == null || u.Scripts.Count > 0).ToList();
+        foreach (var unit in generated)
             GenerateCsproj(project, unit, units);
+
+        GenerateSolutionIfMissing(project, generated);
 
         var compileUnits = units.Where(u => u.Scripts.Count > 0).ToList();
         if (compileUnits.Count == 0)
@@ -461,6 +464,33 @@ public static class ScriptCompiler
         sb.AppendLine("</Project>");
 
         File.WriteAllText(unit.CsprojPath, sb.ToString());
+    }
+
+    /// <summary>
+    /// Writes a .slnx listing the generated csproj files, so an IDE has a single solution to open.
+    /// Only created when absent: the file is a user-editable entry point (they may add their own
+    /// projects to it) as needed.
+    /// </summary>
+    private static void GenerateSolutionIfMissing(Project project, List<CompilationUnit> generatedUnits)
+    {
+        if (File.Exists(project.ProjectSolutionPath) || generatedUnits.Count == 0)
+            return;
+
+        var sb = new StringBuilder();
+        sb.AppendLine("<Solution>");
+        foreach (var unit in generatedUnits.OrderBy(u => u.Name, StringComparer.OrdinalIgnoreCase))
+            sb.AppendLine($"  <Project Path=\"{Xml(Path.GetRelativePath(project.RootPath, unit.CsprojPath))}\" />");
+        sb.AppendLine("</Solution>");
+
+        try
+        {
+            File.WriteAllText(project.ProjectSolutionPath, sb.ToString());
+        }
+        catch (Exception ex)
+        {
+            // A missing solution file never blocks compilation.
+            Runtime.Debug.LogWarning($"[ScriptCompiler] Failed to write solution file: {ex.Message}");
+        }
     }
 
     /// <summary>Appends a Reference item, skipping duplicates (by Include name) and XML-escaping values.</summary>


### PR DESCRIPTION
Made a change so that an SLNX solution is generated alongside the csproj files when the script compiles. The SLNX is generated only once, so the user can modify it to add their own project if needed.