### PR TITLE
Fix NRE when deleting a texture or sprite in the Editor

### DIFF
--- a/Prowl.Editor/GUI/CustomEditors/AssetEditors/SpriteAssetEditor.cs
+++ b/Prowl.Editor/GUI/CustomEditors/AssetEditors/SpriteAssetEditor.cs
@@ -92,7 +92,7 @@ public class SpriteAssetEditor : AssetImporterEditor
                 canvas.RectFilled(px, py, cw, ch, ((cx + cy) & 1) == 0 ? ca : cb);
             }
 
-        if (tex == null || tex.Width == 0 || tex.Height == 0 || sprite.Rect.Width <= 0 || sprite.Rect.Height <= 0)
+        if (tex.IsNotValid() || tex.Width == 0 || tex.Height == 0 || sprite.Rect.Width <= 0 || sprite.Rect.Height <= 0)
             return;
 
         // Fit the sprite rect's aspect inside the preview.

--- a/Prowl.Editor/GUI/CustomEditors/AssetEditors/TextureAssetEditor.cs
+++ b/Prowl.Editor/GUI/CustomEditors/AssetEditors/TextureAssetEditor.cs
@@ -46,8 +46,9 @@ public class TextureAssetEditor : ImportSettingsEditor
         if (font == null) return;
         var m = Origami.Current.Metrics;
         AssetRef<Texture2D> texture = (AssetRef<Texture2D>)(Texture2D)asset;
+        Texture2D? tex = texture.Res;
 
-        if (texture != null)
+        if (tex.IsValid())
         {
             // Preview card: checkerboard behind the image so alpha reads clearly.
             paper.Box($"{id}_preview")
@@ -71,15 +72,17 @@ public class TextureAssetEditor : ImportSettingsEditor
                             canvas.RectFilled(px, py, cw, ch, ((cx + cy) & 1) == 0 ? ca : cb);
                         }
 
+                    if (tex.IsNotValid()) return;
+
                     float maxW = (float)r.Size.X - 16, maxH = (float)r.Size.Y - 16;
-                    float aspect = texture.Res.Width / MathF.Max(1f, texture.Res.Height);
+                    float aspect = tex.Width / MathF.Max(1f, tex.Height);
                     float drawW = maxW, drawH = drawW / aspect;
                     if (drawH > maxH) { drawH = maxH; drawW = drawH * aspect; }
                     float drawX = (float)r.Min.X + ((float)r.Size.X - drawW) / 2f;
                     float drawY = (float)r.Min.Y + ((float)r.Size.Y - drawH) / 2f;
 
                     // Flip V (textures are stored Y-up), same idiom the scene view uses for its RT.
-                    canvas.SetBrushTexture(texture.Res);
+                    canvas.SetBrushTexture(tex);
                     canvas.SetBrushTextureTransform(
                         Transform2D.CreateTranslation(drawX, drawY + drawH) *
                         Transform2D.CreateScale(drawW, -drawH));
@@ -91,9 +94,9 @@ public class TextureAssetEditor : ImportSettingsEditor
             using (paper.Row($"{id}_stats").Height(UnitValue.Auto)
                 .Margin(m.PaddingLarge, m.PaddingLarge, 0, m.SpacingLarge).RowBetween(m.SpacingMedium).Enter())
             {
-                EditorGUI.StatChip(paper, $"{id}_st_size", $"{texture.Res.Width} x {texture.Res.Height}", font);
-                EditorGUI.StatChip(paper, $"{id}_st_fmt", texture.Res.ImageFormat.ToString(), font);
-                EditorGUI.StatChip(paper, $"{id}_st_mip", texture.Res.IsMipmapped ? "Mipmapped" : "No Mipmaps", font);
+                EditorGUI.StatChip(paper, $"{id}_st_size", $"{tex.Width} x {tex.Height}", font);
+                EditorGUI.StatChip(paper, $"{id}_st_fmt", tex.ImageFormat.ToString(), font);
+                EditorGUI.StatChip(paper, $"{id}_st_mip", tex.IsMipmapped ? "Mipmapped" : "No Mipmaps", font);
                 paper.Box($"{id}_st_pad").Height(1).IsNotInteractable();
             }
         }
@@ -104,7 +107,7 @@ public class TextureAssetEditor : ImportSettingsEditor
         // Read once and kept live per asset by the base; edits stay put while you look at something else.
         EchoObject settings = Settings(entry);
 
-        EditorGUI.SectionHeader(paper, $"{id}_settings_hdr", "Import Settings", first: texture == null);
+        EditorGUI.SectionHeader(paper, $"{id}_settings_hdr", "Import Settings", first: tex.IsNotValid());
 
         bool genMips = settings.TryGet("generateMipmaps", out var mipTag) && mipTag.BoolValue;
         EditorGUI.SettingsToggle(paper, $"{id}_mips", "Generate Mipmaps", genMips,


### PR DESCRIPTION
Trying to delete a sprite/texture in the Editor usually gives me a null reference that crashes the editor (it does still delete). Issue was they were using old null check instead of Valid/NotValid