### PR TITLE
Modified icons invocations to standardize them

### DIFF
--- a/Prowl.Editor/GUI/Panels/HierarchyPanel.cs
+++ b/Prowl.Editor/GUI/Panels/HierarchyPanel.cs
@@ -366,8 +366,8 @@ public class HierarchyPanel : DockPanel
                         var (goIcon, goColor) = GetGoStyle(go);
                         if (!go.EnabledInHierarchy) goColor = Color.FromArgb(120, goColor);
                         paper.Box($"hier_ico_{goId}")
-                            .Width(18).Height(EditorTheme.RowHeight).IsNotInteractable()
-                            .Icon(paper, goIcon, goColor, size: 14f);
+                            .Width(24).Height(EditorTheme.RowHeight).IsNotInteractable()
+                            .Icon(paper, goIcon, goColor, size: 19f);
 
                         // Name or rename field
                         if (RenameOverlay.IsRenaming(goId))
@@ -393,9 +393,10 @@ public class HierarchyPanel : DockPanel
                         // Visibility eye
                         paper.Box($"hier_vis_{goId}")
                             .Width(18).Height(EditorTheme.RowHeight)
-                            .Text(node.TrailingIcon ?? "", font)
+                            /*.Text(node.TrailingIcon ?? "", font)
                             .TextColor(node.TrailingIconColor ?? EditorTheme.Ink400)
-                            .FontSize(9f).Alignment(TextAlignment.MiddleCenter)
+                            .FontSize(9f).Alignment(TextAlignment.MiddleCenter)*/
+                            .Icon(paper, new EditorGlyphIcon(node.TrailingIcon ?? ""), node.TrailingIconColor ?? EditorTheme.Ink400, size: 19f)
                             .StopEventPropagation()
                             .OnClick(go, (g, _) =>
                             {

--- a/Prowl.Editor/GUI/Popups/NewScriptDialog.cs
+++ b/Prowl.Editor/GUI/Popups/NewScriptDialog.cs
@@ -168,47 +168,22 @@ public static class NewScriptDialog
         // Footer buttons right-aligned Cancel + Create. The Create button is a real
         // EditorGUI.Button when valid; when invalid we render a visually-disabled Box
         // so the user sees the error hint rather than clicking a dead button.
-        using (paper.Row("scr_btns").Height(EditorTheme.RowHeight).JustifyContent(LayoutJustification.End).Gap(8).Enter())
+        using (paper.Row("scr_btns").Height(EditorTheme.RowHeight).JustifyContent(LayoutJustification.End).Margin(0,0,0,8).Gap(8).Enter())
         {
             Origami.Button(paper, "scr_cancel", Loc.Get("common.cancel"), () => { Modal.Pop(); }).Width(90).Show();
 
             if (ok)
             {
-                using (paper.Box("scr_create")
-                           .Width(110).Height(EditorTheme.RowHeight).Rounded(3)
-                           .BackgroundColor(EditorTheme.Purple400)
-                           .Hovered.BackgroundColor(EditorTheme.Purple500).End()
-                           .BorderWidth(1).BorderColor(EditorTheme.Purple400)
-                           .OnClick(0, (_, _) => DoCreate())
-                           .Enter())
+
+                Origami.Button(paper, "scr_create", Loc.Get("launcher.create"), () =>
                 {
-                    if (font != null)
-                        paper.Box("scr_create_lbl")
-                            .Width(UnitValue.Stretch()).Height(EditorTheme.RowHeight)
-                            .Text(Loc.Get("launcher.create"), font)
-                            .TextColor(EditorTheme.Ink700)
-                            .FontSize(EditorTheme.FontSize)
-                            .Alignment(TextAlignment.MiddleCenter)
-                            .IsNotInteractable();
-                }
+                    DoCreate();
+                }).Primary().Width(90).Show();
+
             }
             else
             {
-                using (paper.Box("scr_create_disabled")
-                           .Width(110).Height(EditorTheme.RowHeight).Rounded(3)
-                           .BackgroundColor(EditorTheme.Neutral200)
-                           .BorderWidth(1).BorderColor(EditorTheme.Neutral100)
-                           .Enter())
-                {
-                    if (font != null)
-                        paper.Box("scr_create_dis_lbl")
-                            .Width(UnitValue.Stretch()).Height(EditorTheme.RowHeight)
-                            .Text(Loc.Get("launcher.create"), font)
-                            .TextColor(EditorTheme.Ink300)
-                            .FontSize(EditorTheme.FontSize)
-                            .Alignment(TextAlignment.MiddleCenter)
-                            .IsNotInteractable();
-                }
+                Origami.Button(paper, "scr_create_disabled", Loc.Get("launcher.create"), null).Primary().Disabled(true).Width(90).Show();
             }
         }
     }

--- a/Prowl.Editor/GUI/Popups/NewScriptDialog.cs
+++ b/Prowl.Editor/GUI/Popups/NewScriptDialog.cs
@@ -95,10 +95,9 @@ public static class NewScriptDialog
                                 if (font != null)
                                 {
                                     paper.Box($"scr_tpl_ico_{i}")
-                                        .Width(22).Height(28)
-                                        .Text(tpl.Icon, font)
-                                        .TextColor(EditorTheme.Ink500)
-                                        .FontSize(11f).Alignment(TextAlignment.MiddleCenter);
+                                        .Width(28).Height(28)
+                                        .Icon(paper, tpl.OrigamiIcon, EditorTheme.Ink500, size: 24f);
+
                                     paper.Box($"scr_tpl_name_{i}")
                                         .Width(UnitValue.Stretch()).Height(28)
                                         .Text(tpl.Name, font)

--- a/Prowl.Editor/GUI/Registries/ScriptTemplateRegistry.cs
+++ b/Prowl.Editor/GUI/Registries/ScriptTemplateRegistry.cs
@@ -1,5 +1,7 @@
 using System;
 
+using Prowl.OrigamiUI;
+
 namespace Prowl.Editor.GUI;
 
 /// <summary> Attribute applied to a method that generates a script template. Provides metadata for the template entry displayed in the editor. </summary>
@@ -9,12 +11,13 @@ public sealed class ScriptTemplateAttribute : Attribute
     public string Name { get; }
     public string Description { get; }
     public string Icon { get; }
+    public IOrigamiIcon OrigamiIcon;
     /// <summary> Gets or sets the sort order of this template relative to others. </summary>
     public int Order { get; set; }
 
     public ScriptTemplateAttribute(string name, string description, string icon)
     {
-        Name = name; Description = description; Icon = icon;
+        Name = name; Description = description; Icon = icon; OrigamiIcon = new EditorGlyphIcon(Icon);
     }
 }
 
@@ -24,6 +27,7 @@ public sealed class ScriptTemplate
     public string Name { get; }
     public string Description { get; }
     public string Icon { get; }
+    public IOrigamiIcon OrigamiIcon;
     /// <summary> Gets the sort order of this template relative to others. </summary>
     public int Order { get; }
     /// <summary> Gets the function that generates the script content from a class name. </summary>
@@ -31,6 +35,7 @@ public sealed class ScriptTemplate
 
     public ScriptTemplate(string name, string description, string icon, int order, Func<string, string> generate)
     {
-        Name = name; Description = description; Icon = icon; Order = order; Generate = generate;
+        Name = name; Description = description; Icon = icon;
+        OrigamiIcon = new EditorGlyphIcon(Icon); Order = order; Generate = generate;
     }
 }


### PR DESCRIPTION
As the title states, the purpose of this is to standardize icon calls in Hierarchy and NewScriptDialog so that they can be modified more easily in the future if necessary. Furthermore, this makes the size of icons in the Hierarchy and in the NewScriptDialog a bit larger so that they're easier on the eyes.

Size increased
<img width="585" height="162" alt="image" src="https://github.com/user-attachments/assets/896a0a71-391a-4726-a52b-5254b3af63ef" />

Original size
<img width="588" height="171" alt="image" src="https://github.com/user-attachments/assets/576b23e0-d130-4f4b-8736-56bb5805f262" />


This also opens a question: do we want to make this larger in scope? I do believe there are more areas of interest that use Icon which could be standardized (i.e. the Component header row in the GameObjectInspector), should this change extend into those areas as well? Let me know and I can make the changes.