### PR TITLE
Added Collider information to SphereCastHit, RayCastHit

### DIFF
--- a/Prowl.Runtime/Components/Physics/Colliders/Collider.cs
+++ b/Prowl.Runtime/Components/Physics/Colliders/Collider.cs
@@ -40,6 +40,12 @@ public abstract class Collider : MonoBehaviour
     private RigidBodyShape[] _attachedShapes;
 
     /// <summary>
+    /// The physics world holding shape-owner entries for <see cref="_attachedShapes"/>. Captured at
+    /// registration so Detach can clean up even once the GameObject can no longer reach its scene.
+    /// </summary>
+    private PhysicsWorld _registeredWorld;
+
+    /// <summary>
     /// Transform version tracking for static colliders.
     /// Used to detect when the transform has moved and shapes need updating.
     /// </summary>
@@ -144,6 +150,13 @@ public abstract class Collider : MonoBehaviour
             }
         }
 
+        if (_registeredWorld != null && _attachedShapes != null)
+        {
+            foreach (RigidBodyShape shape in _attachedShapes)
+                _registeredWorld.UnregisterShapeOwner(shape);
+        }
+
+        _registeredWorld = null;
         _attachedBody = null;
         _attachedRigidbody3D = null;
         _attachedShapes = null;
@@ -171,12 +184,16 @@ public abstract class Collider : MonoBehaviour
 
         if (_attachedShapes != null)
         {
+            var scene = GameObject.IsValid() ? GameObject.Scene : null;
+            _registeredWorld = scene.IsValid() ? scene.Physics : null;
+
             foreach (RigidBodyShape shape in _attachedShapes)
             {
                 // Always use Preserve: per-shape Update mode calls SetMassInertia() after every
                 // addition, which iterates ALL attached shapes. Any TriangleShape in that set
                 // throws NotSupportedException. We set mass once below, after all shapes are added.
                 _attachedBody.AddShape(shape, Jitter2.Dynamics.MassInertiaUpdateMode.Preserve);
+                _registeredWorld?.RegisterShapeOwner(shape, this);
             }
         }
 

--- a/Prowl.Runtime/Physics/PhysicsWorld.cs
+++ b/Prowl.Runtime/Physics/PhysicsWorld.cs
@@ -106,8 +106,37 @@ public class PhysicsWorld
     // Rigidbodies that may need their Transform pushed into the physics world (transform -> body).
     private readonly HashSet<Rigidbody3D> _syncBodies = [];
 
+    // Colliders without a Rigidbody3D all share one static body per layer, so a hit's body cannot say
+    // which GameObject was struck. This maps every shape back to the Collider that created it.
+    private readonly Dictionary<RigidBodyShape, Collider> _shapeOwners = [];
+
     internal void RegisterBody(Rigidbody3D body) => _syncBodies.Add(body);
     internal void UnregisterBody(Rigidbody3D body) => _syncBodies.Remove(body);
+
+    internal void RegisterShapeOwner(RigidBodyShape shape, Collider collider) => _shapeOwners[shape] = collider;
+
+    internal void UnregisterShapeOwner(RigidBodyShape shape) => _shapeOwners.Remove(shape);
+
+    /// <summary>
+    /// The <see cref="Collider"/> that created the given shape, or null if the shape is not tracked.
+    /// </summary>
+    public Collider GetShapeOwner(RigidBodyShape shape)
+    {
+        if (shape != null && _shapeOwners.TryGetValue(shape, out Collider collider) && collider.IsValid())
+            return collider;
+        return null;
+    }
+
+    /// <summary>
+    /// The Transform a query hit should report: the rigidbody's when there is one, otherwise the
+    /// collider's own.
+    /// </summary>
+    internal static Transform ResolveHitTransform(Rigidbody3D rigidbody, Collider collider)
+    {
+        if (rigidbody.IsValid() && rigidbody.GameObject.IsValid()) return rigidbody.GameObject.Transform;
+        if (collider.IsValid() && collider.GameObject.IsValid()) return collider.GameObject.Transform;
+        return null;
+    }
 
     /// <summary>
     /// Pushes any changed Transforms into their physics bodies (transform -> body). Runs automatically
@@ -238,6 +267,11 @@ public class PhysicsWorld
 
         // Clear the static rigidbodies dictionary - they will be recreated as needed
         _staticRigidbodiesByLayer.Clear();
+
+        // World.Clear removed every body, so the per-body registries hold nothing worth visiting.
+        // The components re-register when they recreate their bodies.
+        _syncBodies.Clear();
+        _shapeOwners.Clear();
     }
 
     public void Update()
@@ -304,7 +338,7 @@ public class PhysicsWorld
                 Lambda = lambda,
                 Normal = normal
             };
-            hitInfo.SetFromJitterResult(result, origin, direction);
+            hitInfo.SetFromJitterResult(this, result, origin, direction);
         }
 
         return hit;
@@ -348,7 +382,7 @@ public class PhysicsWorld
                 Lambda = lambda,
                 Normal = normal,
             };
-            hitInfo.SetFromJitterResult(result, origin, direction);
+            hitInfo.SetFromJitterResult(this, result, origin, direction);
         }
 
         return hit;
@@ -392,7 +426,7 @@ public class PhysicsWorld
                 Lambda = lambda,
                 Normal = normal,
             };
-            hitInfo.SetFromJitterResult(result, origin, direction);
+            hitInfo.SetFromJitterResult(this, result, origin, direction);
         }
 
         return hit;
@@ -498,6 +532,7 @@ public class PhysicsWorld
                     normal = JVector.Normalize(normal);
                 }
 
+                Collider owner = GetShapeOwner(targetShape);
                 var castHit = new ShapeCastHit
                 {
                     Hit = true,
@@ -507,7 +542,8 @@ public class PhysicsWorld
                     HitPoint = new Float3(pointB.X, pointB.Y, pointB.Z),
                     Rigidbody = userData.Rigidbody,
                     Shape = targetShape,
-                    Transform = userData.Rigidbody.IsValid() && userData.Rigidbody.GameObject.IsValid() ? userData.Rigidbody.GameObject.Transform : null
+                    Collider = owner,
+                    Transform = ResolveHitTransform(userData.Rigidbody, owner)
                 };
                 hits.Add(castHit);
             }
@@ -592,6 +628,9 @@ public class PhysicsWorld
 
         if (bestLambda < float.MaxValue)
         {
+            // The height provider is the TerrainCollider component itself, so it can name the GameObject
+            // even though terrain has no RigidBodyShape to look up.
+            var terrain = hp as MonoBehaviour;
             hits.Add(new ShapeCastHit
             {
                 Hit = true,
@@ -601,7 +640,8 @@ public class PhysicsWorld
                 HitPoint = new Float3(bestPointB.X, bestPointB.Y, bestPointB.Z),
                 Rigidbody = null,
                 Shape = null,
-                Transform = null,
+                Collider = null,
+                Transform = terrain.IsValid() && terrain.GameObject.IsValid() ? terrain.GameObject.Transform : null,
             });
         }
     }
@@ -993,6 +1033,7 @@ public class PhysicsWorld
 
             if (overlaps && penetration > 0)
             {
+                Collider owner = GetShapeOwner(targetShape);
                 var hit = new ShapeCastHit
                 {
                     Hit = true,
@@ -1003,7 +1044,8 @@ public class PhysicsWorld
                     HitPoint = new Float3(pointB.X, pointB.Y, pointB.Z),
                     Rigidbody = userData.Rigidbody,
                     Shape = targetShape,
-                    Transform = userData.Rigidbody.IsValid() && userData.Rigidbody.GameObject.IsValid() ? userData.Rigidbody.GameObject.Transform : null
+                    Collider = owner,
+                    Transform = ResolveHitTransform(userData.Rigidbody, owner)
                 };
                 hits.Add(hit);
             }

--- a/Prowl.Runtime/Physics/RaycastHit.cs
+++ b/Prowl.Runtime/Physics/RaycastHit.cs
@@ -44,11 +44,17 @@ public struct RaycastHit
     public RigidBodyShape Shape;
 
     /// <summary>
-    /// The Transform of the rigidbody that was hit.
+    /// The Collider that was hit. Null for hits that no Collider owns (e.g. terrain).
+    /// </summary>
+    public Collider Collider;
+
+    /// <summary>
+    /// The Transform of the rigidbody that was hit, or of the collider itself when the hit belongs to
+    /// static geometry (which shares one body per layer and so cannot identify a GameObject).
     /// </summary>
     public Transform Transform;
 
-    internal void SetFromJitterResult(DynamicTree.RayCastResult result, Float3 origin, Float3 direction)
+    internal void SetFromJitterResult(PhysicsWorld world, DynamicTree.RayCastResult result, Float3 origin, Float3 direction)
     {
         Shape = result.Entity as RigidBodyShape;
         if (Shape == null)
@@ -60,8 +66,9 @@ public struct RaycastHit
         var userData = Shape.RigidBody.Tag as Rigidbody3D.RigidBodyUserData;
 
         Hit = true;
-        Rigidbody = userData.Rigidbody;
-        Transform = Rigidbody.IsValid() && Rigidbody.GameObject.IsValid() ? Rigidbody.GameObject.Transform : null;
+        Rigidbody = userData?.Rigidbody;
+        Collider = world.GetShapeOwner(Shape);
+        Transform = PhysicsWorld.ResolveHitTransform(Rigidbody, Collider);
         Normal = new Float3(result.Normal.X, result.Normal.Y, result.Normal.Z);
         Distance = result.Lambda;
         Point = origin + (direction * Distance);

--- a/Prowl.Runtime/Physics/ShapeCastHit.cs
+++ b/Prowl.Runtime/Physics/ShapeCastHit.cs
@@ -54,7 +54,13 @@ public struct ShapeCastHit
     public RigidBodyShape Shape;
 
     /// <summary>
-    /// The Transform of the rigidbody that was hit.
+    /// The Collider that was hit. Null for hits that no Collider owns (e.g. terrain).
+    /// </summary>
+    public Collider Collider;
+
+    /// <summary>
+    /// The Transform of the rigidbody that was hit, or of the collider itself when the hit belongs to
+    /// static geometry (which shares one body per layer and so cannot identify a GameObject).
     /// </summary>
     public Transform Transform;
 


### PR DESCRIPTION
Currently, Prowl does not have any information about objects hit by Raycast/SphereCast/ShapeCast unless they have a Rigidbody, which can be unfortunate in most scenarios where not every object in the scene requires a Rigidbody. This change creates a map of Rigidbody shapes (which are driven by colliders) to point them back to the colliders that own them, so that Hit can relay information about which collider (and consequently which GameObject) was hit.