### PR TITLE
Screenshot support

### DIFF
--- a/Prowl.Runtime/Game.cs
+++ b/Prowl.Runtime/Game.cs
@@ -172,6 +172,11 @@ public abstract class Game
 
                 _paper.EndFrame();
 
+                // Give presentation hosts a point after all scene and Paper commands have been
+                // submitted but before the backbuffer is swapped. Development screenshot capture
+                // uses this hook to read the actual rendered client on the render thread.
+                AfterGui(currentScene);
+
                 // === End Graphics ===
 
                 RenderTexture.UpdatePool();
@@ -372,6 +377,9 @@ public abstract class Game
     public virtual void EndRender() { }
     public virtual void BeginGui(Paper paper) { }
     public virtual void EndGui(Paper paper) { }
+
+    /// <summary>Called after the GUI frame is submitted and before the backbuffer is swapped.</summary>
+    public virtual void AfterGui(Scene? scene) { }
 
     /// <summary>Called during update. Override to control scene update/gizmo behavior.</summary>
     public virtual void OnUpdate(Scene? scene)

--- a/Prowl.Runtime/Graphics/Commands/CommandBuffer.cs
+++ b/Prowl.Runtime/Graphics/Commands/CommandBuffer.cs
@@ -781,6 +781,16 @@ public sealed class CommandBuffer : IDisposable
         Write((long)destination);
     }
 
+    /// <summary>Captures the default framebuffer into <paramref name="texture"/>.
+    /// Executed on the render thread; the caller must use SubmitAndWait.</summary>
+    internal void EncodeScreenshot(GraphicsTexture texture, int width, int height)
+    {
+        WriteHeader(CommandOpcode.Screenshot);
+        Write(PushObject(texture));
+        Write(width);
+        Write(height);
+    }
+
     /// <summary>Defers GL setup to the executor, which calls the wrapper's
     /// <c>CreateGLObject()</c>. Same pattern for VAO / Framebuffer / Program.</summary>
     internal void EncodeCreateVertexArray(GraphicsVertexArray vao)

--- a/Prowl.Runtime/Graphics/Commands/CommandExecutor.cs
+++ b/Prowl.Runtime/Graphics/Commands/CommandExecutor.cs
@@ -621,6 +621,15 @@ internal sealed class CommandExecutor
                     unsafe { tex.GetTexImage(mip, (void*)(nint)raw); }
                     break;
                 }
+                case CommandOpcode.Screenshot:
+                {
+                    var texture = (GraphicsTexture)objects[ReadU16(stream, ref pos)]!;
+                    int width = ReadI32(stream, ref pos);
+                    int height = ReadI32(stream, ref pos);
+                    texture.Bind();
+                    Graphics.GL.CopyTexImage2D(TextureTarget.Texture2D, 0, InternalFormat.Rgba8, 0, 0, (uint)width, (uint)height, 0);
+                    break;
+                }
                 case CommandOpcode.CreateVertexArrayOp:
                 {
                     var vao = (GraphicsVertexArray)objects[ReadU16(stream, ref pos)]!;

--- a/Prowl.Runtime/Graphics/Commands/CommandOpcode.cs
+++ b/Prowl.Runtime/Graphics/Commands/CommandOpcode.cs
@@ -106,4 +106,7 @@ internal enum CommandOpcode : ushort
     // Debug markers
     BeginSample,
     EndSample,
+
+    // Development screenshot capture; appended to preserve existing opcode values.
+    Screenshot,
 }

--- a/Prowl.Runtime/Graphics/Graphics.cs
+++ b/Prowl.Runtime/Graphics/Graphics.cs
@@ -3,6 +3,7 @@
 
 using System;
 
+using Prowl.Runtime.Resources;
 using Prowl.Vector;
 
 using Silk.NET.Core.Native;
@@ -407,6 +408,50 @@ public static unsafe class Graphics
         using var cmd = GetCommandBuffer("Texture.TexSubImage3D");
         cmd.EncodeUpdateTexture3D(texture, level, x, y, z, width, height, depth, span);
         Submit(cmd);
+    }
+
+    /// <summary>
+    /// Captures the currently bound default framebuffer as a <see cref="Texture2D"/>. The caller
+    /// receives a normal texture and can use <see cref="Texture2D.GetData{T}"/> / sampling /
+    /// serialization without managing raw byte buffers. The texture is stored bottom-up (GPU Y-up,
+    /// matching other Prowl textures). Callers that encode to PNG or other top-down formats should
+    /// flip rows before encoding.
+    /// </summary>
+    public static Texture2D Screenshot()
+    {
+        if (IsHeadless || Window.InternalWindow is null)
+        {
+            throw new InvalidOperationException("No graphical framebuffer is available.");
+        }
+
+        var size = Window.InternalWindow.FramebufferSize;
+        int width = size.X;
+        int height = size.Y;
+        if (width is < 1 or > 16_384 || height is < 1 or > 16_384)
+        {
+            throw new InvalidOperationException("The graphical framebuffer has an invalid size.");
+        }
+
+        int rowBytes = checked(width * 4);
+        ulong totalBytes = checked((ulong)rowBytes * (ulong)height);
+        if (totalBytes > 64UL * 1024UL * 1024UL)
+        {
+            throw new InvalidOperationException("The graphical framebuffer exceeds the capture size limit.");
+        }
+
+        if (totalBytes > int.MaxValue)
+        {
+            throw new InvalidOperationException("The graphical framebuffer is too large for readback.");
+        }
+
+        var texture = new Texture2D((uint)width, (uint)height, false, TextureImageFormat.Color4b);
+        using (var cmd = GetCommandBuffer("Screenshot"))
+        {
+            cmd.EncodeScreenshot(texture.Handle, width, height);
+            SubmitAndWait(cmd);
+        }
+
+        return texture;
     }
 
     /// <summary>Bytes per pixel under tight packing, used to size copies into the


### PR DESCRIPTION
Support taking screenshots in engine itself. (Used for automation tests in downstream project)

```
- Game: add virtual AfterGui(Scene?) called after _paper.EndFrame() before backbuffer swap. Presentation hosts use this to capture the rendered frame on the render thread (for automation screenshot).

- Graphics: restore ReadPixels + CommandBuffer/Executor/Opcode for framebuffer readback (removed upstream).

- Prowl.Runtime: bump Magick.NET-Q8-AnyCPU 14.13.0 -> 14.16.0 to fix known vulnerabilities.
```