### PR TITLE
Pass VSync toggle during rendering rather than only at startup

### DIFF
--- a/Prowl.Runtime/Graphics/Graphics.cs
+++ b/Prowl.Runtime/Graphics/Graphics.cs
@@ -232,6 +232,12 @@ public static unsafe class Graphics
 
                 if (job.IsFrameEnd)
                 {
+                    // VSync changes are requested from the main thread but SwapInterval needs the context,
+                    // which lives on this thread for the whole run. Applied next to SwapBuffers because that
+                    // is the call the interval governs.
+                    try { Window.ApplyPendingSwapInterval(); }
+                    catch (Exception ex) { Debug.LogError($"SwapInterval failed: {ex}"); }
+
                     try { Window.InternalWindow.GLContext!.SwapBuffers(); }
                     catch (Exception ex) { Debug.LogError($"SwapBuffers failed: {ex}"); }
                     finally { s_renderFrameDone.Set(); }

--- a/Prowl.Runtime/Window.cs
+++ b/Prowl.Runtime/Window.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Runtime.InteropServices;
+using System.Threading;
 
 using Silk.NET.Input;
 using Silk.NET.Maths;
@@ -127,10 +128,35 @@ public static class Window
         set { InternalWindow.IsVisible = value; }
     }
 
+    // Requested swap interval, or -1 for "nothing pending".
+    private static int s_pendingSwapInterval = -1;
+
     public static bool VSync
     {
         get { return InternalWindow.VSync; }
-        set { InternalWindow.VSync = value; }
+        set
+        {
+            InternalWindow.VSync = value;
+
+            // IWindow.VSync is only read by Silk.NET's automatic Render path, which does not run under the manual loop - so setting it alone changes nothing.
+            // SwapInterval is the call that matters, but it needs the GL context current, and Start() hands the context to the render thread without it ever returning to main.
+            // So record the request and let the render thread apply it.
+            Interlocked.Exchange(ref s_pendingSwapInterval, value ? 1 : 0);
+        }
+    }
+
+    /// <summary>
+    /// Applies a pending <see cref="VSync"/> change. **Render thread only** - the caller must hold the GL context current.
+    /// </summary>
+    internal static void ApplyPendingSwapInterval()
+    {
+        int pending = Interlocked.Exchange(ref s_pendingSwapInterval, -1);
+        if (pending < 0)
+        {
+            return;
+        }
+
+        InternalWindow.GLContext?.SwapInterval(pending);
     }
 
     public static float FramesPerSecond


### PR DESCRIPTION
The swap interval is pushed once, at Start(). InternalWindow.VSync is the property Silk's own render loop would consult — and Prowl doesn't use that loop. So the setter updates a value nobody reads, and the toggle can never do anything at runtime. It only works via InitWindow's options because Start() reads it once afterwards.

This change makes it so that the setter now also stores it as a pending swap, which is read during the render loop as it needs the context.

I know there was mention on the Editor VSync issue (which this also covers in addition to builds) about looking into a more robust solution (framerate caps, etc.) so just wanted to at least throw this up should someone else want it if this isn't something that you want merged in lieu of the other solution.