### PR TITLE
Fix typed characters never reaching the Game View's Paper

### DIFF
--- a/Prowl.Runtime/InputManagement/DefaultInputHandler.cs
+++ b/Prowl.Runtime/InputManagement/DefaultInputHandler.cs
@@ -83,7 +83,7 @@ public class DefaultInputHandler : IInputHandler, IDisposable
     private Queue<char> pressedChars { get; set; } = new();
 
     // Characters typed this frame, accumulated as KeyChar events arrive (during DoEvents) and cleared at
-    // the frame boundary (LateUpdate). Unlike the pressedChars queue this is read non-destructively, so
+    // the frame boundary (BeginFrame). Unlike the pressedChars queue this is read non-destructively, so
     // any number of consumers - Paper, GameObject UI, user UI - can all see the same input each frame.
     private string _inputString = string.Empty;
 
@@ -144,13 +144,20 @@ public class DefaultInputHandler : IInputHandler, IDisposable
         }
     }
 
-    internal void LateUpdate()
+    /// <summary>
+    /// Drops the previous frame's typed characters, before DoEvents appends this frame's. Clearing here
+    /// rather than in LateUpdate is what lets them survive the whole frame - the editor pumps the Game
+    /// View's Paper during Render, which is after LateUpdate, so a clear there dropped every character
+    /// before that Paper could see one.
+    /// </summary>
+    internal void BeginFrame()
     {
-        // Typed characters live for exactly one frame: they arrive during DoEvents, are read (non
-        // destructively) by every consumer during Update, and are cleared here at the frame boundary.
         _inputString = string.Empty;
         pressedChars.Clear();
+    }
 
+    internal void LateUpdate()
+    {
         _prevMousePos = _currentMousePos;
         _currentMousePos = (Int2)(Float2)Mice[0].Position;
         if (!_prevMousePos.Equals(_currentMousePos))

--- a/Prowl.Runtime/Window.cs
+++ b/Prowl.Runtime/Window.cs
@@ -214,6 +214,7 @@ public static class Window
 
             Graphics.BeginFrame();
 
+            WindowInputHandler?.BeginFrame();
             InternalWindow.DoEvents();
             Update?.Invoke(delta);
             WindowInputHandler?.LateUpdate();


### PR DESCRIPTION
Text fields drawn from MonoBehaviour.OnGui accepted Backspace/Delete and arrow keys but no printable characters at all while in play mode in the editor.

The editor's Paper is pumped during Update, before the clear, so inspector fields worked. The Game View's Paper is pumped during Render, after it, so PaperInputBridge's foreach (char ch in Input.InputString) always iterated an empty string. Editing keys were unaffected because they come from Input.GetKeyDown/GetKeyUp, backed by dictionaries that UpdateKeyStates() refreshes at the end of LateUpdate and which stay valid for the rest of the frame.

The fix moves the clear to a new DefaultInputHandler.BeginFrame() called immediately before DoEvents(), so a frame's characters survive from the events that produce them through to PostRender. That matches what the field's own comment already claimed (that any number of consumers can read it each frame) which previously only held for Update-phase consumers.