### PR TITLE
Fix asset selector search only matching the first 200 assets

### DIFF
--- a/Prowl.Editor/GUI/Popups/SelectorModal.cs
+++ b/Prowl.Editor/GUI/Popups/SelectorModal.cs
@@ -309,14 +309,16 @@ public static class SelectorModal
             return;
         }
 
-        var items = db.FindAllOfType(_targetType).Take(200).ToList();
+        // Exact then prefix matches sort ahead so the closest ones survive the cap.
+        var all = db.FindAllOfType(_targetType);
+        var matches = string.IsNullOrEmpty(_searchText)
+            ? all
+            : all.Where(i => i.name.Contains(_searchText, StringComparison.OrdinalIgnoreCase))
+                 .OrderBy(i => i.name.Equals(_searchText, StringComparison.OrdinalIgnoreCase) ? 0
+                             : i.name.StartsWith(_searchText, StringComparison.OrdinalIgnoreCase) ? 1 : 2)
+                 .ThenBy(i => i.name, StringComparer.OrdinalIgnoreCase);
 
-        // Filter by search
-        if (!string.IsNullOrEmpty(_searchText))
-        {
-            items = items.Where(i =>
-                i.name.Contains(_searchText, StringComparison.OrdinalIgnoreCase)).ToList();
-        }
+        var items = matches.Take(200).ToList();
 
         const float cellSize = 72f;
         const float labelH = 18f;


### PR DESCRIPTION
# Summary

SelectorModal's Assets tab capped the candidate list before applying the search query, so search only ever considered the first 200 entries in enumeration order no matter what. 

With a large amount of sliced sprites, even if I name one something specific like "B_KEY_SHEET", because it falls beyond number 200, it was never reachable.

# Fix

Filter first, then cap, so the 200 limits what's drawn rather than searched. Matches are now also ordered exact -> prefix -> substring so that an exact name stays visible even if the search text would bring back 200 assets.

# Ideal Follow-up

Origami's ScrollView should (as in, I think it does support it, it just needs the plumbing) support virtualizing the whole thing like Table.DrawRowsVirtual does, but that seems a bit more in-depth of a change than just fixing the search for now. Something to possibly consider, but this will probably solve 99% of issues.