### PR TITLE
Wire Quill's brush UV clamp through the UI shader and clamp editor sprite sub-rect previews

### DIFF
--- a/Prowl.Editor/GUI/CustomEditors/AssetEditors/SpriteAssetEditor.cs
+++ b/Prowl.Editor/GUI/CustomEditors/AssetEditors/SpriteAssetEditor.cs
@@ -113,6 +113,8 @@ public class SpriteAssetEditor : AssetImporterEditor
         canvas.SetBrushTextureTransform(
             Transform2D.CreateTranslation(drawX - u0 * sx, drawY + drawH - v0 * sy) *
             Transform2D.CreateScale(sx, sy));
+        // Keep the AA fringe from sampling the neighbouring atlas cell.
+        canvas.SetBrushTextureClamp(u0, v0, u1, v1);
         canvas.RectFilled(drawX, drawY, drawW, drawH, Color32.FromArgb(255, 255, 255, 255));
         canvas.ClearBrushTexture();
 

--- a/Prowl.Editor/GUI/CustomEditors/UIImageEditor.cs
+++ b/Prowl.Editor/GUI/CustomEditors/UIImageEditor.cs
@@ -151,6 +151,8 @@ public class UIImageEditor : CustomEditor
                 canvas.SetBrushTextureTransform(
                     Prowl.Vector.Spatial.Transform2D.CreateTranslation(tx, ty) *
                     Prowl.Vector.Spatial.Transform2D.CreateScale(sx, sy));
+                // Keep the AA fringe from sampling the neighbouring atlas cell.
+                canvas.SetBrushTextureClamp(u0, v0, u0 + du, v0 + dv);
                 canvas.RectFilled(x, y, w, h, tint);
                 canvas.ClearBrushTexture();
             }));

--- a/Prowl.Runtime/Assets/Defaults/UI.shader
+++ b/Prowl.Runtime/Assets/Defaults/UI.shader
@@ -69,6 +69,7 @@ Pass "UI"
 
         uniform vec4 textureTransform;
         uniform vec2 textureTranslation;
+        uniform vec4 textureClamp;         // uMin, vMin, uMax, vMax; uMax <= uMin = unclamped
 
         // Font atlas metrics, supplied by Quill rather than probed with textureSize and hardcoded.
         uniform vec2 atlasTexelSize;       // 1 / font atlas size
@@ -165,7 +166,13 @@ Pass "UI"
             // in fragTexCoord.x (1 = solid core, 0 = outer fringe edge).
             float edgeAlpha = clamp(fragTexCoord.x, 0.0, 1.0);
 
-            vec4 fill = color * texture(texture0, applyTransform(textureTransform, textureTranslation, fragPos));
+            // The AA fringe extends half a physical pixel past the nominal rect and this samples by fragPos,
+            // so without the clamp a sub-rect draw reads whatever is next to it in the atlas.
+            vec2 uv = applyTransform(textureTransform, textureTranslation, fragPos);
+            if (textureClamp.z > textureClamp.x)
+                uv = clamp(uv, textureClamp.xy, textureClamp.zw);
+
+            vec4 fill = color * texture(texture0, uv);
 
             // Backdrop blur: composite the fill over the blurred scene behind the shape.
             if (backdropBlurAmount > 0.0) {

--- a/Prowl.Runtime/GUI/PaperRenderer.cs
+++ b/Prowl.Runtime/GUI/PaperRenderer.cs
@@ -213,6 +213,7 @@ public class PaperRenderer : ICanvasRenderer
             drawCall.GetTextureTransform(fbScale, out Float4 texXf, out Float2 texT);
             cmd.SetVector("textureTransform", texXf);
             cmd.SetVector("textureTranslation", texT);
+            cmd.SetVector("textureClamp", drawCall.TextureClamp);
 
             cmd.DrawIndexed(_vertexArrayObject, Topology.Triangles, (uint)drawCall.ElementCount, (uint)indexOffset, 0, true);
             indexOffset += drawCall.ElementCount;


### PR DESCRIPTION
Uses Anthology / Quill PR: https://github.com/ProwlEngine/Anthology/pull/13

As mentioned this is out of my wheelhouse, so largely handled by Claude. Tested locally and it does fix the issue though.

## Problem

Sprite sub-rect draws through Paper/Quill bleed the neighbouring atlas cell along their edges:
`RectFilled`'s AA fringe extends half a physical pixel past the nominal rect, and the canvas shader
samples the brush texture by fragment position with coverage applied after the sample, so fringe
fragments read UVs outside the sprite's window. See the companion Anthology PR for the full
mechanism and the new `SetBrushTextureClamp` API (with its load-bearing half-texel inset).

## Fix

Consume the new Quill brush UV clamp:

- `Prowl.Runtime/Assets/Defaults/UI.shader` — add the `textureClamp` uniform and clamp the brush UV
  before the sample (port of the `Canvas.slang` change).
- `Prowl.Runtime/GUI/PaperRenderer.cs` — upload `drawCall.TextureClamp`.
- `Prowl.Editor/.../SpriteAssetEditor.cs` and `Prowl.Editor/.../UIImageEditor.cs` — the two editor
  previews that draw sprite sub-rects opt in with `canvas.SetBrushTextureClamp(u0, v0, u1, v1)`
  after setting the brush texture/transform.

Notes:

- Depends on the Anthology PR: needs a `Prowl.Paper` package containing `Brush.TextureClamp` /
  `SetBrushTextureClamp` / `DrawCall.TextureClamp` (version bump) before this builds against the feed.
- The runtime `UIImage` component is unaffected by design — it maps sprite UVs through mesh vertex
  UVs, not Quill brush sampling.
- Full-texture editor brush draws (texture preview, sprite editor backdrop, scene/game view RT
  blits) are left unclamped on purpose: their `[0,1]` windows only artifact on Repeat samplers.