### PR TITLE
Adjusted RectTransform inspector, TextComponent editor and UIImageEditor

### DIFF
--- a/Prowl.Editor/GUI/CustomEditors/GameObjectInspector.cs
+++ b/Prowl.Editor/GUI/CustomEditors/GameObjectInspector.cs
@@ -490,14 +490,21 @@ public static class GameObjectInspector
     {
         var rt = go.RectTransform!;
         var t = go.Transform;
+        var goId = go.Identifier;
 
-        paper.Box("gi_rt_header").Height(22).PaddingLeft(8)
-            .Text($"{EditorIcons.VectorSquare}  Rect Transform", font)
-            .TextColor(EditorTheme.Ink500)
-            .FontSize(EditorTheme.FontSize).Alignment(TextAlignment.MiddleLeft);
+        bool expanded = SectionHeader(paper, font, $"gi_recttransform_{goId}", EditorIcons.VectorSquare,
+            Loc.Get("inspector.recttransform"), EditorTheme.Ink500, () =>
+            {
+                EditorGUI.HeaderIconButton(paper, "gi_tf_reset", EditorIcons.ArrowRotateRight, () => ResetTransform(go));
+                EditorGUI.HeaderIconButton(paper, "gi_tf_dots", EditorIcons.EllipsisVertical, () =>
+                    Origami.ContextMenu((float)paper.PointerPos.X, (float)paper.PointerPos.Y, b =>
+                        b.Item(Loc.Get("inspector.reset"), () => ResetTransform(go), icon: EditorIcons.ArrowRotateRight)));
+            });
+
+        if (!expanded) return;
 
         // Top block: 4x4 anchor preset grid on the left, position + size fields filling the rest.
-        using (paper.Row("gi_rt_top").Height(UnitValue.Auto).Gap(8).Margin(4, 4, 2, 2).Enter())
+        using (paper.Row("gi_rt_top").Height(UnitValue.Auto).Gap(8).Margin(8, 4, 2, 2).Enter())
         {
             DrawAnchorPresetGrid(paper, font, go, rt);
 

--- a/Prowl.Editor/GUI/CustomEditors/TextComponentEditor.cs
+++ b/Prowl.Editor/GUI/CustomEditors/TextComponentEditor.cs
@@ -3,10 +3,14 @@
 
 using Prowl.Editor.Core;
 using Prowl.Editor.GUI;
+using Prowl.Editor.Theming;
+using Prowl.Editor.Utils;
 using Prowl.OrigamiUI;
 using Prowl.PaperUI;
+using Prowl.PaperUI.LayoutEngine;
 using Prowl.Runtime;
 using Prowl.Runtime.Resources;
+using Prowl.Vector;
 
 namespace Prowl.Editor.Inspector;
 
@@ -26,11 +30,16 @@ public class TextComponentEditor : CustomEditor
         // ── Text Input ────────────────────────────────────────────
         Origami.Header(paper, $"{id}_h_text", "Text Input").Show();
 
-        // Full-width multi-line area
-        // Sits outside InspectorRow so it isn't clamped to a single row's height.
-        Origami.TextArea(paper, $"{id}_text", text.Text, v => text.Text = v ?? string.Empty, rows: 6)
-            .Placeholder("Enter text...")
-            .Show();
+        int rows = 6;
+
+        using (paper.Box($"{id}_text_box_container").Padding(10).Height(in UnitValue.Auto).Enter())
+        {
+            // Full-width multi-line area
+            // Sits outside InspectorRow so it isn't clamped to a single row's height.
+            Origami.TextArea(paper, $"{id}_text", text.Text, v => text.Text = v ?? string.Empty, rows: rows)
+                .Placeholder("Enter text...")
+                .Show();
+        }
 
         paper.Box($"{id}_sp0").Height(6);
 
@@ -40,31 +49,32 @@ public class TextComponentEditor : CustomEditor
         PropertyGridUtils.DrawField(paper, $"{id}_font", "Font Asset", typeof(AssetRef<FontAsset>), text.Font,
             v => text.Font = (AssetRef<FontAsset>)v!, 0);
 
-        paper.Box($"{id}_sp0.1").Height(6);
+        //paper.Box($"{id}_sp0.1").Height(6);
 
-        EditorGUI.Row(paper, $"{id}_size", "Font Size", () =>
-            Origami.NumericField<int>(paper, $"{id}_size_v", text.Size, v => text.Size = v).Show());
+        using (paper.Box($"{id}_text_properties").Height(in UnitValue.Auto).Gap(EditorTheme.Spacing * 2f).Enter())
+        {
 
-        paper.Box($"{id}_sp0.15").Height(6);
+            PropertyGridUtils.DrawField(paper, $"{id}_font", "Font Asset", typeof(int), text.Size,
+                v => text.Size = (int)v!, 0);
 
-        EditorGUI.Row(paper, $"{id}_quality", "Quality", () =>
-            Origami.EnumDropdown<Prowl.Scribe.FontQuality>(paper, $"{id}_quality_v", text.Quality, v => text.Quality = v).Show());
+            PropertyGridUtils.DrawField(paper, $"{id}_size", "Font Size", typeof(Prowl.Scribe.FontQuality),
+                text.Quality,
+                v => text.Quality = (Prowl.Scribe.FontQuality)v!, 0);
 
-        paper.Box($"{id}_sp0.18").Height(6);
+            PropertyGridUtils.DrawField(paper, $"{id}_quality", "Quality", typeof(Prowl.Scribe.FontQuality),
+                text.Quality,
+                v => text.Quality = (Prowl.Scribe.FontQuality)v!, 0);
 
-        Origami.Checkbox(paper, $"{id}_rich", text.RichTextEnabled, v => text.RichTextEnabled = v)
-            .LabelRight("Rich Text").Show();
+            PropertyGridUtils.DrawField(paper, $"{id}_richtext", "Rich Text", typeof(bool), text.RichTextEnabled,
+                v => text.RichTextEnabled = (bool)v!, 0);
 
-        paper.Box($"{id}_sp0.2").Height(6);
 
-        EditorGUI.Row(paper, $"{id}_color", "Color", () =>
-        Origami.ColorField(paper, $"{id}_color_f", text.Color, v => text.Color = v).Show());
+            PropertyGridUtils.DrawField(paper, $"{id}_color", "Color", typeof(Color), text.Color,
+                v => text.Color = (Color)v!, 0);
 
-        paper.Box($"{id}_sp0.3").Height(6);
+            EditorGUI.TextAlignmentRow(paper, $"{id}_align", "Alignment", text.Alignment, v => text.Alignment = v);
+        }
 
-        EditorGUI.TextAlignmentRow(paper, $"{id}_align", "Alignment", text.Alignment, v => text.Alignment = v);
-
-        paper.Box($"{id}_sp1").Height(6);
 
         // ── Extra Settings ────────────────────────────────────────
         Origami.Header(paper, $"{id}_h_extra", "Extra Settings").Show();

--- a/Prowl.Editor/GUI/CustomEditors/UIImageEditor.cs
+++ b/Prowl.Editor/GUI/CustomEditors/UIImageEditor.cs
@@ -30,46 +30,47 @@ public class UIImageEditor : CustomEditor
 
         Undo.Snapshot(img);
 
-        DrawSourceRow(paper, $"{id}_src", img);
-
-        paper.Box($"{id}_sp0").Height(EditorTheme.Spacing);
-
-        EditorGUI.Row(paper, $"{id}_color", "Color", () =>
-            Origami.ColorField(paper, $"{id}_color_v", img.Color, v => img.Color = v).Show());
-
-        PropertyGridUtils.DrawField(paper, $"{id}_mat", "Material",
-            typeof(AssetRef<Material>), img.Material,
-            v => img.Material = (AssetRef<Material>)v!, 0);
-
-        BoolRow(paper, $"{id}_ray", "Raycast Target", img.RaycastTarget, v => img.RaycastTarget = v);
-
-        paper.Box($"{id}_sp1").Height(EditorTheme.Spacing * 2);
-
-        Origami.Header(paper, $"{id}_h_type", "Image Settings").Show();
-
-        EditorGUI.Row(paper, $"{id}_type", "Image Type", () =>
-            Origami.EnumDropdown<ImageType>(paper, $"{id}_type_v", img.Type, v => img.Type = v).Show());
-
-        switch (img.Type)
+        using (paper.Box($"{id}_main_container").Height(in UnitValue.Auto).Gap(EditorTheme.Spacing * 2f).Enter())
         {
-            case ImageType.Simple:
-                DrawSimpleOptions(paper, $"{id}_simple", img);
-                break;
-            case ImageType.Sliced:
-                DrawSlicedOptions(paper, $"{id}_sliced", img);
-                break;
-            case ImageType.Tiled:
-                DrawTiledOptions(paper, $"{id}_tiled", img);
-                break;
-            case ImageType.Filled:
-                DrawFilledOptions(paper, $"{id}_filled", img);
-                break;
+            DrawSourceRow(paper, $"{id}_src", img);
+
+            PropertyGridUtils.DrawField(paper, $"{id}_color", "Color", typeof(Color), img.Color,
+                v => img.Color = (Color)v!, 0);
+
+            PropertyGridUtils.DrawField(paper, $"{id}_mat", "Material",
+                typeof(AssetRef<Material>), img.Material,
+                v => img.Material = (AssetRef<Material>)v!, 0);
+
+            PropertyGridUtils.DrawField(paper, $"{id}_ray", "Raycast Target", typeof(bool), img.RaycastTarget,
+                v => img.RaycastTarget = (bool)v!, 0);
+
+            Origami.Header(paper, $"{id}_h_type", "Image Settings").Show();
+
+            PropertyGridUtils.DrawField(paper, $"{id}_type", "Image Type", typeof(ImageType), img.Type,
+                v => img.Type = (ImageType)v!, 0);
+
+
+            switch (img.Type)
+            {
+                case ImageType.Simple:
+                    DrawSimpleOptions(paper, $"{id}_simple", img);
+                    break;
+                case ImageType.Sliced:
+                    DrawSlicedOptions(paper, $"{id}_sliced", img);
+                    break;
+                case ImageType.Tiled:
+                    DrawTiledOptions(paper, $"{id}_tiled", img);
+                    break;
+                case ImageType.Filled:
+                    DrawFilledOptions(paper, $"{id}_filled", img);
+                    break;
+            }
         }
     }
 
     private static void BoolRow(Paper paper, string id, string label, bool value, Action<bool> setter)
-        => EditorGUI.Row(paper, id, label, () =>
-            Origami.Checkbox(paper, $"{id}_v", value, setter).Show());
+        => PropertyGridUtils.DrawField(paper, id, label, typeof(bool), value,
+            v => setter((bool)v!));
 
     /// <summary>
     /// A sliced sprite (one that carries a border) is almost always meant to be drawn nine-sliced, so on

--- a/Prowl.Editor/GUI/EditorGUI.cs
+++ b/Prowl.Editor/GUI/EditorGUI.cs
@@ -174,13 +174,13 @@ public static class EditorGUI
     public static void TextAlignmentRow(Paper paper, string id, string label, TextAlign value, Action<TextAlign> setter)
     {
         var font = EditorTheme.DefaultFont;
-        using (paper.Row(id).Height(EditorTheme.RowHeight).Gap(6).Enter())
+        using (paper.Row(id).Height(EditorTheme.RowHeight).Padding(EditorTheme.Padding*2, EditorTheme.Padding*2,0,0).Gap(6).Enter())
         {
             if (font != null)
                 paper.Box($"{id}_lbl")
                     .Width(EditorTheme.LabelWidth).Height(EditorTheme.RowHeight)
                     .PaddingLeft(4).IsNotInteractable()
-                    .Text(label, font).TextColor(EditorTheme.Ink500).FontSize(EditorTheme.FontSize);
+                    .Text(label, font).TextColor(EditorTheme.Ink300).FontSize(EditorTheme.FontSize);
 
             Origami.ButtonGroup(paper, $"{id}_h", TextAlignHIndex(value),
                     idx => setter(TextAlignVFlag(TextAlignVIndex(value)) | TextAlignHFlag(idx)))

--- a/Prowl.Editor/Resources/Locale/de.json
+++ b/Prowl.Editor/Resources/Locale/de.json
@@ -182,6 +182,7 @@
   "inspector.tag": "Tag",
   "inspector.layer": "Ebene",
   "inspector.transform": "Transform",
+  "inspector.recttransform": "Rect Transform",
   "inspector.position": "Position",
   "inspector.rotation": "Rotation",
   "inspector.scale": "Skalierung",

--- a/Prowl.Editor/Resources/Locale/en.json
+++ b/Prowl.Editor/Resources/Locale/en.json
@@ -183,6 +183,7 @@
   "inspector.tag": "Tag",
   "inspector.layer": "Layer",
   "inspector.transform": "Transform",
+  "inspector.recttransform": "Rect Transform",
   "inspector.position": "Position",
   "inspector.rotation": "Rotation",
   "inspector.scale": "Scale",

--- a/Prowl.Editor/Resources/Locale/es.json
+++ b/Prowl.Editor/Resources/Locale/es.json
@@ -182,6 +182,7 @@
   "inspector.tag": "Etiqueta",
   "inspector.layer": "Capa",
   "inspector.transform": "Transform",
+  "inspector.recttransform": "Rect Transform",
   "inspector.position": "Posicion",
   "inspector.rotation": "Rotacion",
   "inspector.scale": "Escala",

--- a/Prowl.Editor/Resources/Locale/fr.json
+++ b/Prowl.Editor/Resources/Locale/fr.json
@@ -182,6 +182,7 @@
   "inspector.tag": "Tag",
   "inspector.layer": "Couche",
   "inspector.transform": "Transform",
+  "inspector.recttransform": "Rect Transform",
   "inspector.position": "Position",
   "inspector.rotation": "Rotation",
   "inspector.scale": "Echelle",

--- a/Prowl.Editor/Resources/Locale/it.json
+++ b/Prowl.Editor/Resources/Locale/it.json
@@ -204,6 +204,7 @@
   "inspector.tag": "Tag",
   "inspector.layer": "Livello",
   "inspector.transform": "Transform",
+  "inspector.recttransform": "Rect Transform",
   "inspector.position": "Posizione",
   "inspector.rotation": "Rotazione",
   "inspector.scale": "Scala",

--- a/Prowl.Editor/Resources/Locale/ja.json
+++ b/Prowl.Editor/Resources/Locale/ja.json
@@ -182,6 +182,7 @@
   "inspector.tag": "タグ",
   "inspector.layer": "レイヤー",
   "inspector.transform": "トランスフォーム",
+  "inspector.recttransform": "レクト トランスフォーム",
   "inspector.position": "位置",
   "inspector.rotation": "回転",
   "inspector.scale": "スケール",

--- a/Prowl.Editor/Resources/Locale/ko.json
+++ b/Prowl.Editor/Resources/Locale/ko.json
@@ -204,6 +204,7 @@
   "inspector.tag": "태그",
   "inspector.layer": "레이어",
   "inspector.transform": "트랜스폼",
+  "inspector.recttransform": "직사각형 변환",
   "inspector.position": "위치",
   "inspector.rotation": "회전",
   "inspector.scale": "크기",

--- a/Prowl.Editor/Resources/Locale/pl.json
+++ b/Prowl.Editor/Resources/Locale/pl.json
@@ -204,6 +204,7 @@
   "inspector.tag": "Tag",
   "inspector.layer": "Warstwa",
   "inspector.transform": "Transform",
+  "inspector.recttransform": "Rect Transform",
   "inspector.position": "Pozycja",
   "inspector.rotation": "Rotacja",
   "inspector.scale": "Skala",

--- a/Prowl.Editor/Resources/Locale/pt.json
+++ b/Prowl.Editor/Resources/Locale/pt.json
@@ -204,6 +204,7 @@
   "inspector.tag": "Tag",
   "inspector.layer": "Camada",
   "inspector.transform": "Transform",
+  "inspector.recttransform": "Rect Transform",
   "inspector.position": "Posicao",
   "inspector.rotation": "Rotacao",
   "inspector.scale": "Escala",

--- a/Prowl.Editor/Resources/Locale/ru.json
+++ b/Prowl.Editor/Resources/Locale/ru.json
@@ -204,6 +204,7 @@
   "inspector.tag": "Тег",
   "inspector.layer": "Слой",
   "inspector.transform": "Транс��ормация",
+  "inspector.recttransform": "Прямое преобразование",
   "inspector.position": "Позиция",
   "inspector.rotation": "Вра��ение",
   "inspector.scale": "Масштаб",

--- a/Prowl.Editor/Resources/Locale/tr.json
+++ b/Prowl.Editor/Resources/Locale/tr.json
@@ -204,6 +204,7 @@
   "inspector.tag": "Etiket",
   "inspector.layer": "Katman",
   "inspector.transform": "Transform",
+  "inspector.recttransform": "Rect Transform",
   "inspector.position": "Konum",
   "inspector.rotation": "Donus",
   "inspector.scale": "Olcek",

--- a/Prowl.Editor/Resources/Locale/zh.json
+++ b/Prowl.Editor/Resources/Locale/zh.json
@@ -204,6 +204,7 @@
   "inspector.tag": "标签",
   "inspector.layer": "层",
   "inspector.transform": "变换",
+  "inspector.recttransform": "矩形变换",
   "inspector.position": "位置",
   "inspector.rotation": "旋转",
   "inspector.scale": "缩放",


### PR DESCRIPTION
These three editors in particular were very out of date or broke the standardized field approach around PropertyGridUtils. This PR fixes them.