### PR TITLE
Brought back LogSuccess different color in console panel

### DIFF
--- a/Prowl.Editor/GUI/Panels/ConsolePanel.cs
+++ b/Prowl.Editor/GUI/Panels/ConsolePanel.cs
@@ -396,6 +396,7 @@ public class ConsolePanel : DockPanel
 
     private static (IOrigamiIcon, Color, string) LevelOf(LogSeverity s) => s switch
     {
+        LogSeverity.Success => (EditorIcons.CircleCheck_I, EditorTheme.Green400, "success"),
         LogSeverity.Warning => (EditorIcons.TriangleExclamation_I, EditorTheme.Amber400, "warning"),
         LogSeverity.Error or LogSeverity.Exception => (EditorIcons.CircleExclamation_I, EditorTheme.Red400, "error"),
         _ => (EditorIcons.CircleInfo_I, EditorTheme.Blue400, "info"),


### PR DESCRIPTION
As title states, I brought back LogSuccess different coloring (which previously was falling back on the same "info" coloring) as I feel it's greatly helpful when working with logging to know what goes well specifically. Didn't feel the need to make a separate filter for it yet though.