### PR TITLE
Add EnableIf and InspectorName Attributes/Field Drawer

### DIFF
--- a/Prowl.Editor/Core/EditorApplication.cs
+++ b/Prowl.Editor/Core/EditorApplication.cs
@@ -175,6 +175,7 @@ public class EditorApplication : Game
         {
             if (typeof(Runtime.EngineObject).IsAssignableFrom(fieldType))
                 EngineObjectPropertyEditor.SetFieldType(fieldType);
+            InspectorNameEnumDrawer.EnsureRegistered(PropertyGridConfig.Drawers, fieldType);
         };
         PropertyGridConfig.DrawTypePicker = (paper, id, baseType, currentValue, onChange) =>
         {

--- a/Prowl.Editor/GUI/AttributeHandlers.cs
+++ b/Prowl.Editor/GUI/AttributeHandlers.cs
@@ -16,6 +16,40 @@ using Prowl.Runtime;
 
 namespace Prowl.Editor.GUI;
 
+/// <summary>
+/// The default property-grid row recipe (gutter padding, label width/colour/truncation) for
+/// handler-drawn fields, so they align with grid-drawn rows instead of each hand-copying the
+/// layout. This is the one place the recipe lives — grid metric changes go here.
+/// </summary>
+public static class HandlerRowLayout
+{
+    /// <summary>Draw a label + control row matching the default grid rows. The control is
+    /// drawn inside a stretch-width, row-height box.</summary>
+    public static void LabelledRow(Paper paper, string id, string label, Action drawControl)
+    {
+        var theme = OrigamiUI.Origami.Current;
+        var m = theme.Metrics;
+        var font = theme.Font;
+
+        using (paper.Row(id).Height(UnitValue.Auto).MinHeight(m.RowHeight)
+            .Padding(m.PaddingLarge, m.PaddingLarge, 0, 0).RowBetween(m.Padding).Enter())
+        {
+            if (font != null && !string.IsNullOrEmpty(label))
+            {
+                paper.Box($"{id}_lbl")
+                    .Width(m.LabelWidth).Height(m.RowHeight)
+                    .Margin(0, 0, UnitValue.Stretch(), UnitValue.Stretch())
+                    .IsNotInteractable()
+                    .Text(label, font).TextColor(theme.Ink.C300)
+                    .FontSize(m.FontSize).Alignment(TextAlignment.MiddleLeft).TextTruncate();
+            }
+
+            using (paper.Box($"{id}_ctl").Width(UnitValue.Stretch()).Height(m.RowHeight).Enter())
+                drawControl();
+        }
+    }
+}
+
 /// <summary>[Header("text")] - draws a header label above the field.</summary>
 public class HeaderAttributeHandler : OrigamiUI.AttributeHandler
 {
@@ -59,6 +93,142 @@ public class ShowIfAttributeHandler : OrigamiUI.AttributeHandler
         return true; // Condition not found, show by default
     }
 }
+
+/// <summary>[EnableIf("memberName")] - greys the field out (visible, not editable) while the
+/// named bool member is false. Interaction is blocked via BeginReadOnly, and the field is
+/// drawn under a faded theme so the disabled state is visually obvious.</summary>
+public class EnableIfAttributeHandler : OrigamiUI.AttributeHandler
+{
+    // OnBeforeDraw/OnAfterDraw run as a strict pair on one thread per field; the stack keeps
+    // nested [EnableIf] objects balanced. The entry carries the pushed-theme scope to pop.
+    [ThreadStatic] private static Stack<IDisposable?>? t_scopes;
+
+    // Faded clone of the active theme, rebuilt only when the theme object changes.
+    private static OrigamiUI.OrigamiTheme? _dimSource;
+    private static OrigamiUI.OrigamiTheme? _dimTheme;
+
+    private static bool EvaluateCondition(string member, object target)
+    {
+        var type = target.GetType();
+        var condField = type.GetField(member, BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
+        if (condField != null && condField.FieldType == typeof(bool))
+            return (bool)(condField.GetValue(target) ?? false);
+        var condProp = type.GetProperty(member, BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
+        if (condProp != null && condProp.PropertyType == typeof(bool))
+            return (bool)(condProp.GetValue(target) ?? false);
+        return true; // condition not found: leave enabled
+    }
+
+    private static OrigamiUI.OrigamiTheme GetDimmedTheme(OrigamiUI.OrigamiTheme source)
+    {
+        if (!ReferenceEquals(_dimSource, source) || _dimTheme == null)
+        {
+            var dim = source.Clone();
+            FadeRamp(dim.Ink);      // labels + field text
+            FadeRamp(dim.Neutral);  // field backgrounds/borders
+            _dimSource = source;
+            _dimTheme = dim;
+        }
+        return _dimTheme;
+    }
+
+    private static void FadeRamp(OrigamiUI.OrigamiRamp ramp)
+    {
+        ramp.C100 = Fade(ramp.C100); ramp.C200 = Fade(ramp.C200); ramp.C300 = Fade(ramp.C300);
+        ramp.C400 = Fade(ramp.C400); ramp.C500 = Fade(ramp.C500); ramp.C600 = Fade(ramp.C600);
+        ramp.C700 = Fade(ramp.C700);
+    }
+
+    private static System.Drawing.Color Fade(System.Drawing.Color c)
+        => System.Drawing.Color.FromArgb((int)(c.A * 0.45f), c.R, c.G, c.B);
+
+    /// <summary>
+    /// Draw a stretch of UI as disabled: blocks interaction (BeginReadOnly) and renders it
+    /// under the faded theme so the state is visually obvious. Dispose the scope to restore.
+    /// Reusable by any editor UI that wants the same look as [EnableIf].
+    /// </summary>
+    public static IDisposable PushDisabledScope()
+    {
+        OrigamiUI.Origami.BeginReadOnly();
+        IDisposable themeScope = OrigamiUI.Origami.PushTheme(GetDimmedTheme(OrigamiUI.Origami.Current));
+        return new DisabledScope(themeScope);
+    }
+
+    private sealed class DisabledScope(IDisposable themeScope) : IDisposable
+    {
+        private bool _disposed;
+        public void Dispose()
+        {
+            if (_disposed) return;
+            _disposed = true;
+            themeScope.Dispose();
+            OrigamiUI.Origami.EndReadOnly();
+        }
+    }
+
+    public override bool OnBeforeDraw(Paper paper, string id, Attribute attr, FieldInfo field, object target, int depth)
+    {
+        bool disabled = !EvaluateCondition(((EnableIfAttribute)attr).ConditionMember, target);
+        IDisposable? scope = null;
+        if (disabled)
+        {
+            OrigamiUI.Origami.BeginReadOnly();
+            scope = OrigamiUI.Origami.PushTheme(GetDimmedTheme(OrigamiUI.Origami.Current));
+        }
+        (t_scopes ??= new()).Push(scope); // null = field was enabled
+        return true;
+    }
+
+    public override void OnAfterDraw(Paper paper, string id, Attribute attr, FieldInfo field, object target, int depth)
+    {
+        if (t_scopes == null || t_scopes.Count == 0) return;
+        IDisposable? scope = t_scopes.Pop();
+        if (scope == null) return; // was enabled
+        scope.Dispose();
+        OrigamiUI.Origami.EndReadOnly();
+    }
+}
+
+/// <summary>[InspectorName("label")] - overrides the field's display label; on enum-typed
+/// fields the dropdown also shows each member's own [InspectorName] instead of the raw name.</summary>
+public class InspectorNameAttributeHandler : OrigamiUI.AttributeHandler
+{
+    /// <summary>Display name for an enum member: its [InspectorName] if present, else the
+    /// nicified member name.</summary>
+    public static string GetEnumDisplayName(Type enumType, object value)
+    {
+        string name = Enum.GetName(enumType, value) ?? value.ToString() ?? "";
+        var attr = enumType.GetField(name)?.GetCustomAttribute<InspectorNameAttribute>();
+        return attr?.DisplayName ?? PropertyGridUtils.NicifyName(name);
+    }
+
+    public override bool OnDraw(Paper paper, string id, string label, Attribute attr,
+        FieldInfo field, object target, Action<object?> onChange, int depth)
+    {
+        string displayLabel = ((InspectorNameAttribute)attr).DisplayName;
+        Type type = field.FieldType;
+
+        // Non-flags enums get a dropdown honouring per-member display names.
+        if (type.IsEnum && !type.IsDefined(typeof(FlagsAttribute), false))
+        {
+            object value = field.GetValue(target) ?? Enum.GetValues(type).GetValue(0)!;
+            HandlerRowLayout.LabelledRow(paper, id, displayLabel, () =>
+            {
+                var values = new List<object>();
+                foreach (object v in Enum.GetValues(type)) values.Add(v);
+                OrigamiUI.Origami.Dropdown(paper, $"{id}_dd", value, v => onChange(v), values)
+                    .Display(v => GetEnumDisplayName(type, v))
+                    .Show();
+            });
+            return true;
+        }
+
+        // Everything else: default rendering, relabelled.
+        PropertyGridUtils.DrawField(paper, id, displayLabel, type, field.GetValue(target), onChange, depth);
+        return true;
+    }
+}
+
 
 /// <summary>[ReadOnly] - makes the field non-editable.</summary>
 public class ReadOnlyAttributeHandler : OrigamiUI.AttributeHandler
@@ -193,6 +363,8 @@ public static class BuiltInAttributeHandlers
         registry.Register<HeaderAttribute>(new HeaderAttributeHandler());
         registry.Register<SpaceAttribute>(new SpaceAttributeHandler());
         registry.Register<ShowIfAttribute>(new ShowIfAttributeHandler());
+        registry.Register<EnableIfAttribute>(new EnableIfAttributeHandler());
+        registry.Register<InspectorNameAttribute>(new InspectorNameAttributeHandler());
         registry.Register<ReadOnlyAttribute>(new ReadOnlyAttributeHandler());
         registry.Register<RangeAttribute>(new RangeAttributeHandler());
         registry.Register<TextAreaAttribute>(new TextAreaAttributeHandler());

--- a/Prowl.Editor/GUI/AttributeHandlers.cs
+++ b/Prowl.Editor/GUI/AttributeHandlers.cs
@@ -9,46 +9,13 @@ using System;
 using System.Collections.Generic;
 using System.Reflection;
 
+using Prowl.Editor.GUI.PropertyEditors;
 using Prowl.OrigamiUI;
 using Prowl.PaperUI;
 using Prowl.PaperUI.LayoutEngine;
 using Prowl.Runtime;
 
 namespace Prowl.Editor.GUI;
-
-/// <summary>
-/// The default property-grid row recipe (gutter padding, label width/colour/truncation) for
-/// handler-drawn fields, so they align with grid-drawn rows instead of each hand-copying the
-/// layout. This is the one place the recipe lives — grid metric changes go here.
-/// </summary>
-public static class HandlerRowLayout
-{
-    /// <summary>Draw a label + control row matching the default grid rows. The control is
-    /// drawn inside a stretch-width, row-height box.</summary>
-    public static void LabelledRow(Paper paper, string id, string label, Action drawControl)
-    {
-        var theme = OrigamiUI.Origami.Current;
-        var m = theme.Metrics;
-        var font = theme.Font;
-
-        using (paper.Row(id).Height(UnitValue.Auto).MinHeight(m.RowHeight)
-            .Padding(m.PaddingLarge, m.PaddingLarge, 0, 0).RowBetween(m.Padding).Enter())
-        {
-            if (font != null && !string.IsNullOrEmpty(label))
-            {
-                paper.Box($"{id}_lbl")
-                    .Width(m.LabelWidth).Height(m.RowHeight)
-                    .Margin(0, 0, UnitValue.Stretch(), UnitValue.Stretch())
-                    .IsNotInteractable()
-                    .Text(label, font).TextColor(theme.Ink.C300)
-                    .FontSize(m.FontSize).Alignment(TextAlignment.MiddleLeft).TextTruncate();
-            }
-
-            using (paper.Box($"{id}_ctl").Width(UnitValue.Stretch()).Height(m.RowHeight).Enter())
-                drawControl();
-        }
-    }
-}
 
 /// <summary>[Header("text")] - draws a header label above the field.</summary>
 public class HeaderAttributeHandler : OrigamiUI.AttributeHandler
@@ -189,42 +156,16 @@ public class EnableIfAttributeHandler : OrigamiUI.AttributeHandler
     }
 }
 
-/// <summary>[InspectorName("label")] - overrides the field's display label; on enum-typed
-/// fields the dropdown also shows each member's own [InspectorName] instead of the raw name.</summary>
+/// <summary>[InspectorName("label")] - overrides the field's display label.</summary>
 public class InspectorNameAttributeHandler : OrigamiUI.AttributeHandler
 {
-    /// <summary>Display name for an enum member: its [InspectorName] if present, else the
-    /// nicified member name.</summary>
-    public static string GetEnumDisplayName(Type enumType, object value)
-    {
-        string name = Enum.GetName(enumType, value) ?? value.ToString() ?? "";
-        var attr = enumType.GetField(name)?.GetCustomAttribute<InspectorNameAttribute>();
-        return attr?.DisplayName ?? PropertyGridUtils.NicifyName(name);
-    }
-
     public override bool OnDraw(Paper paper, string id, string label, Attribute attr,
         FieldInfo field, object target, Action<object?> onChange, int depth)
     {
-        string displayLabel = ((InspectorNameAttribute)attr).DisplayName;
-        Type type = field.FieldType;
-
-        // Non-flags enums get a dropdown honouring per-member display names.
-        if (type.IsEnum && !type.IsDefined(typeof(FlagsAttribute), false))
-        {
-            object value = field.GetValue(target) ?? Enum.GetValues(type).GetValue(0)!;
-            HandlerRowLayout.LabelledRow(paper, id, displayLabel, () =>
-            {
-                var values = new List<object>();
-                foreach (object v in Enum.GetValues(type)) values.Add(v);
-                OrigamiUI.Origami.Dropdown(paper, $"{id}_dd", value, v => onChange(v), values)
-                    .Display(v => GetEnumDisplayName(type, v))
-                    .Show();
-            });
-            return true;
-        }
-
-        // Everything else: default rendering, relabelled.
-        PropertyGridUtils.DrawField(paper, id, displayLabel, type, field.GetValue(target), onChange, depth);
+        // Nothing type-specific here: an enum's member names come from the field drawer
+        // registered for its type, which DrawField resolves like any other.
+        PropertyGridUtils.DrawField(paper, id, ((InspectorNameAttribute)attr).DisplayName,
+            field.FieldType, field.GetValue(target), onChange, depth);
         return true;
     }
 }

--- a/Prowl.Editor/GUI/PropertyEditors/InspectorNameEnumDrawer.cs
+++ b/Prowl.Editor/GUI/PropertyEditors/InspectorNameEnumDrawer.cs
@@ -1,0 +1,56 @@
+// This file is part of the Prowl Game Engine
+// Licensed under the MIT License. See the LICENSE file in the project root for details.
+
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+
+using Prowl.PaperUI;
+using Prowl.Runtime;
+
+namespace Prowl.Editor.GUI.PropertyEditors;
+
+/// <summary>
+/// Draws a non-flags enum using its members' [InspectorName]s — the one place that naming lives, whether or not the field itself carries the attribute.
+/// The property grid has no per-member naming of its own, so the enum type gets its own drawer, registered on demand.
+/// InspectorNameAttributeHandler's own enum branch delegates here so there is one dropdown.
+/// </summary>
+public sealed class InspectorNameEnumDrawer : OrigamiUI.FieldDrawer
+{
+    /// <summary>Stateless, so every enum that wants one shares the instance.</summary>
+    private static readonly InspectorNameEnumDrawer s_instance = new();
+
+    /// <summary>Display name for an enum member: its [InspectorName] if present, else the
+    /// nicified member name.</summary>
+    public static string GetEnumDisplayName(Type enumType, object value)
+    {
+        string name = Enum.GetName(enumType, value) ?? value.ToString() ?? "";
+        var attr = enumType.GetField(name)?.GetCustomAttribute<InspectorNameAttribute>();
+        return attr?.DisplayName ?? PropertyGridUtils.NicifyName(name);
+    }
+
+    /// <summary>Whether this type needs the drawer at all — only enums that actually rename a
+    /// member, so every other enum keeps the grid's own rendering.</summary>
+    public static bool AppliesTo(Type type)
+        => type.IsEnum && !type.IsDefined(typeof(FlagsAttribute), false)
+            && Array.Exists(type.GetFields(BindingFlags.Public | BindingFlags.Static),
+                f => f.IsDefined(typeof(InspectorNameAttribute), false));
+
+    public static void EnsureRegistered(OrigamiUI.FieldDrawerRegistry drawers, Type type)
+    {
+        if (drawers.GetDrawer(type) == null && AppliesTo(type))
+            drawers.Register(type, s_instance);
+    }
+
+    public override void Draw(Paper paper, string id, object? value, Type type,
+        Action<object?> onChange, int depth)
+    {
+        object current = value ?? Enum.GetValues(type).GetValue(0)!;
+        var values = new List<object>();
+        foreach (object v in Enum.GetValues(type)) values.Add(v);
+
+        OrigamiUI.Origami.Dropdown(paper, $"{id}_dd", current, v => onChange(v), values)
+            .Display(v => GetEnumDisplayName(type, v))
+            .Show();
+    }
+}

--- a/Prowl.Runtime/GameObject/Attributes/InspectorAttributes.cs
+++ b/Prowl.Runtime/GameObject/Attributes/InspectorAttributes.cs
@@ -59,6 +59,24 @@ public class ShowIfAttribute : Attribute
     public ShowIfAttribute(string conditionMember) => ConditionMember = conditionMember;
 }
 
+/// <summary>Greys the field out (visible but not editable) unless the named bool
+/// field/property is true. Use for values only meaningful behind an enabling toggle.</summary>
+[AttributeUsage(AttributeTargets.Field)]
+public class EnableIfAttribute : Attribute
+{
+    public string ConditionMember { get; }
+    public EnableIfAttribute(string conditionMember) => ConditionMember = conditionMember;
+}
+
+/// <summary>Overrides the display name the inspector shows for a field or an enum member,
+/// without renaming the code symbol (e.g. keep an API-parity enum name but show "None").</summary>
+[AttributeUsage(AttributeTargets.Field)]
+public class InspectorNameAttribute : Attribute
+{
+    public string DisplayName { get; }
+    public InspectorNameAttribute(string displayName) => DisplayName = displayName;
+}
+
 /// <summary>Draws a string field as a multi-line text area.</summary>
 [AttributeUsage(AttributeTargets.Field)]
 public class TextAreaAttribute : Attribute


### PR DESCRIPTION
Adds two new attributes for Editor decoration:

- Enable If, which takes a conditional and either enables the field if true

<img width="518" height="111" alt="EnableIf" src="https://github.com/user-attachments/assets/f808a4eb-ab99-4228-98bb-eb6b1c4c28b3" />

- Inspector Name, which lets you override the label name for a field. Can be used on individual enums to override their text as well.

<img width="575" height="264" alt="image" src="https://github.com/user-attachments/assets/2f210aa9-5bb4-4960-b0dc-9e6cb38f5f2c" />


<img width="517" height="301" alt="image" src="https://github.com/user-attachments/assets/2c8ef17b-143c-4bc5-8a01-29457d13ee42" />