### PR TITLE
Fix GetGamepadCount to give actual connected count and not slots

### DIFF
--- a/Prowl.Editor.Test/ComponentClipboardTests.cs
+++ b/Prowl.Editor.Test/ComponentClipboardTests.cs
@@ -39,6 +39,7 @@ public sealed class FakeClipboardInput : IInputHandler
     public void SetCursorShape(PaperCursor shape, int miceIndex = 0) { }
 
     public int GetGamepadCount() => 0;
+    public int GetGamepadSlotCount() => 0;
     public bool IsGamepadConnected(int gamepadIndex) => false;
     public bool GetGamepadButton(int gamepadIndex, GamepadButton button) => false;
     public bool GetGamepadButtonDown(int gamepadIndex, GamepadButton button) => false;

--- a/Prowl.Editor/GUI/GameViewInputHandler.cs
+++ b/Prowl.Editor/GUI/GameViewInputHandler.cs
@@ -148,6 +148,7 @@ public class GameViewInputHandler : IInputHandler
 
     // Gamepads always pass through (physical controllers work regardless of focus)
     public int GetGamepadCount() => _real.GetGamepadCount();
+    public int GetGamepadSlotCount() => _real.GetGamepadSlotCount();
     public bool IsGamepadConnected(int gamepadIndex) => _real.IsGamepadConnected(gamepadIndex);
     public bool GetGamepadButton(int gamepadIndex, GamepadButton button) => _real.GetGamepadButton(gamepadIndex, button);
     public bool GetGamepadButtonDown(int gamepadIndex, GamepadButton button) => _real.GetGamepadButtonDown(gamepadIndex, button);

--- a/Prowl.Editor/GUI/InputBindingListener.cs
+++ b/Prowl.Editor/GUI/InputBindingListener.cs
@@ -66,7 +66,8 @@ public static class InputBindingListener
         }
 
         // Check gamepad buttons
-        for (int device = 0; device < Input.GetGamepadCount(); device++)
+        // Slots, not connected count: a pad in slot 3 with 1 and 2 empty must still be reachable.
+        for (int device = 0; device < Input.GetGamepadSlotCount(); device++)
         {
             if (!Input.IsGamepadConnected(device)) continue;
             foreach (GamepadButton gb in Enum.GetValues<GamepadButton>())

--- a/Prowl.Runtime/InputManagement/DefaultInputHandler.cs
+++ b/Prowl.Runtime/InputManagement/DefaultInputHandler.cs
@@ -327,7 +327,20 @@ public class DefaultInputHandler : IInputHandler, IDisposable
     }
 
     // Gamepad methods implementation
-    public int GetGamepadCount() => Context.Gamepads.Count;
+
+    // Backends expose a fixed block of slots (16 under GLFW) whether or not anything is plugged into
+    // them, so Context.Gamepads.Count is a capacity rather than a device count. Every other method here
+    // already gates on IsGamepadConnected; this one now agrees with them.
+    public int GetGamepadCount()
+    {
+        int count = 0;
+        for (int i = 0; i < Context.Gamepads.Count; i++)
+            if (Context.Gamepads[i].IsConnected)
+                count++;
+        return count;
+    }
+
+    public int GetGamepadSlotCount() => Context.Gamepads.Count;
 
     public bool IsGamepadConnected(int gamepadIndex)
     {

--- a/Prowl.Runtime/InputManagement/IInputHandler.cs
+++ b/Prowl.Runtime/InputManagement/IInputHandler.cs
@@ -47,7 +47,17 @@ public interface IInputHandler
     void SetCursorShape(PaperCursor shape, int miceIndex = 0);
 
     // Gamepad methods
+
+    /// <summary>The number of gamepads currently connected.</summary>
     int GetGamepadCount();
+
+    /// <summary>
+    /// The number of gamepad slots the backend exposes, connected or not. This is the valid index range
+    /// for the other gamepad methods, so use it to scan for a device and <see cref="GetGamepadCount"/>
+    /// to ask how many are attached.
+    /// </summary>
+    int GetGamepadSlotCount();
+
     bool IsGamepadConnected(int gamepadIndex);
     bool GetGamepadButton(int gamepadIndex, GamepadButton button);
     bool GetGamepadButtonDown(int gamepadIndex, GamepadButton button);

--- a/Prowl.Runtime/InputManagement/Input.cs
+++ b/Prowl.Runtime/InputManagement/Input.cs
@@ -199,7 +199,16 @@ public static class Input
     }
 
     // Gamepad
+    /// <summary>The number of gamepads currently connected.</summary>
     public static int GetGamepadCount() => Current.GetGamepadCount();
+
+    /// <summary>
+    /// The number of gamepad slots the backend exposes, connected or not. Backends report a fixed slot
+    /// count (16 under GLFW) regardless of what is plugged in, so this is the index range to scan when
+    /// looking for a device - <see cref="GetGamepadCount"/> is how many are actually attached.
+    /// </summary>
+    public static int GetGamepadSlotCount() => Current.GetGamepadSlotCount();
+
     public static bool IsGamepadConnected(int gamepadIndex = 0) => Current.IsGamepadConnected(gamepadIndex);
     public static bool GetGamepadButton(GamepadButton button, int gamepadIndex = 0) => Current.GetGamepadButton(gamepadIndex, button);
     public static bool GetGamepadButtonDown(GamepadButton button, int gamepadIndex = 0) => Current.GetGamepadButtonDown(gamepadIndex, button);

--- a/Prowl.Runtime/InputManagement/NullInputHandler.cs
+++ b/Prowl.Runtime/InputManagement/NullInputHandler.cs
@@ -33,6 +33,7 @@ internal class NullInputHandler : IInputHandler
     public void SetCursorShape(PaperCursor shape, int miceIndex = 0) { }
 
     public int GetGamepadCount() => 0;
+    public int GetGamepadSlotCount() => 0;
     public bool IsGamepadConnected(int gamepadIndex) => false;
     public bool GetGamepadButton(int gamepadIndex, GamepadButton button) => false;
     public bool GetGamepadButtonDown(int gamepadIndex, GamepadButton button) => false;


### PR DESCRIPTION
Input.GetGamepadCount() returned `Context.Gamepads.Count`, which is the backend's fixed slot capacity, so it was always returning 16, regardless of how many controllers were actually attached.

To keep both sets of data available, this is split into two methods:

- GetGamepadCount() which gives the actual connected pad count
- GetGamepadSlotCount() which gives the backend's slot capacity (so 16 atm), i.e. the range to scan when looking for a device

InputBindingListener used the count as an index bound, so it moves to GetGamepadSlotCount(). Without that it would have stopped seeing a controller in slot 3 when slots 1 and 2 were empty.