### PR TITLE
Window sprite sub-rect previews to Quill's new brush texture window

### DIFF
--- a/Prowl.Editor/GUI/CustomEditors/AssetEditors/SpriteAssetEditor.cs
+++ b/Prowl.Editor/GUI/CustomEditors/AssetEditors/SpriteAssetEditor.cs
@@ -113,6 +113,9 @@ public class SpriteAssetEditor : AssetImporterEditor
         canvas.SetBrushTextureTransform(
             Transform2D.CreateTranslation(drawX - u0 * sx, drawY + drawH - v0 * sy) *
             Transform2D.CreateScale(sx, sy));
+        // Window the brush to the sprite's cell; the inset is only needed for blending filters.
+        canvas.SetBrushTextureWindow(u0, v0, u1, v1,
+            insetHalfTexel: tex.MagFilter != TextureMag.Nearest || tex.MinFilter != TextureMin.Nearest);
         canvas.RectFilled(drawX, drawY, drawW, drawH, Color32.FromArgb(255, 255, 255, 255));
         canvas.ClearBrushTexture();
 

--- a/Prowl.Editor/GUI/CustomEditors/UIImageEditor.cs
+++ b/Prowl.Editor/GUI/CustomEditors/UIImageEditor.cs
@@ -151,6 +151,9 @@ public class UIImageEditor : CustomEditor
                 canvas.SetBrushTextureTransform(
                     Prowl.Vector.Spatial.Transform2D.CreateTranslation(tx, ty) *
                     Prowl.Vector.Spatial.Transform2D.CreateScale(sx, sy));
+                // Window the brush to the sprite's cell; the inset is only needed for blending filters.
+                canvas.SetBrushTextureWindow(u0, v0, u0 + du, v0 + dv,
+                    insetHalfTexel: tex.MagFilter != TextureMag.Nearest || tex.MinFilter != TextureMin.Nearest);
                 canvas.RectFilled(x, y, w, h, tint);
                 canvas.ClearBrushTexture();
             }));

--- a/Prowl.Runtime/GUI/PaperRenderer.cs
+++ b/Prowl.Runtime/GUI/PaperRenderer.cs
@@ -113,6 +113,9 @@ public class PaperRenderer : ICanvasRenderer
     public Int2 GetTextureSize(object texture)
     {
         if (texture is not Texture2D tex) throw new ArgumentException("Invalid texture type");
+        // Quill asks at draw time, and a reimport can dispose the texture mid-frame while a panel
+        // still draws it; zero means "skip texel-precise padding" rather than letting Width throw.
+        if (!tex.IsValid()) return Int2.Zero;
         return new Int2((int)tex.Width, (int)tex.Height);
     }
 


### PR DESCRIPTION
Prowl side changes for: https://github.com/ProwlEngine/Anthology/pull/15

The PaperRenderer change can be made by itself, just helps to prevent a potential crash and technically does not rely on the Anthology merge at all either (albeit said merge makes it easier to trigger). The custom editors are 100% optional and can be omitted entirely if we don't want them, but given its a single line each figured I'd throw them up for consistency / an example.