### PR TITLE
Fix range attribute drawing to stay in the property grid

### DIFF
--- a/Prowl.Editor/Core/EditorApplication.cs
+++ b/Prowl.Editor/Core/EditorApplication.cs
@@ -164,6 +164,7 @@ public class EditorApplication : Game
         // Build the editor's PropertyGrid config
         PropertyGridConfig = new OrigamiUI.PropertyGridConfig();
         OrigamiUI.BuiltInFieldDrawers.Register(PropertyGridConfig.Drawers);
+        RangeSliderDrawer.Register(PropertyGridConfig.Drawers); // wraps the built-in float/int drawers
         BuiltInAttributeHandlers.Register(PropertyGridConfig.Handlers);
         PropertyGridConfig.OnBeginRoot = target => Undo.Snapshot(target);
         PropertyGridConfig.OnFieldChanged = target =>

--- a/Prowl.Editor/GUI/AttributeHandlers.cs
+++ b/Prowl.Editor/GUI/AttributeHandlers.cs
@@ -9,6 +9,7 @@ using System;
 using System.Collections.Generic;
 using System.Reflection;
 
+using Prowl.Editor.GUI.PropertyEditors;
 using Prowl.OrigamiUI;
 using Prowl.PaperUI;
 using Prowl.PaperUI.LayoutEngine;
@@ -75,58 +76,38 @@ public class ReadOnlyAttributeHandler : OrigamiUI.AttributeHandler
     }
 }
 
-/// <summary>[Range(min, max)] - replaces numeric fields with a slider.</summary>
+/// <summary>[Range(min, max)] - replaces numeric fields with a slider. The row and label still come
+/// from the property grid, so they match every other field; only the control is swapped, by
+/// RangeSliderDrawer.</summary>
 public class RangeAttributeHandler : OrigamiUI.AttributeHandler
 {
     public override bool OnDraw(Paper paper, string id, string label, Attribute attr,
         FieldInfo field, object target, Action<object?> onChange, int depth)
     {
+        Type type = field.FieldType;
+        if (type != typeof(float) && type != typeof(int))
+            return false; // no slider for this type: let the grid draw the field untouched
+
         var range = (RangeAttribute)attr;
-        var value = field.GetValue(target);
-        var type = field.FieldType;
-        var theme = OrigamiUI.Origami.Current;
-        var m = theme.Metrics;
-        var font = theme.Font;
-        var ink = theme.Ink;
-
-        using (paper.Row(id).Height(UnitValue.Auto).MinHeight(m.RowHeight)
-            .RowBetween(m.SpacingMedium).Margin(0, 0, 0, m.SpacingSmall).Enter())
+        RangeSliderDrawer.Pending = range;
+        try
         {
-            if (font != null && !string.IsNullOrEmpty(label))
-            {
-                paper.Box($"{id}_lbl")
-                    .Width(m.LabelWidth).Height(m.RowHeight)
-                    .Padding(m.PaddingSmall, 0, 0, 0)
-                    .IsNotInteractable()
-                    .Text(label, font).TextColor(ink.C500)
-                    .FontSize(m.FontSize);
-            }
-
-            using (paper.Box($"{id}_ctl").Width(UnitValue.Stretch())
-                .Height(m.RowHeight).Enter())
-            {
-                if (type == typeof(float))
-                {
-                    float f = (float)(value ?? 0f);
-                    OrigamiUI.Origami.Slider(paper, $"{id}_sl", f,
-                        v => onChange(v), range.Min, range.Max).Format("F2").Show();
-                }
-                else if (type == typeof(int))
-                {
-                    int i = (int)(value ?? 0);
-                    OrigamiUI.Origami.Slider(paper, $"{id}_sl", (float)i,
-                        v => onChange((int)MathF.Round(v)), range.Min, range.Max)
-                        .Format("F0").Step(1f).Show();
-                }
-                else
-                {
-                    return false;
-                }
-            }
+            // The grid makes a numeric field's label a drag-scrubber that writes straight through
+            // onChange, so the bounds have to be enforced here rather than by the slider alone.
+            PropertyGridUtils.DrawField(paper, id, label, type, field.GetValue(target),
+                v => onChange(Clamp(v, range, type)), depth);
         }
-
+        finally
+        {
+            RangeSliderDrawer.Pending = null;
+        }
         return true;
     }
+
+    private static object Clamp(object? value, RangeAttribute range, Type type)
+        => type == typeof(float)
+            ? Math.Clamp((float)(value ?? 0f), range.Min, range.Max)
+            : Math.Clamp((int)(value ?? 0), (int)MathF.Round(range.Min), (int)MathF.Round(range.Max));
 }
 
 /// <summary>[Tooltip("text")] - attaches a tooltip to the field row.</summary>

--- a/Prowl.Editor/GUI/PropertyEditors/RangeSliderDrawer.cs
+++ b/Prowl.Editor/GUI/PropertyEditors/RangeSliderDrawer.cs
@@ -1,0 +1,67 @@
+// This file is part of the Prowl Game Engine
+// Licensed under the MIT License. See the LICENSE file in the project root for details.
+
+using System;
+
+using Prowl.PaperUI;
+using Prowl.Runtime;
+
+namespace Prowl.Editor.GUI.PropertyEditors;
+
+/// <summary>
+/// Draws a float or int as a slider while its field's [Range] is in scope, and defers to the
+/// built-in numeric drawer the rest of the time. Swapping only the control lets the property grid
+/// keep drawing the row and label, so [Range] fields line up with every other field instead of
+/// following a hand-copied row recipe that drifts as the grid's metrics change.
+/// </summary>
+public sealed class RangeSliderDrawer : OrigamiUI.FieldDrawer
+{
+    /// <summary>The [Range] of the field being drawn right now, published by
+    /// <see cref="RangeAttributeHandler"/> around its one <c>DrawField</c> call. The grid draws
+    /// fields one at a time on the UI thread, so at most one is ever in flight.</summary>
+    [ThreadStatic] public static RangeAttribute? Pending;
+
+    private readonly OrigamiUI.FieldDrawer _inner;
+
+    private RangeSliderDrawer(OrigamiUI.FieldDrawer inner) => _inner = inner;
+
+    /// <summary>Wraps the built-in float and int drawers, so must run after
+    /// <c>BuiltInFieldDrawers.Register</c> has put them in the registry.</summary>
+    public static void Register(OrigamiUI.FieldDrawerRegistry drawers)
+    {
+        Wrap(typeof(float));
+        Wrap(typeof(int));
+
+        void Wrap(Type type)
+        {
+            OrigamiUI.FieldDrawer inner = drawers.GetDrawer(type)
+                ?? throw new InvalidOperationException(
+                    $"No built-in drawer for {type.Name} to wrap - register RangeSliderDrawer after BuiltInFieldDrawers.");
+            drawers.Register(type, new RangeSliderDrawer(inner));
+        }
+    }
+
+    public override void Draw(Paper paper, string id, object? value, Type type,
+        Action<object?> onChange, int depth)
+    {
+        // Consume on read: one publish draws one slider, so a range can never bleed into the next
+        // numeric field even if this drawer is reached by some path the handler doesn't bracket.
+        RangeAttribute? range = Pending;
+        Pending = null;
+
+        if (range == null)
+        {
+            _inner.Draw(paper, id, value, type, onChange, depth);
+            return;
+        }
+
+        if (type == typeof(float))
+            OrigamiUI.Origami.Slider(paper, $"{id}_sl", (float)(value ?? 0f),
+                v => onChange(v), range.Min, range.Max)
+                .Format("F2").Show();
+        else
+            OrigamiUI.Origami.Slider(paper, $"{id}_sl", (float)(int)(value ?? 0),
+                v => onChange((int)MathF.Round(v)), range.Min, range.Max)
+                .Format("F0").Step(1f).Show();
+    }
+}


### PR DESCRIPTION
Range fields have a couple of small cosmetic issues:

1. They draw outside of the property grid

<img width="523" height="181" alt="Screenshot 2026-08-07 093645" src="https://github.com/user-attachments/assets/1ce850f8-33e0-41e8-9c1f-ddec9fa25991" />

2. Unsupported types draw twice

<img width="514" height="114" alt="image" src="https://github.com/user-attachments/assets/b2e39e26-396a-4ec6-ba05-2d07a996276b" />

---

With this change the range label and slider now match the property grid and unsupported types just render as their normal field (once)

<img width="506" height="197" alt="image" src="https://github.com/user-attachments/assets/b81f56bc-2128-49b1-a474-b91aa3809493" />
